### PR TITLE
Add component versioning system with CLI commands

### DIFF
--- a/src/cli/groups/version.test.ts
+++ b/src/cli/groups/version.test.ts
@@ -73,4 +73,42 @@ describe("sec version CLI", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("status --format json returns raw semver in next, with separate coverage flag", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      const setup = await runCli(["db", "setup"], dir);
+      expect(setup.exitCode).toBe(0);
+
+      const seed = await runCli(
+        ["version", "seed-test", "extractor", "D", "next", "2.1.0"],
+        dir
+      );
+      expect(seed.exitCode).toBe(0);
+
+      const status = await runCli(["version", "status", "--format", "json"], dir);
+      expect(status.exitCode).toBe(0);
+      const parsed = JSON.parse(status.stdout);
+      expect(parsed).toHaveLength(1);
+      // JSON output is raw data — semver only, no presentation suffix.
+      expect(parsed[0].next).toBe("2.1.0");
+      expect(parsed[0].next_coverage_complete).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("status rejects an unsupported --format value", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      const setup = await runCli(["db", "setup"], dir);
+      expect(setup.exitCode).toBe(0);
+
+      const status = await runCli(["version", "status", "--format", "yaml"], dir);
+      expect(status.exitCode).not.toBe(0);
+      expect(status.stderr + status.stdout).toMatch(/Invalid --format/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/groups/version.test.ts
+++ b/src/cli/groups/version.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function runCli(args: string[], dbFolder: string): Promise<RunResult> {
+  const proc = Bun.spawn(["bun", "src/sec.ts", ...args], {
+    env: {
+      ...process.env,
+      SEC_DB_TYPE: "sqlite",
+      SEC_DB_FOLDER: dbFolder,
+      SEC_DB_NAME: "edgar",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  return {
+    stdout: await new Response(proc.stdout).text(),
+    stderr: await new Response(proc.stderr).text(),
+    exitCode,
+  };
+}
+
+describe("sec version CLI", () => {
+  it("status prints empty message when no components are registered", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      const setup = await runCli(["db", "setup"], dir);
+      expect(setup.exitCode).toBe(0);
+
+      const status = await runCli(["version", "status"], dir);
+      expect(status.exitCode).toBe(0);
+      expect(status.stdout).toContain("No components registered");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("seed-test populates a slot and status --format json reflects it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      const setup = await runCli(["db", "setup"], dir);
+      expect(setup.exitCode).toBe(0);
+
+      const seed = await runCli(
+        ["version", "seed-test", "extractor", "D", "current", "1.0.0"],
+        dir
+      );
+      expect(seed.exitCode).toBe(0);
+
+      const status = await runCli(["version", "status", "--format", "json"], dir);
+      expect(status.exitCode).toBe(0);
+      const parsed = JSON.parse(status.stdout);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].component_id).toBe("D");
+      expect(parsed[0].current).toBe("1.0.0");
+      expect(parsed[0].previous).toBe("—");
+      expect(parsed[0].next).toBe("—");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/groups/version.ts
+++ b/src/cli/groups/version.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Command } from "commander";
+import { globalServiceRegistry } from "workglow";
+import {
+  COMPONENT_KINDS,
+  COMPONENT_SLOTS,
+  COMPONENT_VERSION_REPOSITORY_TOKEN,
+  ComponentKind,
+  ComponentSlot,
+} from "../../storage/versioning/ComponentVersionSchema";
+import {
+  isValidSemver,
+  VersionRegistry,
+} from "../../storage/versioning/VersionRegistry";
+import { renderTable } from "../output/TableRenderer";
+import { getVersionStatus } from "../queries/VersionStatus";
+import { runCommand } from "../runCommand";
+
+function assertComponentKind(s: string): asserts s is ComponentKind {
+  if (!(COMPONENT_KINDS as readonly string[]).includes(s)) {
+    throw new Error(
+      `Invalid component kind '${s}'. Expected one of: ${COMPONENT_KINDS.join(", ")}`
+    );
+  }
+}
+
+function assertComponentSlot(s: string): asserts s is ComponentSlot {
+  if (!(COMPONENT_SLOTS as readonly string[]).includes(s)) {
+    throw new Error(
+      `Invalid slot '${s}'. Expected one of: ${COMPONENT_SLOTS.join(", ")}`
+    );
+  }
+}
+
+export function addVersionCommands(program: Command): void {
+  const version = program
+    .command("version")
+    .description("Inspect and manage extractor/resolver versions");
+
+  version
+    .command("status")
+    .description("Show the current/previous/next version of every component")
+    .option("--format <format>", "Output format (table, json)", "table")
+    .action(async (options: Record<string, string>) => {
+      await runCommand(async () => {
+        const rows = await getVersionStatus();
+
+        if (options.format === "json") {
+          console.log(JSON.stringify(rows, null, 2));
+          return;
+        }
+
+        if (rows.length === 0) {
+          console.log("No components registered.");
+          return;
+        }
+
+        console.log(
+          renderTable(
+            rows as unknown as ReadonlyArray<Record<string, unknown>>,
+            [
+              { key: "component_kind", header: "Kind", width: 10 },
+              { key: "component_id", header: "Id", width: 24 },
+              { key: "previous", header: "Previous", width: 16 },
+              { key: "current", header: "Current", width: 16 },
+              { key: "next", header: "Next", width: 28 },
+            ],
+            { format: "table" }
+          )
+        );
+      });
+    });
+
+  version
+    .command("seed-test <kind> <id> <slot> <semver>")
+    .description(
+      "(internal) Write a single slot directly. PR3 replaces this with start-dev/promote."
+    )
+    .action(async (kind: string, id: string, slot: string, semver: string) => {
+      await runCommand(async () => {
+        assertComponentKind(kind);
+        assertComponentSlot(slot);
+        if (!isValidSemver(semver)) {
+          throw new Error(`Invalid semver: ${semver}`);
+        }
+        const reg = new VersionRegistry(
+          globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+        );
+        await reg.putSlot({
+          component_kind: kind,
+          component_id: id,
+          slot,
+          semver,
+          bump_type: null,
+          started_at: new Date().toISOString(),
+          coverage_complete: slot !== "next",
+        });
+        console.log(`Seeded ${kind}:${id} slot=${slot} semver=${semver}`);
+      });
+    });
+}

--- a/src/cli/groups/version.ts
+++ b/src/cli/groups/version.ts
@@ -37,6 +37,8 @@ function assertComponentSlot(s: string): asserts s is ComponentSlot {
   }
 }
 
+const SUPPORTED_STATUS_FORMATS = ["table", "json"] as const;
+
 export function addVersionCommands(program: Command): void {
   const version = program
     .command("version")
@@ -48,6 +50,12 @@ export function addVersionCommands(program: Command): void {
     .option("--format <format>", "Output format (table, json)", "table")
     .action(async (options: Record<string, string>) => {
       await runCommand(async () => {
+        if (!(SUPPORTED_STATUS_FORMATS as readonly string[]).includes(options.format)) {
+          throw new Error(
+            `Invalid --format '${options.format}'. Expected one of: ${SUPPORTED_STATUS_FORMATS.join(", ")}`
+          );
+        }
+
         const rows = await getVersionStatus();
 
         if (options.format === "json") {
@@ -60,9 +68,21 @@ export function addVersionCommands(program: Command): void {
           return;
         }
 
+        // Decorate `next` for the table view only. JSON consumers get raw
+        // semver in `next` plus the boolean `next_coverage_complete` flag.
+        const tableRows = rows.map((r) => ({
+          ...r,
+          next:
+            r.next === "—"
+              ? r.next
+              : r.next_coverage_complete
+                ? `${r.next} (ready)`
+                : `${r.next} (in progress)`,
+        }));
+
         console.log(
           renderTable(
-            rows as unknown as ReadonlyArray<Record<string, unknown>>,
+            tableRows as unknown as ReadonlyArray<Record<string, unknown>>,
             [
               { key: "component_kind", header: "Kind", width: 10 },
               { key: "component_id", header: "Id", width: 24 },

--- a/src/cli/queries/VersionStatus.ts
+++ b/src/cli/queries/VersionStatus.ts
@@ -47,9 +47,7 @@ export async function getVersionStatus(): Promise<VersionStatusRow[]> {
     } else if (row.slot === "next") {
       grouped.set(key, {
         ...acc,
-        next: row.coverage_complete
-          ? `${row.semver} (ready)`
-          : `${row.semver} (in progress)`,
+        next: row.semver,
         next_coverage_complete: row.coverage_complete,
       });
     }

--- a/src/cli/queries/VersionStatus.ts
+++ b/src/cli/queries/VersionStatus.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  COMPONENT_VERSION_REPOSITORY_TOKEN,
+  ComponentKind,
+} from "../../storage/versioning/ComponentVersionSchema";
+import { VersionRegistry } from "../../storage/versioning/VersionRegistry";
+
+export interface VersionStatusRow {
+  readonly component_kind: ComponentKind;
+  readonly component_id: string;
+  readonly previous: string;
+  readonly current: string;
+  readonly next: string;
+  readonly next_coverage_complete: boolean;
+}
+
+export async function getVersionStatus(): Promise<VersionStatusRow[]> {
+  const reg = new VersionRegistry(
+    globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+  );
+  const rows = await reg.listAll();
+
+  const grouped = new Map<string, VersionStatusRow>();
+  const keyFor = (kind: ComponentKind, id: string): string => `${kind}::${id}`;
+  const emptyRow = (kind: ComponentKind, id: string): VersionStatusRow => ({
+    component_kind: kind,
+    component_id: id,
+    previous: "—",
+    current: "—",
+    next: "—",
+    next_coverage_complete: false,
+  });
+
+  for (const row of rows) {
+    const key = keyFor(row.component_kind, row.component_id);
+    const acc = grouped.get(key) ?? emptyRow(row.component_kind, row.component_id);
+    if (row.slot === "previous") {
+      grouped.set(key, { ...acc, previous: row.semver });
+    } else if (row.slot === "current") {
+      grouped.set(key, { ...acc, current: row.semver });
+    } else if (row.slot === "next") {
+      grouped.set(key, {
+        ...acc,
+        next: row.coverage_complete
+          ? `${row.semver} (ready)`
+          : `${row.semver} (in progress)`,
+        next_coverage_complete: row.coverage_complete,
+      });
+    }
+  }
+
+  return [...grouped.values()].sort((a, b) => {
+    if (a.component_kind !== b.component_kind) {
+      return a.component_kind < b.component_kind ? -1 : 1;
+    }
+    return a.component_id < b.component_id ? -1 : 1;
+  });
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,7 @@ import { addInitCommand } from "../cli/groups/init";
 import { addQueryCommands } from "../cli/groups/query";
 import { addSyncCommand } from "../cli/groups/sync";
 import { addUpdateCommands } from "../cli/groups/update";
+import { addVersionCommands } from "../cli/groups/version";
 import { DefaultDI } from "../config/DefaultDI";
 import { EnvToDI } from "../config/EnvToDI";
 import { SEC_DRY_RUN } from "../config/tokens";
@@ -59,4 +60,5 @@ export const AddCommands = (program: Command): void => {
   addQueryCommands(program);
   addDbCommands(program);
   addInitCommand(program);
+  addVersionCommands(program);
 };

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -160,16 +160,6 @@ import {
   ProcessedSubmissionsSchema,
 } from "../storage/processing/ProcessedSubmissionsSchema";
 import {
-  COMPONENT_VERSION_REPOSITORY_TOKEN,
-  ComponentVersionPrimaryKeyNames,
-  ComponentVersionSchema,
-} from "../storage/versioning/ComponentVersionSchema";
-import {
-  EXTRACTOR_RUN_REPOSITORY_TOKEN,
-  ExtractorRunPrimaryKeyNames,
-  ExtractorRunSchema,
-} from "../storage/versioning/ExtractorRunSchema";
-import {
   REGA_EQUITY_CLASS_REPOSITORY_TOKEN,
   RegAEquityClassPrimaryKeyNames,
   RegAEquityClassSchema,
@@ -194,6 +184,16 @@ import {
   RegAServiceProviderPrimaryKeyNames,
   RegAServiceProviderSchema,
 } from "../storage/reg-a/RegAServiceProviderSchema";
+import {
+  COMPONENT_VERSION_REPOSITORY_TOKEN,
+  ComponentVersionPrimaryKeyNames,
+  ComponentVersionSchema,
+} from "../storage/versioning/ComponentVersionSchema";
+import {
+  EXTRACTOR_RUN_REPOSITORY_TOKEN,
+  ExtractorRunPrimaryKeyNames,
+  ExtractorRunSchema,
+} from "../storage/versioning/ExtractorRunSchema";
 import { createStorage } from "./createStorage";
 
 export const DefaultDI = () => {
@@ -473,25 +473,14 @@ export const DefaultDI = () => {
   // ------------------------------ Versioning -----------------------------------
   globalServiceRegistry.registerInstance(
     COMPONENT_VERSION_REPOSITORY_TOKEN,
-    createStorage(
-      "component_versions",
-      ComponentVersionSchema,
-      ComponentVersionPrimaryKeyNames,
-      [["component_kind", "component_id"]]
-    )
+    createStorage("component_versions", ComponentVersionSchema, ComponentVersionPrimaryKeyNames)
   );
   globalServiceRegistry.registerInstance(
     EXTRACTOR_RUN_REPOSITORY_TOKEN,
-    createStorage(
-      "extractor_runs",
-      ExtractorRunSchema,
-      ExtractorRunPrimaryKeyNames,
-      [
-        ["cik", "accession_number"],
-        ["extractor_id", "extractor_version"],
-        ["form", "extractor_version"],
-      ]
-    )
+    createStorage("extractor_runs", ExtractorRunSchema, ExtractorRunPrimaryKeyNames, [
+      ["extractor_id", "extractor_version"],
+      ["form", "extractor_version"],
+    ])
   );
 
   // ------------------------------ Company Facts --------------------------------

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -160,6 +160,16 @@ import {
   ProcessedSubmissionsSchema,
 } from "../storage/processing/ProcessedSubmissionsSchema";
 import {
+  COMPONENT_VERSION_REPOSITORY_TOKEN,
+  ComponentVersionPrimaryKeyNames,
+  ComponentVersionSchema,
+} from "../storage/versioning/ComponentVersionSchema";
+import {
+  EXTRACTOR_RUN_REPOSITORY_TOKEN,
+  ExtractorRunPrimaryKeyNames,
+  ExtractorRunSchema,
+} from "../storage/versioning/ExtractorRunSchema";
+import {
   REGA_EQUITY_CLASS_REPOSITORY_TOKEN,
   RegAEquityClassPrimaryKeyNames,
   RegAEquityClassSchema,
@@ -458,6 +468,30 @@ export const DefaultDI = () => {
     createStorage("processed_filings", ProcessedFilingsSchema, ProcessedFilingsPrimaryKeyNames, [
       ["last_processed", "success", "form"],
     ])
+  );
+
+  // ------------------------------ Versioning -----------------------------------
+  globalServiceRegistry.registerInstance(
+    COMPONENT_VERSION_REPOSITORY_TOKEN,
+    createStorage(
+      "component_versions",
+      ComponentVersionSchema,
+      ComponentVersionPrimaryKeyNames,
+      [["component_kind", "component_id"]]
+    )
+  );
+  globalServiceRegistry.registerInstance(
+    EXTRACTOR_RUN_REPOSITORY_TOKEN,
+    createStorage(
+      "extractor_runs",
+      ExtractorRunSchema,
+      ExtractorRunPrimaryKeyNames,
+      [
+        ["cik", "accession_number"],
+        ["extractor_id", "extractor_version"],
+        ["form", "extractor_version"],
+      ]
+    )
   );
 
   // ------------------------------ Company Facts --------------------------------

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -181,6 +181,16 @@ import {
   RegAServiceProviderPrimaryKeyNames,
   RegAServiceProviderSchema,
 } from "../storage/reg-a/RegAServiceProviderSchema";
+import {
+  COMPONENT_VERSION_REPOSITORY_TOKEN,
+  ComponentVersionPrimaryKeyNames,
+  ComponentVersionSchema,
+} from "../storage/versioning/ComponentVersionSchema";
+import {
+  EXTRACTOR_RUN_REPOSITORY_TOKEN,
+  ExtractorRunPrimaryKeyNames,
+  ExtractorRunSchema,
+} from "../storage/versioning/ExtractorRunSchema";
 
 export function resetDependencyInjectionsForTesting() {
   // Initialize Company repositories
@@ -427,6 +437,22 @@ export function resetDependencyInjectionsForTesting() {
     PROCESSED_FILINGS_REPOSITORY_TOKEN,
     new InMemoryTabularStorage(ProcessedFilingsSchema, ProcessedFilingsPrimaryKeyNames, [
       ["last_processed", "success", "form"],
+    ])
+  );
+
+  // Initialize Versioning repositories
+  globalServiceRegistry.registerInstance(
+    COMPONENT_VERSION_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(ComponentVersionSchema, ComponentVersionPrimaryKeyNames, [
+      ["component_kind", "component_id"],
+    ])
+  );
+  globalServiceRegistry.registerInstance(
+    EXTRACTOR_RUN_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(ExtractorRunSchema, ExtractorRunPrimaryKeyNames, [
+      ["cik", "accession_number"],
+      ["extractor_id", "extractor_version"],
+      ["form", "extractor_version"],
     ])
   );
 

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -443,14 +443,11 @@ export function resetDependencyInjectionsForTesting() {
   // Initialize Versioning repositories
   globalServiceRegistry.registerInstance(
     COMPONENT_VERSION_REPOSITORY_TOKEN,
-    new InMemoryTabularStorage(ComponentVersionSchema, ComponentVersionPrimaryKeyNames, [
-      ["component_kind", "component_id"],
-    ])
+    new InMemoryTabularStorage(ComponentVersionSchema, ComponentVersionPrimaryKeyNames, [])
   );
   globalServiceRegistry.registerInstance(
     EXTRACTOR_RUN_REPOSITORY_TOKEN,
     new InMemoryTabularStorage(ExtractorRunSchema, ExtractorRunPrimaryKeyNames, [
-      ["cik", "accession_number"],
       ["extractor_id", "extractor_version"],
       ["form", "extractor_version"],
     ])

--- a/src/config/resetAllDatabases.ts
+++ b/src/config/resetAllDatabases.ts
@@ -55,6 +55,8 @@ import { REGA_FINANCIAL_DATA_REPOSITORY_TOKEN } from "../storage/reg-a/RegAFinan
 import { REGA_OFFERING_HISTORY_REPOSITORY_TOKEN } from "../storage/reg-a/RegAOfferingHistorySchema";
 import { REGA_OFFERING_REPOSITORY_TOKEN } from "../storage/reg-a/RegAOfferingSchema";
 import { REGA_SERVICE_PROVIDER_REPOSITORY_TOKEN } from "../storage/reg-a/RegAServiceProviderSchema";
+import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../storage/versioning/ComponentVersionSchema";
+import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../storage/versioning/ExtractorRunSchema";
 
 /**
  * Truncates every registered repository. Used by `sec db reset --confirm`
@@ -103,5 +105,7 @@ export async function resetAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(PROCESSED_FACTS_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(PROCESSED_FILINGS_REPOSITORY_TOKEN).deleteAll();
+  await globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN).deleteAll();
+  await globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(COMPANY_FACTS_REPOSITORY_TOKEN).deleteAll();
 }

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -55,6 +55,8 @@ import { REGA_FINANCIAL_DATA_REPOSITORY_TOKEN } from "../storage/reg-a/RegAFinan
 import { REGA_OFFERING_HISTORY_REPOSITORY_TOKEN } from "../storage/reg-a/RegAOfferingHistorySchema";
 import { REGA_OFFERING_REPOSITORY_TOKEN } from "../storage/reg-a/RegAOfferingSchema";
 import { REGA_SERVICE_PROVIDER_REPOSITORY_TOKEN } from "../storage/reg-a/RegAServiceProviderSchema";
+import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../storage/versioning/ComponentVersionSchema";
+import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../storage/versioning/ExtractorRunSchema";
 
 /**
  * Calls setupDatabase() on all registered repository instances,
@@ -104,4 +106,6 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(PROCESSED_FILINGS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(COMPANY_FACTS_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN).setupDatabase();
 }

--- a/src/storage/versioning/ComponentVersionSchema.ts
+++ b/src/storage/versioning/ComponentVersionSchema.ts
@@ -8,19 +8,6 @@ import { Static, Type } from "typebox";
 import type { ITabularStorage } from "workglow";
 import { createServiceToken } from "workglow";
 
-// Helper to derive a Type.Union of literals from a const string tuple.
-// We use a runtime `as any` because TypeBox's TUnion typing on dynamic
-// literal arrays loses precision; the Static<> output is still correct.
-function literalUnion<T extends readonly string[]>(
-  values: T,
-  options?: { description?: string }
-) {
-  return Type.Union(
-    values.map((v) => Type.Literal(v)),
-    options as any
-  ) as any;
-}
-
 export const COMPONENT_KINDS = ["extractor", "resolver"] as const;
 export type ComponentKind = (typeof COMPONENT_KINDS)[number];
 
@@ -31,29 +18,36 @@ export const BUMP_TYPES = ["major", "minor", "patch"] as const;
 export type BumpType = (typeof BUMP_TYPES)[number];
 
 export const ComponentVersionSchema = Type.Object({
-  component_kind: literalUnion(COMPONENT_KINDS, {
-    description: "Which subsystem this component belongs to",
-  }),
+  component_kind: Type.Union(
+    [Type.Literal("extractor"), Type.Literal("resolver")],
+    { description: "Which subsystem this component belongs to" }
+  ),
   component_id: Type.String({
     maxLength: 64,
     description:
       "Form symbol (e.g. 'D', '1-A') for extractors, or domain name ('person', 'company') for resolvers",
   }),
-  slot: literalUnion(COMPONENT_SLOTS, {
-    description: "Which of the three slots this row occupies",
-  }),
+  slot: Type.Union(
+    [Type.Literal("previous"), Type.Literal("current"), Type.Literal("next")],
+    { description: "Which of the three slots this row occupies" }
+  ),
   semver: Type.String({
     maxLength: 32,
     description:
       "Semantic version, e.g. '2.1.0'. Validation enforced by VersionRegistry, not schema.",
   }),
   bump_type: Type.Union(
-    [...BUMP_TYPES.map((v) => Type.Literal(v)), Type.Null()],
+    [
+      Type.Literal("major"),
+      Type.Literal("minor"),
+      Type.Literal("patch"),
+      Type.Null(),
+    ],
     {
       description:
         "Declared bump type for the next→current transition. Null on initial seed.",
     }
-  ) as any,
+  ),
   started_at: Type.String({
     description: "ISO 8601 timestamp when this slot was populated",
   }),

--- a/src/storage/versioning/ComponentVersionSchema.ts
+++ b/src/storage/versioning/ComponentVersionSchema.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+
+export const COMPONENT_KINDS = ["extractor", "resolver"] as const;
+export type ComponentKind = (typeof COMPONENT_KINDS)[number];
+
+export const COMPONENT_SLOTS = ["previous", "current", "next"] as const;
+export type ComponentSlot = (typeof COMPONENT_SLOTS)[number];
+
+export const BUMP_TYPES = ["major", "minor", "patch"] as const;
+export type BumpType = (typeof BUMP_TYPES)[number];
+
+export const ComponentVersionSchema = Type.Object({
+  component_kind: Type.Union(
+    [Type.Literal("extractor"), Type.Literal("resolver")],
+    { description: "Which subsystem this component belongs to" }
+  ),
+  component_id: Type.String({
+    maxLength: 64,
+    description:
+      "Form symbol (e.g. 'D', '1-A') for extractors, or domain name ('person', 'company') for resolvers",
+  }),
+  slot: Type.Union(
+    [Type.Literal("previous"), Type.Literal("current"), Type.Literal("next")],
+    { description: "Which of the three slots this row occupies" }
+  ),
+  semver: Type.String({
+    maxLength: 32,
+    description:
+      "Semantic version, e.g. '2.1.0'. Validation enforced by VersionRegistry, not schema.",
+  }),
+  bump_type: Type.Union(
+    [
+      Type.Literal("major"),
+      Type.Literal("minor"),
+      Type.Literal("patch"),
+      Type.Null(),
+    ],
+    {
+      description:
+        "Declared bump type for the next→current transition. Null on initial seed.",
+    }
+  ),
+  started_at: Type.String({
+    description: "ISO 8601 timestamp when this slot was populated",
+  }),
+  coverage_complete: Type.Boolean({
+    description:
+      "Whether the next slot has 100% coverage. Always true for current/previous. Gate for major-promote.",
+  }),
+});
+
+export type ComponentVersion = Static<typeof ComponentVersionSchema>;
+
+export const ComponentVersionPrimaryKeyNames = [
+  "component_kind",
+  "component_id",
+  "slot",
+] as const;
+
+export type ComponentVersionRepositoryStorage = ITabularStorage<
+  typeof ComponentVersionSchema,
+  typeof ComponentVersionPrimaryKeyNames,
+  ComponentVersion
+>;
+
+export const COMPONENT_VERSION_REPOSITORY_TOKEN =
+  createServiceToken<ComponentVersionRepositoryStorage>(
+    "sec.storage.componentVersionRepository"
+  );

--- a/src/storage/versioning/ComponentVersionSchema.ts
+++ b/src/storage/versioning/ComponentVersionSchema.ts
@@ -8,6 +8,19 @@ import { Static, Type } from "typebox";
 import type { ITabularStorage } from "workglow";
 import { createServiceToken } from "workglow";
 
+// Helper to derive a Type.Union of literals from a const string tuple.
+// We use a runtime `as any` because TypeBox's TUnion typing on dynamic
+// literal arrays loses precision; the Static<> output is still correct.
+function literalUnion<T extends readonly string[]>(
+  values: T,
+  options?: { description?: string }
+) {
+  return Type.Union(
+    values.map((v) => Type.Literal(v)),
+    options as any
+  ) as any;
+}
+
 export const COMPONENT_KINDS = ["extractor", "resolver"] as const;
 export type ComponentKind = (typeof COMPONENT_KINDS)[number];
 
@@ -18,36 +31,29 @@ export const BUMP_TYPES = ["major", "minor", "patch"] as const;
 export type BumpType = (typeof BUMP_TYPES)[number];
 
 export const ComponentVersionSchema = Type.Object({
-  component_kind: Type.Union(
-    [Type.Literal("extractor"), Type.Literal("resolver")],
-    { description: "Which subsystem this component belongs to" }
-  ),
+  component_kind: literalUnion(COMPONENT_KINDS, {
+    description: "Which subsystem this component belongs to",
+  }),
   component_id: Type.String({
     maxLength: 64,
     description:
       "Form symbol (e.g. 'D', '1-A') for extractors, or domain name ('person', 'company') for resolvers",
   }),
-  slot: Type.Union(
-    [Type.Literal("previous"), Type.Literal("current"), Type.Literal("next")],
-    { description: "Which of the three slots this row occupies" }
-  ),
+  slot: literalUnion(COMPONENT_SLOTS, {
+    description: "Which of the three slots this row occupies",
+  }),
   semver: Type.String({
     maxLength: 32,
     description:
       "Semantic version, e.g. '2.1.0'. Validation enforced by VersionRegistry, not schema.",
   }),
   bump_type: Type.Union(
-    [
-      Type.Literal("major"),
-      Type.Literal("minor"),
-      Type.Literal("patch"),
-      Type.Null(),
-    ],
+    [...BUMP_TYPES.map((v) => Type.Literal(v)), Type.Null()],
     {
       description:
         "Declared bump type for the next→current transition. Null on initial seed.",
     }
-  ),
+  ) as any,
   started_at: Type.String({
     description: "ISO 8601 timestamp when this slot was populated",
   }),

--- a/src/storage/versioning/ExtractorRunSchema.ts
+++ b/src/storage/versioning/ExtractorRunSchema.ts
@@ -7,12 +7,10 @@
 import { Static, Type } from "typebox";
 import type { ITabularStorage } from "workglow";
 import { createServiceToken } from "workglow";
+import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 
 export const ExtractorRunSchema = Type.Object({
-  cik: Type.Integer({
-    minimum: 0,
-    description: "Central Index Key",
-  }),
+  cik: TypeSecCik({ description: "Central Index Key" }),
   accession_number: Type.String({
     maxLength: 20,
     description: "SEC accession number",

--- a/src/storage/versioning/ExtractorRunSchema.ts
+++ b/src/storage/versioning/ExtractorRunSchema.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+
+export const ExtractorRunSchema = Type.Object({
+  cik: Type.Integer({
+    minimum: 0,
+    description: "Central Index Key",
+  }),
+  accession_number: Type.String({
+    maxLength: 20,
+    description: "SEC accession number",
+  }),
+  form: Type.String({
+    maxLength: 8,
+    description: "Form type (e.g. 'D', '1-A')",
+  }),
+  extractor_id: Type.String({
+    maxLength: 64,
+    description: "Matches component_versions.component_id for component_kind='extractor'",
+  }),
+  extractor_version: Type.String({
+    maxLength: 32,
+    description: "Semver of the extractor that produced this run",
+  }),
+  slot_at_run: Type.Union(
+    [Type.Literal("current"), Type.Literal("next")],
+    { description: "Which slot the version occupied at the time the run executed" }
+  ),
+  ran_at: Type.String({
+    description: "ISO 8601 timestamp",
+  }),
+  success: Type.Boolean({
+    description: "Whether the extractor completed without error",
+  }),
+  error: Type.Union(
+    [Type.String({ maxLength: 4096 }), Type.Null()],
+    { description: "Error message if success=false, else null" }
+  ),
+});
+
+export type ExtractorRun = Static<typeof ExtractorRunSchema>;
+
+export const ExtractorRunPrimaryKeyNames = [
+  "cik",
+  "accession_number",
+  "extractor_id",
+  "extractor_version",
+] as const;
+
+export type ExtractorRunRepositoryStorage = ITabularStorage<
+  typeof ExtractorRunSchema,
+  typeof ExtractorRunPrimaryKeyNames,
+  ExtractorRun
+>;
+
+export const EXTRACTOR_RUN_REPOSITORY_TOKEN =
+  createServiceToken<ExtractorRunRepositoryStorage>(
+    "sec.storage.extractorRunRepository"
+  );

--- a/src/storage/versioning/VersionRegistry.test.ts
+++ b/src/storage/versioning/VersionRegistry.test.ts
@@ -187,4 +187,90 @@ describe("VersionRegistry", () => {
     expect(extractors).toHaveLength(1);
     expect(extractors[0].component_id).toBe("D");
   });
+
+  it("rejects putSlot with malformed semver", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await expect(
+      reg.putSlot({
+        component_kind: "extractor",
+        component_id: "D",
+        slot: "current",
+        semver: "not-a-version",
+        bump_type: null,
+        started_at: "2026-05-21T00:00:00Z",
+        coverage_complete: true,
+      })
+    ).rejects.toThrow(/invalid semver/);
+  });
+
+  it("rejects putSlot when current slot has coverage_complete=false", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await expect(
+      reg.putSlot({
+        component_kind: "extractor",
+        component_id: "D",
+        slot: "current",
+        semver: "1.0.0",
+        bump_type: null,
+        started_at: "2026-05-21T00:00:00Z",
+        coverage_complete: false,
+      })
+    ).rejects.toThrow(/coverage_complete must be true/);
+  });
+
+  it("allows putSlot for next slot with coverage_complete=false", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "next",
+      semver: "2.1.0",
+      bump_type: "minor",
+      started_at: "2026-05-21T01:00:00Z",
+      coverage_complete: false,
+    });
+    expect((await reg.getNext("extractor", "D"))?.coverage_complete).toBe(false);
+  });
+
+  it("putSlot overwrites the same slot on second call", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "current",
+      semver: "1.0.0",
+      bump_type: null,
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: true,
+    });
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "current",
+      semver: "1.0.1",
+      bump_type: "patch",
+      started_at: "2026-05-21T02:00:00Z",
+      coverage_complete: true,
+    });
+    const row = await reg.getCurrent("extractor", "D");
+    expect(row?.semver).toBe("1.0.1");
+    expect(row?.bump_type).toBe("patch");
+  });
+
+  it("clearSlot on a slot that doesn't exist is a no-op", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    // Should not throw
+    await reg.clearSlot("extractor", "D", "next");
+    expect(await reg.getNext("extractor", "D")).toBeUndefined();
+  });
 });

--- a/src/storage/versioning/VersionRegistry.test.ts
+++ b/src/storage/versioning/VersionRegistry.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "./ComponentVersionSchema";
+import { isValidSemver, VersionRegistry } from "./VersionRegistry";
+
+describe("isValidSemver", () => {
+  it("accepts standard semver", () => {
+    expect(isValidSemver("1.0.0")).toBe(true);
+    expect(isValidSemver("2.10.3")).toBe(true);
+    expect(isValidSemver("0.0.1")).toBe(true);
+  });
+  it("rejects malformed strings", () => {
+    expect(isValidSemver("1.0")).toBe(false);
+    expect(isValidSemver("v1.0.0")).toBe(false);
+    expect(isValidSemver("1.0.0-alpha")).toBe(false); // intentionally not supported in v1
+    expect(isValidSemver("")).toBe(false);
+    expect(isValidSemver("foo")).toBe(false);
+  });
+});
+
+describe("VersionRegistry", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("returns undefined for missing slots", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    expect(await reg.getCurrent("extractor", "D")).toBeUndefined();
+    expect(await reg.getPrevious("extractor", "D")).toBeUndefined();
+    expect(await reg.getNext("extractor", "D")).toBeUndefined();
+  });
+
+  it("round-trips a single slot via putSlot/getCurrent", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "current",
+      semver: "1.0.0",
+      bump_type: null,
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: true,
+    });
+    const cur = await reg.getCurrent("extractor", "D");
+    expect(cur?.semver).toBe("1.0.0");
+    expect(cur?.coverage_complete).toBe(true);
+    expect(await reg.getPrevious("extractor", "D")).toBeUndefined();
+    expect(await reg.getNext("extractor", "D")).toBeUndefined();
+  });
+
+  it("keeps slots independent for the same component", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "previous",
+      semver: "1.0.0",
+      bump_type: null,
+      started_at: "2026-05-20T00:00:00Z",
+      coverage_complete: true,
+    });
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "current",
+      semver: "2.0.0",
+      bump_type: "major",
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: true,
+    });
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "next",
+      semver: "2.1.0",
+      bump_type: "minor",
+      started_at: "2026-05-21T01:00:00Z",
+      coverage_complete: false,
+    });
+
+    expect((await reg.getPrevious("extractor", "D"))?.semver).toBe("1.0.0");
+    expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("2.0.0");
+    expect((await reg.getNext("extractor", "D"))?.semver).toBe("2.1.0");
+  });
+
+  it("clearSlot removes only the targeted slot", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "current",
+      semver: "2.0.0",
+      bump_type: null,
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: true,
+    });
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "next",
+      semver: "2.1.0",
+      bump_type: "minor",
+      started_at: "2026-05-21T01:00:00Z",
+      coverage_complete: false,
+    });
+
+    await reg.clearSlot("extractor", "D", "next");
+
+    expect(await reg.getNext("extractor", "D")).toBeUndefined();
+    expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("2.0.0");
+  });
+
+  it("listAll returns rows across kinds and ids", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "current",
+      semver: "1.0.0",
+      bump_type: null,
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: true,
+    });
+    await reg.putSlot({
+      component_kind: "resolver",
+      component_id: "person",
+      slot: "current",
+      semver: "1.0.0",
+      bump_type: null,
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: true,
+    });
+
+    const all = await reg.listAll();
+    expect(all).toHaveLength(2);
+    const kinds = all.map((r) => r.component_kind).sort();
+    expect(kinds).toEqual(["extractor", "resolver"]);
+  });
+
+  it("listByKind filters", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "current",
+      semver: "1.0.0",
+      bump_type: null,
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: true,
+    });
+    await reg.putSlot({
+      component_kind: "resolver",
+      component_id: "person",
+      slot: "current",
+      semver: "1.0.0",
+      bump_type: null,
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: true,
+    });
+
+    const extractors = await reg.listByKind("extractor");
+    expect(extractors).toHaveLength(1);
+    expect(extractors[0].component_id).toBe("D");
+  });
+});

--- a/src/storage/versioning/VersionRegistry.ts
+++ b/src/storage/versioning/VersionRegistry.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  ComponentKind,
+  ComponentSlot,
+  ComponentVersion,
+  ComponentVersionRepositoryStorage,
+} from "./ComponentVersionSchema";
+
+const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function isValidSemver(s: string): boolean {
+  return SEMVER_RE.test(s);
+}
+
+export class VersionRegistry {
+  constructor(private readonly storage: ComponentVersionRepositoryStorage) {}
+
+  async getCurrent(
+    kind: ComponentKind,
+    id: string
+  ): Promise<ComponentVersion | undefined> {
+    return this.getSlot(kind, id, "current");
+  }
+
+  async getPrevious(
+    kind: ComponentKind,
+    id: string
+  ): Promise<ComponentVersion | undefined> {
+    return this.getSlot(kind, id, "previous");
+  }
+
+  async getNext(
+    kind: ComponentKind,
+    id: string
+  ): Promise<ComponentVersion | undefined> {
+    return this.getSlot(kind, id, "next");
+  }
+
+  async putSlot(row: ComponentVersion): Promise<void> {
+    await this.storage.put(row);
+  }
+
+  async clearSlot(
+    kind: ComponentKind,
+    id: string,
+    slot: ComponentSlot
+  ): Promise<void> {
+    await this.storage.delete({
+      component_kind: kind,
+      component_id: id,
+      slot,
+    });
+  }
+
+  async listAll(): Promise<ComponentVersion[]> {
+    const rows = await this.storage.getAll();
+    return rows ?? [];
+  }
+
+  async listByKind(kind: ComponentKind): Promise<ComponentVersion[]> {
+    const rows = await this.storage.query({ component_kind: kind });
+    return rows ?? [];
+  }
+
+  private async getSlot(
+    kind: ComponentKind,
+    id: string,
+    slot: ComponentSlot
+  ): Promise<ComponentVersion | undefined> {
+    const rows = await this.storage.query({
+      component_kind: kind,
+      component_id: id,
+      slot,
+    });
+    return rows?.[0];
+  }
+}

--- a/src/storage/versioning/VersionRegistry.ts
+++ b/src/storage/versioning/VersionRegistry.ts
@@ -13,6 +13,10 @@ import type {
 
 const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
+/**
+ * Validates MAJOR.MINOR.PATCH semver strings. Pre-release suffixes
+ * (e.g. "1.0.0-alpha") and build metadata are intentionally unsupported in v1.
+ */
 export function isValidSemver(s: string): boolean {
   return SEMVER_RE.test(s);
 }
@@ -42,6 +46,16 @@ export class VersionRegistry {
   }
 
   async putSlot(row: ComponentVersion): Promise<void> {
+    if (!isValidSemver(row.semver)) {
+      throw new Error(
+        `VersionRegistry: invalid semver '${row.semver}' for ${row.component_kind}:${row.component_id} slot=${row.slot}`
+      );
+    }
+    if (row.slot !== "next" && !row.coverage_complete) {
+      throw new Error(
+        `VersionRegistry: coverage_complete must be true for ${row.slot} slot (got false on ${row.component_kind}:${row.component_id})`
+      );
+    }
     await this.storage.put(row);
   }
 


### PR DESCRIPTION
## Summary

Introduces a component versioning system to track extractor and resolver versions across three slots (previous, current, next). Includes storage schemas, a registry class for version management, CLI commands for inspection and seeding, and comprehensive tests.

## Key Changes

- **ComponentVersionSchema** (`src/storage/versioning/ComponentVersionSchema.ts`): Defines the schema for tracking component versions with slots, semantic versions, bump types, and coverage status. Includes primary key constraints on (component_kind, component_id, slot).

- **ExtractorRunSchema** (`src/storage/versioning/ExtractorRunSchema.ts`): Defines schema for recording extractor execution history, linking runs to specific component versions and filing data.

- **VersionRegistry** (`src/storage/versioning/VersionRegistry.ts`): Core registry class providing:
  - Slot-based access methods (`getCurrent`, `getPrevious`, `getNext`)
  - `putSlot` with validation (semver format, coverage_complete requirements)
  - `clearSlot` for removing specific slots
  - `listAll` and `listByKind` for querying across components
  - `isValidSemver` utility for MAJOR.MINOR.PATCH validation (pre-release suffixes intentionally unsupported in v1)

- **CLI version commands** (`src/cli/groups/version.ts`):
  - `version status`: Displays current/previous/next versions of all components in table or JSON format
  - `version seed-test`: Internal command for populating test data (to be replaced by start-dev/promote in PR3)

- **VersionStatus query** (`src/cli/queries/VersionStatus.ts`): Aggregates version data across slots into a human-readable format with coverage indicators.

- **Dependency injection setup**: Registered component version and extractor run repositories in both `DefaultDI.ts` (SQLite) and `TestingDI.ts` (in-memory).

- **Database initialization**: Added schema setup in `resetAllDatabases.ts` and `setupAllDatabases.ts`.

- **Comprehensive tests**:
  - `VersionRegistry.test.ts`: 11 unit tests covering validation, slot independence, CRUD operations, and edge cases
  - `version.test.ts`: Integration tests for CLI commands with temporary SQLite databases

## Notable Implementation Details

- Semver validation uses strict regex (`/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/`) to reject pre-release and build metadata formats
- The `current` and `previous` slots enforce `coverage_complete=true`; only `next` allows incomplete coverage
- Slot operations are independent—updating one slot does not affect others for the same component
- Version status display uses "—" for missing slots and "(ready)" / "(in progress)" indicators for next slot coverage
- CLI integration via `addVersionCommands` in `src/commands/index.ts`

https://claude.ai/code/session_01CAQMiENJGSmLi4HqE4pZ5t