### PR TITLE
Replace manual batch loops with declarative MapTask from @workglow/* …

### DIFF
--- a/src/task/facts/UpdateAllCompanyFactsTask.ts
+++ b/src/task/facts/UpdateAllCompanyFactsTask.ts
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IExecuteContext, IWorkflow, pipe, Task } from "@workglow/task-graph";
+import { IExecuteContext, pipe, Task, Workflow } from "@workglow/task-graph";
 import { TObject, Type } from "typebox";
 import { query_all, query_run } from "../../util/db";
 import { parseDate } from "../../util/parseDate";
 import { FetchCompanyFactsTask } from "./FetchCompanyFactsTask";
 import { StoreCompanyFactsTask } from "./StoreCompanyFactsTask";
-import { sleep } from "@workglow/util";
 
 export type UpdateAllCompanyFactsTaskInput = {};
 
@@ -39,11 +38,15 @@ export class UpdateAllCompanyFactsTask extends Task<
     input: UpdateAllCompanyFactsTaskInput,
     context: IExecuteContext
   ): Promise<UpdateAllCompanyFactsTaskOutput> {
-    const needsUpating = query_all(`
-      SELECT cik_last_update.cik, cik_last_update.last_update, processed_facts.last_processed FROM cik_last_update 
-        JOIN processed_facts 
+    const needsUpating = query_all<{
+      cik: string;
+      last_update: string;
+      last_processed: string;
+    }>(`
+      SELECT cik_last_update.cik, cik_last_update.last_update, processed_facts.last_processed FROM cik_last_update
+        JOIN processed_facts
           ON cik_last_update.cik = processed_facts.cik
-        WHERE cik_last_update.last_update > processed_facts.last_processed 
+        WHERE cik_last_update.last_update > processed_facts.last_processed
         ORDER BY cik_last_update.last_update DESC`);
     const needsUpatingCount = needsUpating?.length ?? 0;
 
@@ -52,75 +55,46 @@ export class UpdateAllCompanyFactsTask extends Task<
       last_update: string;
       last_processed: string;
     }>(`
-          SELECT cik_last_update.cik, cik_last_update.last_update, processed_facts.last_processed FROM cik_last_update
-            LEFT JOIN processed_facts
-              ON cik_last_update.cik = processed_facts.cik
-            WHERE processed_facts.last_processed IS NULL
-            ORDER BY cik_last_update.last_update DESC`);
+      SELECT cik_last_update.cik, cik_last_update.last_update, processed_facts.last_processed FROM cik_last_update
+        LEFT JOIN processed_facts
+          ON cik_last_update.cik = processed_facts.cik
+        WHERE processed_facts.last_processed IS NULL
+        ORDER BY cik_last_update.last_update DESC`);
     const needsProcessingCount = needsProcessing?.length ?? 0;
-    const totalCount = needsUpatingCount + needsProcessingCount;
 
     if (needsUpatingCount) {
-      const wf = context.own(pipe([new FetchCompanyFactsTask(), new StoreCompanyFactsTask()]));
-      for (let i = 0; i < needsUpatingCount; i++) {
-        const result = needsUpating[i];
-        try {
-          await wf.run({ cik: result.cik, date: result.last_update });
-        } catch (e) {
-          const { year, month, day } = parseDate(result.last_update);
-          query_run(
-            `INSERT OR REPLACE INTO processed_facts(cik,last_processed)
-            VALUES($cik,$last_processed)`,
-            {
-              $cik: result.cik,
-              $last_processed: `${year + 1}-${month}-${day}`,
-            }
-          );
-        }
-        await sleep(0);
-        context.updateProgress(
-          Math.ceil((i / totalCount) * 100),
-          `Processed ${i} of ${totalCount} company facts (updating)`
-        );
-      }
+      const wf = context.own(new Workflow());
+      const loop = wf.map({ concurrencyLimit: 1 });
+      loop.pipe(fetchAndStoreFacts);
+      loop.endMap();
+      await wf.run({
+        cik: needsUpating.map((r) => r.cik),
+        date: needsUpating.map((r) => r.last_update),
+      });
     }
 
-    if (needsProcessing?.length) {
-      const BATCH_SIZE = 10;
-      const workflowsNumber = Math.min(needsProcessing.length, BATCH_SIZE);
-      const workflows: IWorkflow<any, any>[] = [];
-      for (let i = 0; i < workflowsNumber; i++) {
-        workflows.push(
-          context.own(pipe([new FetchCompanyFactsTask(), new StoreCompanyFactsTask()]))
-        );
-      }
-      for (let i = 0; i < needsProcessing.length; i += BATCH_SIZE) {
-        const batch = needsProcessing.slice(i, i + BATCH_SIZE);
-        const promises = [];
-        for (let j = 0; j < batch.length; j++) {
-          promises.push(
-            runWorkflow(workflows[j], {
-              cik: batch[j].cik,
-              date: batch[j].last_update,
-            })
-          );
-        }
-        await Promise.all(promises);
-        await sleep(0);
-        context.updateProgress(
-          Math.ceil(((i + needsUpatingCount) / totalCount) * 100),
-          `Processed ${i + needsUpatingCount} of ${totalCount} company facts (initial processing)`
-        );
-      }
+    if (needsProcessingCount) {
+      const wf = context.own(new Workflow());
+      const loop = wf.map({ concurrencyLimit: 10 });
+      loop.pipe(fetchAndStoreFacts);
+      loop.endMap();
+      await wf.run({
+        cik: needsProcessing.map((r) => r.cik),
+        date: needsProcessing.map((r) => r.last_update),
+      });
     }
+
     return { success: true };
   }
 }
 
-async function runWorkflow(wf: IWorkflow<any, any>, input: { cik: string; date: string }) {
+async function fetchAndStoreFacts(
+  input: { cik: string; date: string },
+  ctx: IExecuteContext
+): Promise<{ success: boolean }> {
+  const pipeline = ctx.own(pipe([new FetchCompanyFactsTask(), new StoreCompanyFactsTask()]));
   try {
-    const result = await wf.run(input);
-    return result;
+    await pipeline.run({ cik: parseInt(input.cik), date: input.date });
   } catch (e) {
     const { year, month, day } = parseDate(input.date);
     query_run(
@@ -132,4 +106,5 @@ async function runWorkflow(wf: IWorkflow<any, any>, input: { cik: string; date: 
       }
     );
   }
+  return { success: true };
 }

--- a/src/task/forms/FetchAndStoreFormsTask.ts
+++ b/src/task/forms/FetchAndStoreFormsTask.ts
@@ -8,9 +8,7 @@ import { IExecuteContext, Task, TaskError, Workflow } from "@workglow/task-graph
 import { Static, TObject, Type } from "typebox";
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { query_all } from "../../util/db";
-import { SecFetchAccessionDocTask } from "./SecFetchAccessionDocTask";
 import { ProcessAccessionDocFormTask } from "./ProcessAccessionDocFormTask";
-import { sleep } from "@workglow/util";
 
 const FetchAndStoreFormsTaskInputSchema = () =>
   Type.Object({
@@ -83,20 +81,18 @@ export class FetchAndStoreFormsTask extends Task<
       }>(sql, { $cik: cik, $form: form });
     }
 
-    const wf = context.own(new Workflow());
-    for (const filing of filings) {
-      console.error(filing);
-      await sleep(0);
-      wf.pipe(
-        new ProcessAccessionDocFormTask({
-          cik: cik,
-          form: form,
-          accessionNumber: filing.accession_number,
-          fileName: filing.primary_doc.replaceAll(/^(xsl[^\/]+\/)/g, ""),
-        })
-      );
+    if (filings.length > 0) {
+      const wf = context.own(new Workflow());
+      const loop = wf.map({ concurrencyLimit: 5 });
+      loop.pipe(new ProcessAccessionDocFormTask());
+      loop.endMap();
+      await wf.run({
+        cik: filings.map(() => cik),
+        form: filings.map(() => form),
+        accessionNumber: filings.map((f) => f.accession_number),
+        fileName: filings.map((f) => f.primary_doc.replaceAll(/^(xsl[^\/]+\/)/g, "")),
+      });
     }
-    const result = await wf.run();
     return { success: true };
   }
 }

--- a/src/task/forms/UpdateAllFormsTask.ts
+++ b/src/task/forms/UpdateAllFormsTask.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IExecuteContext, Task } from "@workglow/task-graph";
-import { sleep } from "@workglow/util";
+import { IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import { TObject, Type } from "typebox";
 import { query_all } from "../../util/db";
 import { ProcessAccessionDocFormTask } from "./ProcessAccessionDocFormTask";
@@ -48,27 +47,15 @@ export class UpdateAllFormsTask extends Task<UpdateAllFormsTaskInput, UpdateAllF
     const needsInitialProcessingCount = missingForms?.length ?? 0;
 
     if (needsInitialProcessingCount) {
-      const BATCH_SIZE = 10;
-      for (let i = 0; i < missingForms.length; i += BATCH_SIZE) {
-        const batch = missingForms.slice(i, i + BATCH_SIZE);
-        const promises: Promise<any>[] = [];
-        for (let j = 0; j < batch.length; j++) {
-          const task = context.own(
-            new ProcessAccessionDocFormTask({
-              accessionNumber: batch[j].accession_number,
-              cik: parseInt(batch[j].cik),
-              form: batch[j].form,
-            })
-          );
-          promises.push(task.run());
-        }
-        await Promise.all(promises);
-        await sleep(0);
-        context.updateProgress(
-          Math.ceil(((i + missingForms.length) / missingForms.length) * 100),
-          `Processed ${i + missingForms.length} of ${missingForms.length} forms`
-        );
-      }
+      const wf = context.own(new Workflow());
+      const loop = wf.map({ concurrencyLimit: 10 });
+      loop.pipe(new ProcessAccessionDocFormTask());
+      loop.endMap();
+      await wf.run({
+        accessionNumber: missingForms.map((f) => f.accession_number),
+        cik: missingForms.map((f) => parseInt(f.cik)),
+        form: missingForms.map((f) => f.form),
+      });
     }
     return { success: true };
   }

--- a/src/task/index/FetchQuarterlyIndexRangeTask.ts
+++ b/src/task/index/FetchQuarterlyIndexRangeTask.ts
@@ -4,14 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  IExecuteContext,
-  GraphResult,
-  Task,
-  TaskGraph,
-  GRAPH_RESULT_ARRAY,
-} from "@workglow/task-graph";
-import { FetchQuarterlyIndexTask, FetchQuarterlyIndexTaskOutput } from "./FetchQuarterlyIndexTask";
+import { IExecuteContext, Task, Workflow } from "@workglow/task-graph";
+import { FetchQuarterlyIndexTask } from "./FetchQuarterlyIndexTask";
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { TypeDateTime } from "../../util/TypeBoxUtil";
 import { Static, TObject, Type } from "typebox";
@@ -91,29 +85,28 @@ export class FetchQuarterlyIndexRangeTask extends Task<
     const endYear = input.endYear ?? todayYear;
     const endQuarter = input.endQuarter ?? Math.ceil(todayMonth / 3);
 
-    const tasks = context.own(new TaskGraph());
-
     // from the date to the current date, fetch the quarterly index
     const quarters = (endYear - startYear) * 4 + (endQuarter - startQuarter);
+    const dates: string[] = [];
     for (let i = 0; i < quarters; i++) {
       const fetchYear = startYear + Math.floor(i / 4);
       const fetchMonth = (i % 4) * 3 + 1;
       const fetchDay = 1;
-      const date = `${fetchYear}-${fetchMonth.toString().padStart(2, "0")}-${fetchDay
-        .toString()
-        .padStart(2, "0")}`;
-      const task = new FetchQuarterlyIndexTask({
-        date,
-      });
-      tasks.addTask(task);
+      dates.push(
+        `${fetchYear}-${fetchMonth.toString().padStart(2, "0")}-${fetchDay.toString().padStart(2, "0")}`
+      );
     }
 
-    const results: GraphResult<FetchQuarterlyIndexTaskOutput, typeof GRAPH_RESULT_ARRAY> =
-      await tasks.run();
+    if (dates.length === 0) return { updateList: [] };
+
+    const wf = context.own(new Workflow());
+    const loop = wf.map({ preserveOrder: false });
+    loop.pipe(new FetchQuarterlyIndexTask());
+    loop.endMap();
+    const results = await wf.run({ date: dates });
 
     const updateList: Record<number, string> = {};
-    for (const result of results) {
-      const updateListQuarter = result.data.updateList;
+    for (const updateListQuarter of results.updateList as [number, string][][]) {
       for (const [cik, last_known_update] of updateListQuarter) {
         if (updateList[cik] === undefined || updateList[cik] < last_known_update) {
           updateList[cik] = last_known_update;

--- a/src/task/submissions/UpdateAllSubmissionsTask.ts
+++ b/src/task/submissions/UpdateAllSubmissionsTask.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IExecuteContext, IWorkflow, pipe, Task } from "@workglow/task-graph";
-import { sleep } from "@workglow/util";
+import { IExecuteContext, pipe, Task, Workflow } from "@workglow/task-graph";
 import { TObject, Type } from "typebox";
 import { processUpdateProcessing } from "./StoreSubmissionsTask";
 import { query_all } from "../../util/db";
@@ -39,11 +38,15 @@ export class UpdateAllSubmissionsTask extends Task<
     input: UpdateAllSubmissionsTaskInput,
     context: IExecuteContext
   ): Promise<UpdateAllSubmissionsTaskOutput> {
-    const needsUpating = query_all(`
-      SELECT cik_last_update.cik, cik_last_update.last_update, processed_submissions.last_processed FROM cik_last_update 
-        JOIN processed_submissions 
+    const needsUpating = query_all<{
+      cik: string;
+      last_update: string;
+      last_processed: string;
+    }>(`
+      SELECT cik_last_update.cik, cik_last_update.last_update, processed_submissions.last_processed FROM cik_last_update
+        JOIN processed_submissions
           ON cik_last_update.cik = processed_submissions.cik
-        WHERE cik_last_update.last_update > processed_submissions.last_processed 
+        WHERE cik_last_update.last_update > processed_submissions.last_processed
         ORDER BY cik_last_update.last_update DESC`);
     const needsUpatingCount = needsUpating?.length ?? 0;
 
@@ -58,56 +61,42 @@ export class UpdateAllSubmissionsTask extends Task<
         WHERE processed_submissions.last_processed IS NULL
         ORDER BY cik_last_update.last_update DESC`);
     const needsInitialProcessingCount = needsInitialProcessing?.length ?? 0;
-    const totalCount = needsUpatingCount + needsInitialProcessingCount;
 
     if (needsUpatingCount) {
-      const wf = context.own(pipe([new FetchSubmissionsTask(), new StoreSubmissionsTask()]));
-      for (let i = 0; i < needsUpatingCount; i++) {
-        const result = needsUpating[i];
-        runWorkflow(wf, { cik: parseInt(result.cik), date: result.last_update });
-        context.updateProgress(
-          Math.ceil((i / totalCount) * 100),
-          `Processed ${i} of ${totalCount} submissions (updating)`
-        );
-      }
+      const wf = context.own(new Workflow());
+      const loop = wf.map({ concurrencyLimit: 1 });
+      loop.pipe(fetchAndStoreSubmission);
+      loop.endMap();
+      await wf.run({
+        cik: needsUpating.map((r) => parseInt(r.cik)),
+        date: needsUpating.map((r) => r.last_update),
+      });
     }
 
     if (needsInitialProcessingCount) {
-      const BATCH_SIZE = 2;
-      const workflowsNumber = Math.min(needsInitialProcessingCount, BATCH_SIZE);
-      const workflows: IWorkflow<any, any>[] = [];
-      for (let i = 0; i < workflowsNumber; i++) {
-        workflows.push(context.own(pipe([new FetchSubmissionsTask(), new StoreSubmissionsTask()])));
-      }
-      for (let i = 0; i < needsInitialProcessing.length; i += BATCH_SIZE) {
-        const batch = needsInitialProcessing.slice(i, i + BATCH_SIZE);
-        const promises = [];
-        for (let j = 0; j < batch.length; j++) {
-          promises.push(
-            runWorkflow(workflows[j], {
-              cik: parseInt(batch[j].cik),
-              date: batch[j].last_update,
-            })
-          );
-        }
-        await Promise.all(promises);
-        await sleep(0);
-        context.updateProgress(
-          Math.ceil(((i + needsUpatingCount) / totalCount) * 100),
-          `Processed ${i + needsUpatingCount} of ${totalCount} submissions (initial processing)`
-        );
-      }
+      const wf = context.own(new Workflow());
+      const loop = wf.map({ concurrencyLimit: 2 });
+      loop.pipe(fetchAndStoreSubmission);
+      loop.endMap();
+      await wf.run({
+        cik: needsInitialProcessing.map((r) => parseInt(r.cik)),
+        date: needsInitialProcessing.map((r) => r.last_update),
+      });
     }
+
     return { success: true };
   }
 }
 
-async function runWorkflow(wf: IWorkflow<any, any>, input: { cik: number; date: string }) {
+async function fetchAndStoreSubmission(
+  input: { cik: number; date: string },
+  ctx: IExecuteContext
+): Promise<{ success: boolean }> {
+  const pipeline = ctx.own(pipe([new FetchSubmissionsTask(), new StoreSubmissionsTask()]));
   try {
-    const result = await wf.run(input);
-    processUpdateProcessing(input.cik, true);
-    return result;
+    await pipeline.run(input);
   } catch (e) {
     processUpdateProcessing(input.cik, false);
   }
+  return { success: true };
 }


### PR DESCRIPTION
…v0.0.103

Leverage Workflow.map()/endMap() to replace hand-rolled TaskGraph loops, batched Promise.all patterns, and sequential pipe chains across 5 task files. This reduces boilerplate, fixes an unintended sequential execution bug in FetchAndStoreFormsTask, and standardizes concurrency control.