### PR TITLE
Version-bump ceremonies — start-dev, promote, rollback, drop-next (PR3)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,1 +1,9 @@
 install.linker = "isolated"
+
+[test]
+# Multi-spawn CLI integration tests (e.g. version.test.ts, forceWarning.test.ts)
+# each fire 2-5 sequential `bun src/sec.ts` subprocesses; each spawn pays the
+# DI bootstrap cost (~1s locally, slower on CI runners). The default 5000ms
+# was triggering flakes on the busiest tests; 30s gives generous headroom
+# across all environments without slowing the common case.
+timeout = 30000

--- a/src/cli/groups/version.test.ts
+++ b/src/cli/groups/version.test.ts
@@ -62,45 +62,25 @@ describe("sec version CLI", () => {
     }
   });
 
-  it("seed-test populates a slot and status --format json reflects it", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
-    try {
-      const setup = await runCli(["db", "setup"], dir);
-      expect(setup.exitCode).toBe(0);
-
-      const seed = await runCli(
-        ["version", "seed-test", "extractor", "D", "current", "1.0.0"],
-        dir
-      );
-      expect(seed.exitCode).toBe(0);
-
-      const status = await runCli(["version", "status", "--format", "json"], dir);
-      expect(status.exitCode).toBe(0);
-      const parsed = JSON.parse(status.stdout);
-      // After PR2 bootstrap, status lists all five extractors; locate "D".
-      const dRow = parsed.find(
-        (r: { component_id: string }) => r.component_id === "D"
-      );
-      expect(dRow).toBeDefined();
-      expect(dRow.current).toBe("1.0.0");
-      expect(dRow.previous).toBe("—");
-      expect(dRow.next).toBe("—");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
   it("status --format json returns raw semver in next, with separate coverage flag", async () => {
     const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
     try {
       const setup = await runCli(["db", "setup"], dir);
       expect(setup.exitCode).toBe(0);
 
-      const seed = await runCli(
-        ["version", "seed-test", "extractor", "D", "next", "2.1.0"],
+      const startDev = await runCli(
+        [
+          "version",
+          "start-dev",
+          "extractor",
+          "D",
+          "2.0.0",
+          "--bump",
+          "major",
+        ],
         dir
       );
-      expect(seed.exitCode).toBe(0);
+      expect(startDev.exitCode).toBe(0);
 
       const status = await runCli(["version", "status", "--format", "json"], dir);
       expect(status.exitCode).toBe(0);
@@ -111,7 +91,7 @@ describe("sec version CLI", () => {
       );
       expect(dRow).toBeDefined();
       // JSON output is raw data — semver only, no presentation suffix.
-      expect(dRow.next).toBe("2.1.0");
+      expect(dRow.next).toBe("2.0.0");
       expect(dRow.next_coverage_complete).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -127,6 +107,208 @@ describe("sec version CLI", () => {
       const status = await runCli(["version", "status", "--format", "yaml"], dir);
       expect(status.exitCode).not.toBe(0);
       expect(status.stderr + status.stdout).toMatch(/Invalid --format/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("start-dev creates a next slot and history records it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      const setup = await runCli(["db", "setup"], dir);
+      expect(setup.exitCode).toBe(0);
+
+      const result = await runCli(
+        [
+          "version",
+          "start-dev",
+          "extractor",
+          "D",
+          "2.0.0",
+          "--bump",
+          "major",
+          "--notes",
+          "first dev cycle",
+        ],
+        dir
+      );
+      expect(result.exitCode).toBe(0);
+
+      const status = await runCli(["version", "status", "--format", "json"], dir);
+      expect(status.exitCode).toBe(0);
+      const parsed = JSON.parse(status.stdout);
+      const dRow = parsed.find(
+        (r: { component_id: string }) => r.component_id === "D"
+      );
+      expect(dRow?.next).toBe("2.0.0");
+      expect(dRow?.next_coverage_complete).toBe(false);
+
+      const history = await runCli(
+        ["version", "history", "extractor", "D", "--format", "json"],
+        dir
+      );
+      expect(history.exitCode).toBe(0);
+      const events = JSON.parse(history.stdout);
+      expect(events).toHaveLength(1);
+      expect(events[0].event_type).toBe("start-dev");
+      expect(events[0].notes).toBe("first dev cycle");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("coverage reports in-progress with a known denominator", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      await runCli(["db", "setup"], dir);
+      await runCli(
+        ["version", "start-dev", "extractor", "D", "2.0.0", "--bump", "major"],
+        dir
+      );
+      const result = await runCli(
+        ["version", "coverage", "extractor", "D", "--format", "json"],
+        dir
+      );
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.next_semver).toBe("2.0.0");
+      expect(parsed.target_count).toBe(0); // no filings seeded
+      expect(parsed.status).toMatch(/ready to promote/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("promote with --force rotates slots and history records both events", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      await runCli(["db", "setup"], dir);
+      await runCli(
+        ["version", "start-dev", "extractor", "D", "2.0.0", "--bump", "major"],
+        dir
+      );
+      const promote = await runCli(
+        ["version", "promote", "extractor", "D", "--force"],
+        dir
+      );
+      expect(promote.exitCode).toBe(0);
+
+      const status = await runCli(["version", "status", "--format", "json"], dir);
+      const parsed = JSON.parse(status.stdout);
+      const dRow = parsed.find(
+        (r: { component_id: string }) => r.component_id === "D"
+      );
+      expect(dRow?.current).toBe("2.0.0");
+      expect(dRow?.previous).toBe("1.0.0");
+      expect(dRow?.next).toBe("—");
+
+      const history = await runCli(
+        ["version", "history", "extractor", "D", "--format", "json"],
+        dir
+      );
+      const events = JSON.parse(history.stdout);
+      expect(events).toHaveLength(2);
+      expect(events[0].event_type).toBe("promote");
+      expect(events[1].event_type).toBe("start-dev");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rollback swaps current and previous", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      await runCli(["db", "setup"], dir);
+      await runCli(
+        ["version", "start-dev", "extractor", "D", "2.0.0", "--bump", "major"],
+        dir
+      );
+      await runCli(["version", "promote", "extractor", "D", "--force"], dir);
+
+      const result = await runCli(
+        ["version", "rollback", "extractor", "D"],
+        dir
+      );
+      expect(result.exitCode).toBe(0);
+
+      const status = await runCli(["version", "status", "--format", "json"], dir);
+      const parsed = JSON.parse(status.stdout);
+      const dRow = parsed.find(
+        (r: { component_id: string }) => r.component_id === "D"
+      );
+      expect(dRow?.current).toBe("1.0.0");
+      expect(dRow?.previous).toBe("2.0.0");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("drop-next clears the next slot", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      await runCli(["db", "setup"], dir);
+      await runCli(
+        ["version", "start-dev", "extractor", "D", "2.0.0", "--bump", "major"],
+        dir
+      );
+      const result = await runCli(
+        ["version", "drop-next", "extractor", "D"],
+        dir
+      );
+      expect(result.exitCode).toBe(0);
+
+      const status = await runCli(["version", "status", "--format", "json"], dir);
+      const parsed = JSON.parse(status.stdout);
+      const dRow = parsed.find(
+        (r: { component_id: string }) => r.component_id === "D"
+      );
+      expect(dRow?.next).toBe("—");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("start-dev --bump patch updates current in place without a next slot", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      await runCli(["db", "setup"], dir);
+      const result = await runCli(
+        ["version", "start-dev", "extractor", "D", "1.0.1", "--bump", "patch"],
+        dir
+      );
+      expect(result.exitCode).toBe(0);
+
+      const status = await runCli(["version", "status", "--format", "json"], dir);
+      const parsed = JSON.parse(status.stdout);
+      const dRow = parsed.find(
+        (r: { component_id: string }) => r.component_id === "D"
+      );
+      expect(dRow?.current).toBe("1.0.1");
+      expect(dRow?.next).toBe("—");
+      expect(dRow?.previous).toBe("—");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects start-dev for an unknown extractor id", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
+    try {
+      await runCli(["db", "setup"], dir);
+      const result = await runCli(
+        [
+          "version",
+          "start-dev",
+          "extractor",
+          "no-such-form",
+          "1.0.0",
+          "--bump",
+          "major",
+        ],
+        dir
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr + result.stdout).toMatch(/no extractor registered/i);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/cli/groups/version.test.ts
+++ b/src/cli/groups/version.test.ts
@@ -179,7 +179,9 @@ describe("sec version CLI", () => {
     }
   });
 
-  it("promote with --force rotates slots and history records both events", async () => {
+  it(
+    "promote with --force rotates slots and history records both events",
+    async () => {
     const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
     try {
       await runCli(["db", "setup"], dir);
@@ -213,9 +215,13 @@ describe("sec version CLI", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+    },
+    15000
+  );
 
-  it("rollback swaps current and previous", async () => {
+  it(
+    "rollback swaps current and previous",
+    async () => {
     const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));
     try {
       await runCli(["db", "setup"], dir);
@@ -241,7 +247,9 @@ describe("sec version CLI", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+    },
+    15000
+  );
 
   it("drop-next clears the next slot", async () => {
     const dir = mkdtempSync(join(tmpdir(), "sec-version-test-"));

--- a/src/cli/groups/version.ts
+++ b/src/cli/groups/version.ts
@@ -119,6 +119,7 @@ export function addVersionCommands(program: Command): void {
           bump_type: null,
           started_at: new Date().toISOString(),
           coverage_complete: slot !== "next",
+          target_count: null,
         });
         console.log(`Seeded ${kind}:${id} slot=${slot} semver=${semver}`);
       });

--- a/src/cli/groups/version.ts
+++ b/src/cli/groups/version.ts
@@ -17,6 +17,7 @@ import {
   rollback as rollbackCeremony,
   startDev as startDevCeremony,
 } from "../../storage/versioning/ceremonies";
+import { isRegisteredComponent } from "../../storage/versioning/componentRegistry";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
 import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
 import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
@@ -224,6 +225,22 @@ export function addVersionCommands(program: Command): void {
           assertComponentKind(kind);
           const bumpArg = options.bump as string;
           assertBump(bumpArg);
+          if (!isRegisteredComponent(kind, id)) {
+            throw new Error(`No ${kind} registered: '${id}'`);
+          }
+          // For non-patch bumps, fail-fast if a dev cycle is already in flight
+          // — saves the snapshotTargetCount filing-set materialization.
+          if (bumpArg !== "patch") {
+            const regCheck = new VersionRegistry(
+              globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+            );
+            const existingNext = await regCheck.getNext(kind, id);
+            if (existingNext) {
+              throw new Error(
+                `next slot already exists for ${kind} '${id}' (at ${existingNext.semver}). drop-next first.`
+              );
+            }
+          }
           const reg = new VersionRegistry(
             globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
           );

--- a/src/cli/groups/version.ts
+++ b/src/cli/groups/version.ts
@@ -8,16 +8,25 @@ import type { Command } from "commander";
 import { globalServiceRegistry } from "workglow";
 import {
   COMPONENT_KINDS,
-  COMPONENT_SLOTS,
   COMPONENT_VERSION_REPOSITORY_TOKEN,
   ComponentKind,
-  ComponentSlot,
 } from "../../storage/versioning/ComponentVersionSchema";
 import {
-  isValidSemver,
-  VersionRegistry,
-} from "../../storage/versioning/VersionRegistry";
+  dropNext as dropNextCeremony,
+  promote as promoteCeremony,
+  rollback as rollbackCeremony,
+  startDev as startDevCeremony,
+} from "../../storage/versioning/ceremonies";
+import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
+import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
+import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
+import { FORM_TO_EXTRACTOR_ID } from "../../storage/versioning/extractorIds";
+import { VERSION_EVENT_REPOSITORY_TOKEN } from "../../storage/versioning/VersionEventSchema";
+import { VersionEventRepo } from "../../storage/versioning/VersionEventRepo";
+import { VersionRegistry } from "../../storage/versioning/VersionRegistry";
 import { renderTable } from "../output/TableRenderer";
+import { getVersionCoverage } from "../queries/VersionCoverage";
+import { getVersionHistory } from "../queries/VersionHistory";
 import { getVersionStatus } from "../queries/VersionStatus";
 import { runCommand } from "../runCommand";
 
@@ -29,47 +38,62 @@ function assertComponentKind(s: string): asserts s is ComponentKind {
   }
 }
 
-function assertComponentSlot(s: string): asserts s is ComponentSlot {
-  if (!(COMPONENT_SLOTS as readonly string[]).includes(s)) {
-    throw new Error(
-      `Invalid slot '${s}'. Expected one of: ${COMPONENT_SLOTS.join(", ")}`
-    );
+function assertBump(s: string): asserts s is "major" | "minor" | "patch" {
+  if (s !== "major" && s !== "minor" && s !== "patch") {
+    throw new Error(`Invalid --bump '${s}'. Expected: major, minor, patch`);
   }
 }
 
 const SUPPORTED_STATUS_FORMATS = ["table", "json"] as const;
+function assertFormat(s: string): asserts s is "table" | "json" {
+  if (!(SUPPORTED_STATUS_FORMATS as readonly string[]).includes(s)) {
+    throw new Error(
+      `Invalid --format '${s}'. Expected one of: ${SUPPORTED_STATUS_FORMATS.join(", ")}`
+    );
+  }
+}
+
+/**
+ * For a major-bump start-dev, snapshot the count of filings handled by this
+ * extractor. The result is stored on the next-slot row and acts as the
+ * promote-gate denominator.
+ */
+async function snapshotTargetCount(extractorId: string): Promise<number> {
+  const filingRepo = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
+  const forms = Object.entries(FORM_TO_EXTRACTOR_ID)
+    .filter(([, eid]) => eid === extractorId)
+    .map(([form]) => form);
+  let total = 0;
+  for (const form of forms) {
+    const rows = (await filingRepo.query({ form })) ?? [];
+    total += rows.length;
+  }
+  return total;
+}
 
 export function addVersionCommands(program: Command): void {
   const version = program
     .command("version")
     .description("Inspect and manage extractor/resolver versions");
 
+  // status
   version
     .command("status")
     .description("Show the current/previous/next version of every component")
     .option("--format <format>", "Output format (table, json)", "table")
     .action(async (options: Record<string, string>) => {
       await runCommand(async () => {
-        if (!(SUPPORTED_STATUS_FORMATS as readonly string[]).includes(options.format)) {
-          throw new Error(
-            `Invalid --format '${options.format}'. Expected one of: ${SUPPORTED_STATUS_FORMATS.join(", ")}`
-          );
-        }
-
+        assertFormat(options.format);
         const rows = await getVersionStatus();
 
         if (options.format === "json") {
           console.log(JSON.stringify(rows, null, 2));
           return;
         }
-
         if (rows.length === 0) {
           console.log("No components registered.");
           return;
         }
-
-        // Decorate `next` for the table view only. JSON consumers get raw
-        // semver in `next` plus the boolean `next_coverage_complete` flag.
         const tableRows = rows.map((r) => ({
           ...r,
           next:
@@ -79,7 +103,6 @@ export function addVersionCommands(program: Command): void {
                 ? `${r.next} (ready)`
                 : `${r.next} (in progress)`,
         }));
-
         console.log(
           renderTable(
             tableRows as unknown as ReadonlyArray<Record<string, unknown>>,
@@ -96,32 +119,243 @@ export function addVersionCommands(program: Command): void {
       });
     });
 
+  // history
   version
-    .command("seed-test <kind> <id> <slot> <semver>")
-    .description(
-      "(internal) Write a single slot directly. PR3 replaces this with start-dev/promote."
-    )
-    .action(async (kind: string, id: string, slot: string, semver: string) => {
+    .command("history <kind> <id>")
+    .description("Show recent ceremony events for a component")
+    .option("--limit <n>", "Maximum number of events to show", "20")
+    .option("--format <format>", "Output format (table, json)", "table")
+    .action(async (kind: string, id: string, options: Record<string, string>) => {
       await runCommand(async () => {
         assertComponentKind(kind);
-        assertComponentSlot(slot);
-        if (!isValidSemver(semver)) {
-          throw new Error(`Invalid semver: ${semver}`);
+        assertFormat(options.format);
+        const limit = parseInt(options.limit, 10);
+        if (Number.isNaN(limit) || limit < 1) {
+          throw new Error(
+            `Invalid --limit '${options.limit}'. Expected positive integer.`
+          );
         }
-        const reg = new VersionRegistry(
-          globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+        const events = await getVersionHistory(kind, id, limit);
+        if (options.format === "json") {
+          console.log(JSON.stringify(events, null, 2));
+          return;
+        }
+        if (events.length === 0) {
+          console.log(`No history for ${kind}:${id}.`);
+          return;
+        }
+        console.log(
+          renderTable(
+            events as unknown as ReadonlyArray<Record<string, unknown>>,
+            [
+              { key: "at_timestamp", header: "When", width: 24 },
+              { key: "event_type", header: "Event", width: 12 },
+              { key: "from_semver", header: "From", width: 12 },
+              { key: "to_semver", header: "To", width: 12 },
+              { key: "bump_type", header: "Bump", width: 8 },
+              { key: "notes", header: "Notes", width: 40 },
+            ],
+            { format: "table" }
+          )
         );
-        await reg.putSlot({
-          component_kind: kind,
-          component_id: id,
-          slot,
-          semver,
-          bump_type: null,
-          started_at: new Date().toISOString(),
-          coverage_complete: slot !== "next",
-          target_count: null,
-        });
-        console.log(`Seeded ${kind}:${id} slot=${slot} semver=${semver}`);
       });
     });
+
+  // coverage
+  version
+    .command("coverage <kind> <id>")
+    .description("Show major-promote coverage for a component")
+    .option("--format <format>", "Output format (table, json)", "table")
+    .action(async (kind: string, id: string, options: Record<string, string>) => {
+      await runCommand(async () => {
+        assertComponentKind(kind);
+        assertFormat(options.format);
+        const result = await getVersionCoverage(kind, id);
+        if (options.format === "json") {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(
+          `${result.component_kind}:${result.component_id}\n` +
+            `  Status:     ${result.status}\n` +
+            `  Next:       ${result.next_semver ?? "—"} (${result.bump_type ?? "—"})\n` +
+            `  Target:     ${result.target_count ?? "—"}\n` +
+            `  Successful: ${result.successful_count ?? "—"}\n` +
+            `  Percent:    ${result.percent !== null ? `${result.percent}%` : "—"}`
+        );
+      });
+    });
+
+  // start-dev
+  version
+    .command("start-dev <kind> <id> <semver>")
+    .description("Begin a dev cycle for a component (or apply a patch in place)")
+    .requiredOption("--bump <type>", "Bump type: major, minor, or patch")
+    .option("--notes <text>", "Optional notes for the audit log", "")
+    .option("--dry-run", "Print what would happen; commit nothing", false)
+    .action(
+      async (
+        kind: string,
+        id: string,
+        semver: string,
+        options: Record<string, string | boolean>
+      ) => {
+        await runCommand(async () => {
+          assertComponentKind(kind);
+          const bumpArg = options.bump as string;
+          assertBump(bumpArg);
+          if (options.dryRun) {
+            console.log(
+              `(dry-run) start-dev ${kind} ${id} ${semver} --bump ${bumpArg}`
+            );
+            return;
+          }
+          const reg = new VersionRegistry(
+            globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+          );
+          const events = new VersionEventRepo(
+            globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+          );
+          const targetCount =
+            bumpArg === "major" ? await snapshotTargetCount(id) : null;
+          const notes =
+            typeof options.notes === "string" && options.notes !== ""
+              ? options.notes
+              : null;
+          await startDevCeremony({
+            reg,
+            events,
+            kind,
+            id,
+            semver,
+            bump: bumpArg,
+            targetCount,
+            notes,
+          });
+          if (bumpArg === "patch") {
+            console.log(`Patched ${kind}:${id} → ${semver} (in place)`);
+          } else {
+            console.log(
+              `Started dev cycle: ${kind}:${id} ${semver} --bump ${bumpArg}${
+                targetCount !== null ? ` (target_count=${targetCount})` : ""
+              }`
+            );
+          }
+        });
+      }
+    );
+
+  // promote
+  version
+    .command("promote <kind> <id>")
+    .description("Promote the next slot to current (slot rotation)")
+    .option("--force", "Bypass the major-bump coverage gate", false)
+    .option("--notes <text>", "Optional notes for the audit log", "")
+    .option("--dry-run", "Print what would happen; commit nothing", false)
+    .action(
+      async (kind: string, id: string, options: Record<string, boolean | string>) => {
+        await runCommand(async () => {
+          assertComponentKind(kind);
+          if (options.dryRun) {
+            console.log(`(dry-run) promote ${kind} ${id}`);
+            return;
+          }
+          const reg = new VersionRegistry(
+            globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+          );
+          const events = new VersionEventRepo(
+            globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+          );
+          const runs = new ExtractorRunRepo(
+            globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN)
+          );
+          const notes =
+            typeof options.notes === "string" && options.notes !== ""
+              ? options.notes
+              : null;
+          await promoteCeremony({
+            reg,
+            events,
+            runs,
+            kind,
+            id,
+            force: options.force === true,
+            notes,
+          });
+          console.log(`Promoted ${kind}:${id}`);
+        });
+      }
+    );
+
+  // rollback
+  version
+    .command("rollback <kind> <id>")
+    .description("Swap current and previous slots")
+    .option("--notes <text>", "Optional notes for the audit log", "")
+    .option("--dry-run", "Print what would happen; commit nothing", false)
+    .action(
+      async (kind: string, id: string, options: Record<string, boolean | string>) => {
+        await runCommand(async () => {
+          assertComponentKind(kind);
+          if (options.dryRun) {
+            console.log(`(dry-run) rollback ${kind} ${id}`);
+            return;
+          }
+          const reg = new VersionRegistry(
+            globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+          );
+          const events = new VersionEventRepo(
+            globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+          );
+          const notes =
+            typeof options.notes === "string" && options.notes !== ""
+              ? options.notes
+              : null;
+          await rollbackCeremony({
+            reg,
+            events,
+            kind,
+            id,
+            notes,
+          });
+          console.log(`Rolled back ${kind}:${id}`);
+        });
+      }
+    );
+
+  // drop-next
+  version
+    .command("drop-next <kind> <id>")
+    .description("Discard the in-flight dev cycle (clear the next slot)")
+    .option("--notes <text>", "Optional notes for the audit log", "")
+    .option("--dry-run", "Print what would happen; commit nothing", false)
+    .action(
+      async (kind: string, id: string, options: Record<string, boolean | string>) => {
+        await runCommand(async () => {
+          assertComponentKind(kind);
+          if (options.dryRun) {
+            console.log(`(dry-run) drop-next ${kind} ${id}`);
+            return;
+          }
+          const reg = new VersionRegistry(
+            globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+          );
+          const events = new VersionEventRepo(
+            globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+          );
+          const notes =
+            typeof options.notes === "string" && options.notes !== ""
+              ? options.notes
+              : null;
+          await dropNextCeremony({
+            reg,
+            events,
+            kind,
+            id,
+            notes,
+          });
+          console.log(`Dropped next slot for ${kind}:${id}`);
+        });
+      }
+    );
 }

--- a/src/cli/groups/version.ts
+++ b/src/cli/groups/version.ts
@@ -63,6 +63,13 @@ function assertFormat(s: string): asserts s is "table" | "json" {
  * dev-cycle, they will need their own kind-aware snapshot strategy
  * (count of observations? count of canonical identities? TBD). Add a
  * dispatch table keyed on ComponentKind here when PR4 lands.
+ *
+ * TODO(perf): currently loads all filings into memory via filingRepo.query()
+ * just to count them. For Form D at projected scale (hundreds of thousands
+ * of filings) this is ~100MB transient. A filtered-count helper on the
+ * tabular storage or a paged-iteration counter would be cheaper. Acceptable
+ * for v1 because start-dev is a rare manual ceremony; revisit if it becomes
+ * a routine operation.
  */
 async function snapshotTargetCount(
   kind: ComponentKind,

--- a/src/cli/groups/version.ts
+++ b/src/cli/groups/version.ts
@@ -28,6 +28,7 @@ import { renderTable } from "../output/TableRenderer";
 import { getVersionCoverage } from "../queries/VersionCoverage";
 import { getVersionHistory } from "../queries/VersionHistory";
 import { getVersionStatus } from "../queries/VersionStatus";
+import { parseGlobalOptions } from "../GlobalOptions";
 import { runCommand } from "../runCommand";
 
 function assertComponentKind(s: string): asserts s is ComponentKind {
@@ -54,14 +55,27 @@ function assertFormat(s: string): asserts s is "table" | "json" {
 }
 
 /**
- * For a major-bump start-dev, snapshot the count of filings handled by this
- * extractor. The result is stored on the next-slot row and acts as the
+ * For a major-bump extractor start-dev, snapshot the count of filings
+ * handled by this extractor. Stored on the next-slot row; used as the
  * promote-gate denominator.
+ *
+ * TODO(PR4): this is extractor-specific. When resolvers gain a major
+ * dev-cycle, they will need their own kind-aware snapshot strategy
+ * (count of observations? count of canonical identities? TBD). Add a
+ * dispatch table keyed on ComponentKind here when PR4 lands.
  */
-async function snapshotTargetCount(extractorId: string): Promise<number> {
+async function snapshotTargetCount(
+  kind: ComponentKind,
+  id: string
+): Promise<number> {
+  if (kind !== "extractor") {
+    throw new Error(
+      `snapshotTargetCount: kind '${kind}' is not yet supported; only 'extractor' has a snapshot strategy. Add resolver support in PR4.`
+    );
+  }
   const filingRepo = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
   const forms = Object.entries(FORM_TO_EXTRACTOR_ID)
-    .filter(([, eid]) => eid === extractorId)
+    .filter(([, eid]) => eid === id)
     .map(([form]) => form);
   let total = 0;
   for (const form of forms) {
@@ -192,7 +206,6 @@ export function addVersionCommands(program: Command): void {
     .description("Begin a dev cycle for a component (or apply a patch in place)")
     .requiredOption("--bump <type>", "Bump type: major, minor, or patch")
     .option("--notes <text>", "Optional notes for the audit log", "")
-    .option("--dry-run", "Print what would happen; commit nothing", false)
     .action(
       async (
         kind: string,
@@ -204,12 +217,6 @@ export function addVersionCommands(program: Command): void {
           assertComponentKind(kind);
           const bumpArg = options.bump as string;
           assertBump(bumpArg);
-          if (options.dryRun) {
-            console.log(
-              `(dry-run) start-dev ${kind} ${id} ${semver} --bump ${bumpArg}`
-            );
-            return;
-          }
           const reg = new VersionRegistry(
             globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
           );
@@ -217,11 +224,12 @@ export function addVersionCommands(program: Command): void {
             globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
           );
           const targetCount =
-            bumpArg === "major" ? await snapshotTargetCount(id) : null;
+            bumpArg === "major" ? await snapshotTargetCount(kind, id) : null;
           const notes =
             typeof options.notes === "string" && options.notes !== ""
               ? options.notes
               : null;
+          const dryRun = parseGlobalOptions(program).dryRun;
           await startDevCeremony({
             reg,
             events,
@@ -231,8 +239,15 @@ export function addVersionCommands(program: Command): void {
             bump: bumpArg,
             targetCount,
             notes,
+            dryRun,
           });
-          if (bumpArg === "patch") {
+          if (dryRun) {
+            console.log(
+              `(dry-run) start-dev ${kind} ${id} ${semver} --bump ${bumpArg} would succeed${
+                targetCount !== null ? ` (would snapshot target_count=${targetCount})` : ""
+              }`
+            );
+          } else if (bumpArg === "patch") {
             console.log(`Patched ${kind}:${id} → ${semver} (in place)`);
           } else {
             console.log(
@@ -251,15 +266,10 @@ export function addVersionCommands(program: Command): void {
     .description("Promote the next slot to current (slot rotation)")
     .option("--force", "Bypass the major-bump coverage gate", false)
     .option("--notes <text>", "Optional notes for the audit log", "")
-    .option("--dry-run", "Print what would happen; commit nothing", false)
     .action(
       async (kind: string, id: string, options: Record<string, boolean | string>) => {
         await runCommand(async () => {
           assertComponentKind(kind);
-          if (options.dryRun) {
-            console.log(`(dry-run) promote ${kind} ${id}`);
-            return;
-          }
           const reg = new VersionRegistry(
             globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
           );
@@ -273,6 +283,7 @@ export function addVersionCommands(program: Command): void {
             typeof options.notes === "string" && options.notes !== ""
               ? options.notes
               : null;
+          const dryRun = parseGlobalOptions(program).dryRun;
           await promoteCeremony({
             reg,
             events,
@@ -281,8 +292,13 @@ export function addVersionCommands(program: Command): void {
             id,
             force: options.force === true,
             notes,
+            dryRun,
           });
-          console.log(`Promoted ${kind}:${id}`);
+          console.log(
+            dryRun
+              ? `(dry-run) promote ${kind} ${id} would succeed`
+              : `Promoted ${kind}:${id}`
+          );
         });
       }
     );
@@ -292,15 +308,10 @@ export function addVersionCommands(program: Command): void {
     .command("rollback <kind> <id>")
     .description("Swap current and previous slots")
     .option("--notes <text>", "Optional notes for the audit log", "")
-    .option("--dry-run", "Print what would happen; commit nothing", false)
     .action(
       async (kind: string, id: string, options: Record<string, boolean | string>) => {
         await runCommand(async () => {
           assertComponentKind(kind);
-          if (options.dryRun) {
-            console.log(`(dry-run) rollback ${kind} ${id}`);
-            return;
-          }
           const reg = new VersionRegistry(
             globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
           );
@@ -311,14 +322,20 @@ export function addVersionCommands(program: Command): void {
             typeof options.notes === "string" && options.notes !== ""
               ? options.notes
               : null;
+          const dryRun = parseGlobalOptions(program).dryRun;
           await rollbackCeremony({
             reg,
             events,
             kind,
             id,
             notes,
+            dryRun,
           });
-          console.log(`Rolled back ${kind}:${id}`);
+          console.log(
+            dryRun
+              ? `(dry-run) rollback ${kind} ${id} would succeed`
+              : `Rolled back ${kind}:${id}`
+          );
         });
       }
     );
@@ -328,15 +345,10 @@ export function addVersionCommands(program: Command): void {
     .command("drop-next <kind> <id>")
     .description("Discard the in-flight dev cycle (clear the next slot)")
     .option("--notes <text>", "Optional notes for the audit log", "")
-    .option("--dry-run", "Print what would happen; commit nothing", false)
     .action(
       async (kind: string, id: string, options: Record<string, boolean | string>) => {
         await runCommand(async () => {
           assertComponentKind(kind);
-          if (options.dryRun) {
-            console.log(`(dry-run) drop-next ${kind} ${id}`);
-            return;
-          }
           const reg = new VersionRegistry(
             globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
           );
@@ -347,14 +359,20 @@ export function addVersionCommands(program: Command): void {
             typeof options.notes === "string" && options.notes !== ""
               ? options.notes
               : null;
+          const dryRun = parseGlobalOptions(program).dryRun;
           await dropNextCeremony({
             reg,
             events,
             kind,
             id,
             notes,
+            dryRun,
           });
-          console.log(`Dropped next slot for ${kind}:${id}`);
+          console.log(
+            dryRun
+              ? `(dry-run) drop-next ${kind} ${id} would succeed`
+              : `Dropped next slot for ${kind}:${id}`
+          );
         });
       }
     );

--- a/src/cli/queries/VersionCoverage.test.ts
+++ b/src/cli/queries/VersionCoverage.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../storage/versioning/ComponentVersionSchema";
+import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
+import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
+import { VersionRegistry } from "../../storage/versioning/VersionRegistry";
+import { getVersionCoverage } from "./VersionCoverage";
+
+describe("getVersionCoverage", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("returns 'no dev cycle in flight' when no next slot exists", async () => {
+    const result = await getVersionCoverage("extractor", "D");
+    expect(result.status).toBe("no dev cycle in flight");
+    expect(result.next_semver).toBeNull();
+    expect(result.target_count).toBeNull();
+    expect(result.successful_count).toBeNull();
+    expect(result.percent).toBeNull();
+  });
+
+  it("returns 'no coverage gate' when next slot has minor bump", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "next",
+      semver: "1.1.0",
+      bump_type: "minor",
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: false,
+      target_count: null,
+    });
+    const result = await getVersionCoverage("extractor", "D");
+    expect(result.status).toBe("no coverage gate (bump_type=minor)");
+    expect(result.next_semver).toBe("1.1.0");
+    expect(result.target_count).toBeNull();
+  });
+
+  it("returns 'in progress' when major bump has incomplete coverage", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    const runs = new ExtractorRunRepo(
+      globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "next",
+      semver: "2.0.0",
+      bump_type: "major",
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: false,
+      target_count: 4,
+    });
+    // 2 successful out of 4 target.
+    for (let i = 0; i < 2; i++) {
+      await runs.recordRun({
+        cik: 1000000 + i,
+        accession_number: `0001000000-25-00000${i}`,
+        form: "D",
+        extractor_id: "D",
+        extractor_version: "2.0.0",
+        slot_at_run: "next",
+        success: true,
+        error: null,
+      });
+    }
+
+    const result = await getVersionCoverage("extractor", "D");
+    expect(result.status).toBe("in progress");
+    expect(result.target_count).toBe(4);
+    expect(result.successful_count).toBe(2);
+    expect(result.percent).toBe(50);
+  });
+
+  it("returns 'ready to promote' when successful >= target", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    const runs = new ExtractorRunRepo(
+      globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "next",
+      semver: "2.0.0",
+      bump_type: "major",
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: false,
+      target_count: 2,
+    });
+    for (let i = 0; i < 2; i++) {
+      await runs.recordRun({
+        cik: 1000000 + i,
+        accession_number: `0001000000-25-00000${i}`,
+        form: "D",
+        extractor_id: "D",
+        extractor_version: "2.0.0",
+        slot_at_run: "next",
+        success: true,
+        error: null,
+      });
+    }
+    const result = await getVersionCoverage("extractor", "D");
+    expect(result.status).toBe("ready to promote");
+    expect(result.percent).toBe(100);
+  });
+
+  it("returns 'ready to promote (target_count=0)' when target is zero", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "next",
+      semver: "2.0.0",
+      bump_type: "major",
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: false,
+      target_count: 0,
+    });
+    const result = await getVersionCoverage("extractor", "D");
+    expect(result.status).toBe("ready to promote (target_count=0)");
+    expect(result.percent).toBe(100);
+  });
+});

--- a/src/cli/queries/VersionCoverage.ts
+++ b/src/cli/queries/VersionCoverage.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import type { ComponentKind } from "../../storage/versioning/ComponentVersionSchema";
+import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../storage/versioning/ComponentVersionSchema";
+import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
+import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
+import { VersionRegistry } from "../../storage/versioning/VersionRegistry";
+
+export interface VersionCoverageResult {
+  readonly component_kind: ComponentKind;
+  readonly component_id: string;
+  readonly status: string;
+  readonly next_semver: string | null;
+  readonly bump_type: string | null;
+  readonly target_count: number | null;
+  readonly successful_count: number | null;
+  readonly percent: number | null;
+}
+
+export async function getVersionCoverage(
+  kind: ComponentKind,
+  id: string
+): Promise<VersionCoverageResult> {
+  const reg = new VersionRegistry(
+    globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+  );
+  const runs = new ExtractorRunRepo(
+    globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN)
+  );
+
+  const next = await reg.getNext(kind, id);
+  if (!next) {
+    return {
+      component_kind: kind,
+      component_id: id,
+      status: "no dev cycle in flight",
+      next_semver: null,
+      bump_type: null,
+      target_count: null,
+      successful_count: null,
+      percent: null,
+    };
+  }
+
+  if (next.bump_type !== "major") {
+    return {
+      component_kind: kind,
+      component_id: id,
+      status: `no coverage gate (bump_type=${next.bump_type})`,
+      next_semver: next.semver,
+      bump_type: next.bump_type,
+      target_count: null,
+      successful_count: null,
+      percent: null,
+    };
+  }
+
+  const target = next.target_count ?? 0;
+  const successful = await runs.countSuccessfulAtVersion(id, next.semver);
+  const percent = target === 0 ? 100 : Math.round((successful / target) * 10000) / 100;
+
+  let status: string;
+  if (target === 0) status = "ready to promote (target_count=0)";
+  else if (successful >= target) status = "ready to promote";
+  else status = "in progress";
+
+  return {
+    component_kind: kind,
+    component_id: id,
+    status,
+    next_semver: next.semver,
+    bump_type: next.bump_type,
+    target_count: target,
+    successful_count: successful,
+    percent,
+  };
+}

--- a/src/cli/queries/VersionCoverage.ts
+++ b/src/cli/queries/VersionCoverage.ts
@@ -60,7 +60,19 @@ export async function getVersionCoverage(
     };
   }
 
-  const target = next.target_count ?? 0;
+  if (next.target_count === null) {
+    return {
+      component_kind: kind,
+      component_id: id,
+      status: "invalid state: missing target_count (major bump requires snapshot)",
+      next_semver: next.semver,
+      bump_type: next.bump_type,
+      target_count: null,
+      successful_count: null,
+      percent: null,
+    };
+  }
+  const target = next.target_count;
   const successful = await runs.countSuccessfulAtVersion(id, next.semver);
   const percent = target === 0 ? 100 : Math.round((successful / target) * 10000) / 100;
 

--- a/src/cli/queries/VersionHistory.test.ts
+++ b/src/cli/queries/VersionHistory.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { VersionEventRepo } from "../../storage/versioning/VersionEventRepo";
+import { VERSION_EVENT_REPOSITORY_TOKEN } from "../../storage/versioning/VersionEventSchema";
+import { getVersionHistory } from "./VersionHistory";
+
+describe("getVersionHistory", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("returns empty when no events recorded for the component", async () => {
+    const events = await getVersionHistory("extractor", "D");
+    expect(events).toEqual([]);
+  });
+
+  it("returns events newest-first for the component", async () => {
+    const repo = new VersionEventRepo(
+      globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+    );
+    await repo.recordEvent({
+      component_kind: "extractor",
+      component_id: "D",
+      event_type: "start-dev",
+      from_semver: "1.0.0",
+      to_semver: "2.0.0",
+      bump_type: "major",
+      target_count: 100,
+      notes: null,
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    await repo.recordEvent({
+      component_kind: "extractor",
+      component_id: "D",
+      event_type: "promote",
+      from_semver: "1.0.0",
+      to_semver: "2.0.0",
+      bump_type: "major",
+      target_count: null,
+      notes: null,
+    });
+
+    const events = await getVersionHistory("extractor", "D");
+    expect(events).toHaveLength(2);
+    expect(events[0].event_type).toBe("promote");
+    expect(events[1].event_type).toBe("start-dev");
+  });
+
+  it("honors the limit parameter", async () => {
+    const repo = new VersionEventRepo(
+      globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+    );
+    for (let i = 0; i < 5; i++) {
+      await repo.recordEvent({
+        component_kind: "extractor",
+        component_id: "D",
+        event_type: "drop-next",
+        from_semver: `2.0.${i}`,
+        to_semver: null,
+        bump_type: "major",
+        target_count: null,
+        notes: null,
+      });
+      await new Promise((r) => setTimeout(r, 2));
+    }
+    const limited = await getVersionHistory("extractor", "D", 2);
+    expect(limited).toHaveLength(2);
+  });
+
+  it("filters by component (kind, id)", async () => {
+    const repo = new VersionEventRepo(
+      globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+    );
+    await repo.recordEvent({
+      component_kind: "extractor",
+      component_id: "D",
+      event_type: "start-dev",
+      from_semver: "1.0.0",
+      to_semver: "2.0.0",
+      bump_type: "major",
+      target_count: 100,
+      notes: null,
+    });
+    await repo.recordEvent({
+      component_kind: "extractor",
+      component_id: "C",
+      event_type: "start-dev",
+      from_semver: "1.0.0",
+      to_semver: "2.0.0",
+      bump_type: "major",
+      target_count: 50,
+      notes: null,
+    });
+
+    const dEvents = await getVersionHistory("extractor", "D");
+    expect(dEvents).toHaveLength(1);
+    expect(dEvents[0].component_id).toBe("D");
+  });
+});

--- a/src/cli/queries/VersionHistory.ts
+++ b/src/cli/queries/VersionHistory.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import type { ComponentKind } from "../../storage/versioning/ComponentVersionSchema";
+import type { VersionEvent } from "../../storage/versioning/VersionEventSchema";
+import { VERSION_EVENT_REPOSITORY_TOKEN } from "../../storage/versioning/VersionEventSchema";
+import { VersionEventRepo } from "../../storage/versioning/VersionEventRepo";
+
+export async function getVersionHistory(
+  kind: ComponentKind,
+  id: string,
+  limit: number = 20
+): Promise<VersionEvent[]> {
+  const repo = new VersionEventRepo(
+    globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+  );
+  return repo.listForComponent(kind, id, limit);
+}

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -189,6 +189,11 @@ import {
   ExtractorRunPrimaryKeyNames,
   ExtractorRunSchema,
 } from "../storage/versioning/ExtractorRunSchema";
+import {
+  VERSION_EVENT_REPOSITORY_TOKEN,
+  VersionEventPrimaryKeyNames,
+  VersionEventSchema,
+} from "../storage/versioning/VersionEventSchema";
 import { createStorage } from "./createStorage";
 
 export const DefaultDI = () => {
@@ -470,6 +475,15 @@ export const DefaultDI = () => {
       ["extractor_id", "extractor_version"],
       ["form", "extractor_version"],
     ])
+  );
+  globalServiceRegistry.registerInstance(
+    VERSION_EVENT_REPOSITORY_TOKEN,
+    createStorage(
+      "version_events",
+      VersionEventSchema,
+      VersionEventPrimaryKeyNames,
+      [["component_kind", "component_id", "at_timestamp"]]
+    )
   );
 
   // ------------------------------ Company Facts --------------------------------

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -186,6 +186,11 @@ import {
   ExtractorRunPrimaryKeyNames,
   ExtractorRunSchema,
 } from "../storage/versioning/ExtractorRunSchema";
+import {
+  VERSION_EVENT_REPOSITORY_TOKEN,
+  VersionEventPrimaryKeyNames,
+  VersionEventSchema,
+} from "../storage/versioning/VersionEventSchema";
 
 export function resetDependencyInjectionsForTesting() {
   // Initialize Company repositories
@@ -439,6 +444,12 @@ export function resetDependencyInjectionsForTesting() {
     new InMemoryTabularStorage(ExtractorRunSchema, ExtractorRunPrimaryKeyNames, [
       ["extractor_id", "extractor_version"],
       ["form", "extractor_version"],
+    ])
+  );
+  globalServiceRegistry.registerInstance(
+    VERSION_EVENT_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(VersionEventSchema, VersionEventPrimaryKeyNames, [
+      ["component_kind", "component_id", "at_timestamp"],
     ])
   );
 

--- a/src/config/resetAllDatabases.ts
+++ b/src/config/resetAllDatabases.ts
@@ -56,6 +56,7 @@ import { REGA_OFFERING_REPOSITORY_TOKEN } from "../storage/reg-a/RegAOfferingSch
 import { REGA_SERVICE_PROVIDER_REPOSITORY_TOKEN } from "../storage/reg-a/RegAServiceProviderSchema";
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../storage/versioning/ComponentVersionSchema";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../storage/versioning/ExtractorRunSchema";
+import { VERSION_EVENT_REPOSITORY_TOKEN } from "../storage/versioning/VersionEventSchema";
 
 /**
  * Truncates every registered repository. Used by `sec db reset --confirm`
@@ -105,5 +106,6 @@ export async function resetAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN).deleteAll();
+  await globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(COMPANY_FACTS_REPOSITORY_TOKEN).deleteAll();
 }

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -57,6 +57,7 @@ import { REGA_SERVICE_PROVIDER_REPOSITORY_TOKEN } from "../storage/reg-a/RegASer
 import { bootstrapExtractorVersions } from "../storage/versioning/bootstrapExtractorVersions";
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../storage/versioning/ComponentVersionSchema";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../storage/versioning/ExtractorRunSchema";
+import { VERSION_EVENT_REPOSITORY_TOKEN } from "../storage/versioning/VersionEventSchema";
 
 /**
  * Calls setupDatabase() on all registered repository instances,
@@ -107,5 +108,6 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(COMPANY_FACTS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN).setupDatabase();
   await bootstrapExtractorVersions();
 }

--- a/src/storage/versioning/ComponentVersionSchema.ts
+++ b/src/storage/versioning/ComponentVersionSchema.ts
@@ -55,6 +55,10 @@ export const ComponentVersionSchema = Type.Object({
     description:
       "Whether the next slot has 100% coverage. Always true for current/previous. Gate for major-promote.",
   }),
+  target_count: Type.Union([Type.Integer({ minimum: 0 }), Type.Null()], {
+    description:
+      "Snapshot of filings handled by this extractor at start-dev time. Populated only on next-slot rows with bump_type='major'; null elsewhere. Denominator for the major-promote coverage gate.",
+  }),
 });
 
 export type ComponentVersion = Static<typeof ComponentVersionSchema>;

--- a/src/storage/versioning/ExtractorRunRepo.test.ts
+++ b/src/storage/versioning/ExtractorRunRepo.test.ts
@@ -290,6 +290,66 @@ describe("ExtractorRunRepo", () => {
     );
     expect(dOnly.map((f) => f.cik)).toEqual([2000000]);
   });
+
+  it("listFilingsWithoutSuccessfulRun treats patch versions as equivalent (1.0.0 row counts for 1.0.1 gate)", async () => {
+    const repo = new ExtractorRunRepo(
+      globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN)
+    );
+    // Filing was processed at version 1.0.0.
+    await repo.recordRun({
+      cik: 1000000,
+      accession_number: "0001000000-25-000001",
+      form: "D",
+      extractor_id: "D",
+      extractor_version: "1.0.0",
+      slot_at_run: "current",
+      success: true,
+      error: null,
+    });
+
+    // After a patch bump to 1.0.1, the same filing should NOT show as unprocessed.
+    const unprocessed = await repo.listFilingsWithoutSuccessfulRun(
+      [{ cik: 1000000, accession_number: "0001000000-25-000001" }],
+      "D",
+      "1.0.1",
+      "D"
+    );
+    expect(unprocessed).toEqual([]);
+  });
+
+  it("listFilingsWithoutSuccessfulRun does NOT count rows across major.minor boundary", async () => {
+    const repo = new ExtractorRunRepo(
+      globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN)
+    );
+    await repo.recordRun({
+      cik: 1000000,
+      accession_number: "0001000000-25-000001",
+      form: "D",
+      extractor_id: "D",
+      extractor_version: "1.0.0",
+      slot_at_run: "current",
+      success: true,
+      error: null,
+    });
+
+    // Gate at 1.1.0 (minor bump) — old 1.0.0 row should NOT count.
+    const afterMinor = await repo.listFilingsWithoutSuccessfulRun(
+      [{ cik: 1000000, accession_number: "0001000000-25-000001" }],
+      "D",
+      "1.1.0",
+      "D"
+    );
+    expect(afterMinor).toHaveLength(1);
+
+    // Gate at 2.0.0 (major bump) — also shouldn't count.
+    const afterMajor = await repo.listFilingsWithoutSuccessfulRun(
+      [{ cik: 1000000, accession_number: "0001000000-25-000001" }],
+      "D",
+      "2.0.0",
+      "D"
+    );
+    expect(afterMajor).toHaveLength(1);
+  });
 });
 
 // Verifies that listFilingsWithoutSuccessfulRun's boolean-criteria query

--- a/src/storage/versioning/ExtractorRunRepo.ts
+++ b/src/storage/versioning/ExtractorRunRepo.ts
@@ -8,6 +8,7 @@ import type {
   ExtractorRun,
   ExtractorRunRepositoryStorage,
 } from "./ExtractorRunSchema";
+import { semverMajorMinorPrefix } from "./semver";
 
 export interface FilingKey {
   readonly cik: number;
@@ -93,21 +94,31 @@ export class ExtractorRunRepo {
     extractor_version: string,
     form?: string
   ): Promise<T[]> {
+    // Patch-ceremony reading-side gating (PR3 spec D7): match on major.minor
+    // prefix so a row at "1.0.0" satisfies the gate for any "1.0.x" current.
+    // A row at "1.1.0" or "2.0.0" does NOT satisfy a "1.0.x" gate.
+    const prefix = semverMajorMinorPrefix(extractor_version);
+
+    // Workglow's tabular query doesn't expose LIKE/prefix matching today, so
+    // we narrow with the available criteria (extractor_id, success, optionally
+    // form) and post-filter on extractor_version in memory. Cost is the same
+    // O(N-successful-rows) as before — see the scale-note JSDoc above.
     const successful =
       form === undefined
         ? await this.storage.query({
             extractor_id,
-            extractor_version,
             success: true,
           })
         : await this.storage.query({
             extractor_id,
-            extractor_version,
             success: true,
             form,
           });
+
     const successfulKeys = new Set(
-      (successful ?? []).map((r) => `${r.cik}::${r.accession_number}`)
+      (successful ?? [])
+        .filter((r) => r.extractor_version.startsWith(prefix))
+        .map((r) => `${r.cik}::${r.accession_number}`)
     );
     return filings.filter(
       (f) => !successfulKeys.has(`${f.cik}::${f.accession_number}`)

--- a/src/storage/versioning/ExtractorRunRepo.ts
+++ b/src/storage/versioning/ExtractorRunRepo.ts
@@ -68,6 +68,23 @@ export class ExtractorRunRepo {
   }
 
   /**
+   * Counts successful runs for a specific (extractor_id, extractor_version).
+   * Used by the major-promote coverage gate. Exact-match (not major.minor
+   * prefix) because the gate measures actual production at the new version.
+   */
+  async countSuccessfulAtVersion(
+    extractor_id: string,
+    extractor_version: string
+  ): Promise<number> {
+    const rows = await this.storage.query({
+      extractor_id,
+      extractor_version,
+      success: true,
+    });
+    return rows?.length ?? 0;
+  }
+
+  /**
    * Given a list of candidate filings, returns those WITHOUT a successful
    * run for the given (extractor_id, extractor_version). A failed run
    * still counts as "unprocessed" — it should be retried.

--- a/src/storage/versioning/ExtractorRunRepo.ts
+++ b/src/storage/versioning/ExtractorRunRepo.ts
@@ -118,8 +118,13 @@ export class ExtractorRunRepo {
 
     // Workglow's tabular query doesn't expose LIKE/prefix matching today, so
     // we narrow with the available criteria (extractor_id, success, optionally
-    // form) and post-filter on extractor_version in memory. Cost is the same
-    // O(N-successful-rows) as before — see the scale-note JSDoc above.
+    // form) and post-filter on extractor_version in memory. Note: with patch
+    // ceremony (PR3 D7), the criteria no longer constrains extractor_version,
+    // so the worst-case successful-set spans ALL versions for this extractor
+    // (1.0.0, 1.0.1, 1.1.0, 2.0.0, ...). For a long-lived extractor with many
+    // versions and many filings, this set can grow substantially. See the
+    // scale-note JSDoc above; a streaming/anti-join migration is the
+    // documented long-term fix.
     const successful =
       form === undefined
         ? await this.storage.query({

--- a/src/storage/versioning/VersionEventRepo.test.ts
+++ b/src/storage/versioning/VersionEventRepo.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { VersionEventRepo } from "./VersionEventRepo";
+import { VERSION_EVENT_REPOSITORY_TOKEN } from "./VersionEventSchema";
+
+describe("VersionEventRepo", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("recordEvent then listForComponent round-trips", async () => {
+    const repo = new VersionEventRepo(
+      globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+    );
+    await repo.recordEvent({
+      component_kind: "extractor",
+      component_id: "D",
+      event_type: "start-dev",
+      from_semver: "1.0.0",
+      to_semver: "2.0.0",
+      bump_type: "major",
+      target_count: 1234,
+      notes: "first dev cycle",
+    });
+
+    const events = await repo.listForComponent("extractor", "D");
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe("start-dev");
+    expect(events[0].from_semver).toBe("1.0.0");
+    expect(events[0].to_semver).toBe("2.0.0");
+    expect(events[0].bump_type).toBe("major");
+    expect(events[0].target_count).toBe(1234);
+    expect(events[0].notes).toBe("first dev cycle");
+    expect(events[0].at_timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("listForComponent returns events ordered newest first", async () => {
+    const repo = new VersionEventRepo(
+      globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+    );
+    await repo.recordEvent({
+      component_kind: "extractor",
+      component_id: "D",
+      event_type: "start-dev",
+      from_semver: "1.0.0",
+      to_semver: "2.0.0",
+      bump_type: "major",
+      target_count: 100,
+      notes: null,
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    await repo.recordEvent({
+      component_kind: "extractor",
+      component_id: "D",
+      event_type: "promote",
+      from_semver: "1.0.0",
+      to_semver: "2.0.0",
+      bump_type: "major",
+      target_count: null,
+      notes: null,
+    });
+
+    const events = await repo.listForComponent("extractor", "D");
+    expect(events).toHaveLength(2);
+    expect(events[0].event_type).toBe("promote");
+    expect(events[1].event_type).toBe("start-dev");
+  });
+
+  it("listForComponent filters by (kind, id)", async () => {
+    const repo = new VersionEventRepo(
+      globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+    );
+    await repo.recordEvent({
+      component_kind: "extractor",
+      component_id: "D",
+      event_type: "start-dev",
+      from_semver: "1.0.0",
+      to_semver: "2.0.0",
+      bump_type: "major",
+      target_count: 100,
+      notes: null,
+    });
+    await repo.recordEvent({
+      component_kind: "extractor",
+      component_id: "C",
+      event_type: "start-dev",
+      from_semver: "1.0.0",
+      to_semver: "2.0.0",
+      bump_type: "major",
+      target_count: 50,
+      notes: null,
+    });
+
+    const dEvents = await repo.listForComponent("extractor", "D");
+    expect(dEvents).toHaveLength(1);
+    expect(dEvents[0].component_id).toBe("D");
+  });
+
+  it("listForComponent honors the limit parameter", async () => {
+    const repo = new VersionEventRepo(
+      globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+    );
+    for (let i = 0; i < 5; i++) {
+      await repo.recordEvent({
+        component_kind: "extractor",
+        component_id: "D",
+        event_type: "drop-next",
+        from_semver: `2.0.${i}`,
+        to_semver: null,
+        bump_type: "major",
+        target_count: null,
+        notes: null,
+      });
+      await new Promise((r) => setTimeout(r, 2));
+    }
+    const limited = await repo.listForComponent("extractor", "D", 3);
+    expect(limited).toHaveLength(3);
+  });
+});

--- a/src/storage/versioning/VersionEventRepo.ts
+++ b/src/storage/versioning/VersionEventRepo.ts
@@ -18,6 +18,12 @@ import type {
  * The repo assumes single-process invocation (matches the CLI's existing
  * single-operator assumption). Two concurrent recordEvent calls could
  * theoretically race on id assignment; not a realistic concern for this CLI.
+ *
+ * Note: ids are assigned via storage.size() + 1. This is correct for an
+ * append-only log but breaks if any consumer ever deletes rows from this
+ * table (a delete-then-insert sequence will reuse the deleted id). PR3
+ * never deletes events; future code that wants to garbage-collect old
+ * audit rows MUST migrate to a stable id source (e.g. UUIDs) first.
  */
 export class VersionEventRepo {
   constructor(private readonly storage: VersionEventRepositoryStorage) {}

--- a/src/storage/versioning/VersionEventRepo.ts
+++ b/src/storage/versioning/VersionEventRepo.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ComponentKind } from "./ComponentVersionSchema";
+import type {
+  VersionEvent,
+  VersionEventRepositoryStorage,
+} from "./VersionEventSchema";
+
+/**
+ * Append-only ceremony audit log. One row per start-dev / promote / rollback /
+ * drop-next invocation. `id` is auto-assigned by the repo on insert; callers
+ * never set it. `at_timestamp` is auto-assigned to now-ISO.
+ *
+ * The repo assumes single-process invocation (matches the CLI's existing
+ * single-operator assumption). Two concurrent recordEvent calls could
+ * theoretically race on id assignment; not a realistic concern for this CLI.
+ */
+export class VersionEventRepo {
+  constructor(private readonly storage: VersionEventRepositoryStorage) {}
+
+  async recordEvent(
+    event: Omit<VersionEvent, "id" | "at_timestamp">
+  ): Promise<void> {
+    const size = (await this.storage.size()) ?? 0;
+    await this.storage.put({
+      ...event,
+      id: size + 1,
+      at_timestamp: new Date().toISOString(),
+    } as VersionEvent);
+  }
+
+  async listForComponent(
+    kind: ComponentKind,
+    id: string,
+    limit: number = 20
+  ): Promise<VersionEvent[]> {
+    const rows =
+      (await this.storage.query({
+        component_kind: kind,
+        component_id: id,
+      })) ?? [];
+    // Newest first by at_timestamp; tie-break by id descending so within-second
+    // ordering is deterministic.
+    rows.sort((a, b) => {
+      if (a.at_timestamp !== b.at_timestamp) {
+        return a.at_timestamp < b.at_timestamp ? 1 : -1;
+      }
+      return b.id - a.id;
+    });
+    return rows.slice(0, limit);
+  }
+}

--- a/src/storage/versioning/VersionEventSchema.ts
+++ b/src/storage/versioning/VersionEventSchema.ts
@@ -18,7 +18,8 @@ export type VersionEventType = (typeof VERSION_EVENT_TYPES)[number];
 
 export const VersionEventSchema = Type.Object({
   id: Type.Integer({
-    description: "Auto-incrementing primary key",
+    description:
+      "Sequential primary key, assigned by VersionEventRepo on insert via storage.size() + 1. The table is append-only by design; see VersionEventRepo JSDoc for the no-delete invariant.",
   }),
   component_kind: Type.Union(
     [Type.Literal("extractor"), Type.Literal("resolver")],

--- a/src/storage/versioning/VersionEventSchema.ts
+++ b/src/storage/versioning/VersionEventSchema.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+
+export const VERSION_EVENT_TYPES = [
+  "start-dev",
+  "promote",
+  "rollback",
+  "drop-next",
+] as const;
+export type VersionEventType = (typeof VERSION_EVENT_TYPES)[number];
+
+export const VersionEventSchema = Type.Object({
+  id: Type.Integer({
+    description: "Auto-incrementing primary key",
+  }),
+  component_kind: Type.Union(
+    [Type.Literal("extractor"), Type.Literal("resolver")],
+    { description: "Which subsystem this event belongs to" }
+  ),
+  component_id: Type.String({
+    maxLength: 64,
+    description: "Form symbol or domain name",
+  }),
+  event_type: Type.Union(
+    [
+      Type.Literal("start-dev"),
+      Type.Literal("promote"),
+      Type.Literal("rollback"),
+      Type.Literal("drop-next"),
+    ],
+    { description: "Ceremony that produced this event" }
+  ),
+  from_semver: Type.Union([Type.String({ maxLength: 32 }), Type.Null()], {
+    description: "Semver of the prior state (depends on event_type)",
+  }),
+  to_semver: Type.Union([Type.String({ maxLength: 32 }), Type.Null()], {
+    description: "Semver of the resulting state (depends on event_type)",
+  }),
+  bump_type: Type.Union(
+    [
+      Type.Literal("major"),
+      Type.Literal("minor"),
+      Type.Literal("patch"),
+      Type.Null(),
+    ],
+    { description: "Bump type associated with the event" }
+  ),
+  target_count: Type.Union([Type.Integer({ minimum: 0 }), Type.Null()], {
+    description: "Snapshot count captured on major start-dev events; null otherwise",
+  }),
+  at_timestamp: Type.String({
+    description: "ISO 8601 timestamp",
+  }),
+  notes: Type.Union([Type.String({ maxLength: 4096 }), Type.Null()], {
+    description: "Operator-supplied --notes annotation, if any",
+  }),
+});
+
+export type VersionEvent = Static<typeof VersionEventSchema>;
+
+export const VersionEventPrimaryKeyNames = ["id"] as const;
+
+export type VersionEventRepositoryStorage = ITabularStorage<
+  typeof VersionEventSchema,
+  typeof VersionEventPrimaryKeyNames,
+  VersionEvent
+>;
+
+export const VERSION_EVENT_REPOSITORY_TOKEN =
+  createServiceToken<VersionEventRepositoryStorage>(
+    "sec.storage.versionEventRepository"
+  );

--- a/src/storage/versioning/VersionRegistry.test.ts
+++ b/src/storage/versioning/VersionRegistry.test.ts
@@ -57,6 +57,7 @@ describe("VersionRegistry", () => {
       bump_type: null,
       started_at: "2026-05-21T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
     const cur = await reg.getCurrent("extractor", "D");
     expect(cur?.semver).toBe("1.0.0");
@@ -77,6 +78,7 @@ describe("VersionRegistry", () => {
       bump_type: null,
       started_at: "2026-05-20T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
     await reg.putSlot({
       component_kind: "extractor",
@@ -86,6 +88,7 @@ describe("VersionRegistry", () => {
       bump_type: "major",
       started_at: "2026-05-21T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
     await reg.putSlot({
       component_kind: "extractor",
@@ -95,6 +98,7 @@ describe("VersionRegistry", () => {
       bump_type: "minor",
       started_at: "2026-05-21T01:00:00Z",
       coverage_complete: false,
+      target_count: null,
     });
 
     expect((await reg.getPrevious("extractor", "D"))?.semver).toBe("1.0.0");
@@ -114,6 +118,7 @@ describe("VersionRegistry", () => {
       bump_type: null,
       started_at: "2026-05-21T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
     await reg.putSlot({
       component_kind: "extractor",
@@ -123,6 +128,7 @@ describe("VersionRegistry", () => {
       bump_type: "minor",
       started_at: "2026-05-21T01:00:00Z",
       coverage_complete: false,
+      target_count: null,
     });
 
     await reg.clearSlot("extractor", "D", "next");
@@ -143,6 +149,7 @@ describe("VersionRegistry", () => {
       bump_type: null,
       started_at: "2026-05-21T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
     await reg.putSlot({
       component_kind: "resolver",
@@ -152,6 +159,7 @@ describe("VersionRegistry", () => {
       bump_type: null,
       started_at: "2026-05-21T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
 
     const all = await reg.listAll();
@@ -175,6 +183,7 @@ describe("VersionRegistry", () => {
       bump_type: null,
       started_at: "2026-05-21T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
     await reg.putSlot({
       component_kind: "resolver",
@@ -184,6 +193,7 @@ describe("VersionRegistry", () => {
       bump_type: null,
       started_at: "2026-05-21T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
 
     const extractors = await reg.listByKind("extractor");
@@ -207,6 +217,7 @@ describe("VersionRegistry", () => {
         bump_type: null,
         started_at: "2026-05-21T00:00:00Z",
         coverage_complete: true,
+        target_count: null,
       })
     ).rejects.toThrow(/invalid semver/);
   });
@@ -224,6 +235,7 @@ describe("VersionRegistry", () => {
         bump_type: null,
         started_at: "2026-05-21T00:00:00Z",
         coverage_complete: false,
+        target_count: null,
       })
     ).rejects.toThrow(/coverage_complete must be true/);
   });
@@ -240,6 +252,7 @@ describe("VersionRegistry", () => {
       bump_type: "minor",
       started_at: "2026-05-21T01:00:00Z",
       coverage_complete: false,
+      target_count: null,
     });
     expect((await reg.getNext("extractor", "D"))?.coverage_complete).toBe(false);
   });
@@ -256,6 +269,7 @@ describe("VersionRegistry", () => {
       bump_type: null,
       started_at: "2026-05-21T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
     await reg.putSlot({
       component_kind: "extractor",
@@ -265,6 +279,7 @@ describe("VersionRegistry", () => {
       bump_type: "patch",
       started_at: "2026-05-21T02:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
     const row = await reg.getCurrent("extractor", "D");
     expect(row?.semver).toBe("1.0.1");

--- a/src/storage/versioning/VersionRegistry.ts
+++ b/src/storage/versioning/VersionRegistry.ts
@@ -66,6 +66,15 @@ export class VersionRegistry {
         `VersionRegistry: target_count is only meaningful for bump_type='major' (got ${row.target_count} with bump_type=${row.bump_type})`
       );
     }
+    if (
+      row.slot === "next" &&
+      row.bump_type === "major" &&
+      row.target_count === null
+    ) {
+      throw new Error(
+        `VersionRegistry: major bump in next slot requires non-null target_count (got null on ${row.component_kind}:${row.component_id})`
+      );
+    }
     await this.storage.put(row);
   }
 

--- a/src/storage/versioning/VersionRegistry.ts
+++ b/src/storage/versioning/VersionRegistry.ts
@@ -56,6 +56,16 @@ export class VersionRegistry {
         `VersionRegistry: coverage_complete must be true for ${row.slot} slot (got false on ${row.component_kind}:${row.component_id})`
       );
     }
+    if (row.target_count !== null && row.slot !== "next") {
+      throw new Error(
+        `VersionRegistry: target_count must be null for ${row.slot} slot (got ${row.target_count} on ${row.component_kind}:${row.component_id})`
+      );
+    }
+    if (row.target_count !== null && row.bump_type !== "major") {
+      throw new Error(
+        `VersionRegistry: target_count is only meaningful for bump_type='major' (got ${row.target_count} with bump_type=${row.bump_type})`
+      );
+    }
     await this.storage.put(row);
   }
 

--- a/src/storage/versioning/bootstrapExtractorVersions.test.ts
+++ b/src/storage/versioning/bootstrapExtractorVersions.test.ts
@@ -62,6 +62,7 @@ describe("bootstrapExtractorVersions", () => {
       bump_type: null,
       started_at: "2026-05-22T00:00:00Z",
       coverage_complete: true,
+      target_count: null,
     });
 
     await bootstrapExtractorVersions();

--- a/src/storage/versioning/bootstrapExtractorVersions.ts
+++ b/src/storage/versioning/bootstrapExtractorVersions.ts
@@ -34,6 +34,7 @@ export async function bootstrapExtractorVersions(): Promise<void> {
       bump_type: null,
       started_at: startedAt,
       coverage_complete: true,
+      target_count: null,
     });
   }
 }

--- a/src/storage/versioning/ceremonies.test.ts
+++ b/src/storage/versioning/ceremonies.test.ts
@@ -195,6 +195,41 @@ describe("ceremonies.startDev", () => {
       })
     ).rejects.toThrow(/no extractor registered/i);
   });
+
+  it("dry-run validates inputs but does not write", async () => {
+    const { reg, events } = buildDeps();
+
+    // Invalid bump progression should still throw even with dryRun.
+    await expect(
+      startDev({
+        reg,
+        events,
+        kind: "extractor",
+        id: "D",
+        semver: "2.1.0", // major bump can't reset to .1
+        bump: "major",
+        targetCount: 0,
+        notes: null,
+        dryRun: true,
+      })
+    ).rejects.toThrow(/reset minor/i);
+
+    // Valid input with dryRun=true should NOT write the next slot or log.
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 0,
+      notes: "dry run",
+      dryRun: true,
+    });
+    expect(await reg.getNext("extractor", "D")).toBeUndefined();
+    const evts = await events.listForComponent("extractor", "D");
+    expect(evts).toHaveLength(0);
+  });
 });
 
 describe("ceremonies.promote", () => {
@@ -328,6 +363,39 @@ describe("ceremonies.promote", () => {
       notes: null,
     });
     expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("1.1.0");
+  });
+
+  it("after promote, getActiveSlot returns the new current (not the next that was promoted)", async () => {
+    const { reg, events, runs } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 0,
+      notes: null,
+    });
+
+    // Before promote: getActiveSlot should return next.
+    const { getActiveSlot } = await import("./getActiveSlot");
+    const beforePromote = await getActiveSlot(reg, "extractor", "D");
+    expect(beforePromote).toEqual({ slot: "next", semver: "2.0.0" });
+
+    await promote({
+      reg,
+      events,
+      runs,
+      kind: "extractor",
+      id: "D",
+      force: true,
+      notes: null,
+    });
+
+    // After promote: next is empty, so getActiveSlot returns current at 2.0.0.
+    const afterPromote = await getActiveSlot(reg, "extractor", "D");
+    expect(afterPromote).toEqual({ slot: "current", semver: "2.0.0" });
   });
 });
 

--- a/src/storage/versioning/ceremonies.test.ts
+++ b/src/storage/versioning/ceremonies.test.ts
@@ -135,6 +135,34 @@ describe("ceremonies.startDev", () => {
     ).rejects.toThrow(/next slot already exists.*drop-next/i);
   });
 
+  it("rejects patch start-dev when next slot already exists", async () => {
+    const { reg, events } = buildDeps();
+    // Start a major dev cycle in flight.
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 42,
+      notes: null,
+    });
+    // Now try a patch — should be rejected.
+    await expect(
+      startDev({
+        reg,
+        events,
+        kind: "extractor",
+        id: "D",
+        semver: "1.0.1",
+        bump: "patch",
+        targetCount: null,
+        notes: null,
+      })
+    ).rejects.toThrow(/next slot already exists.*drop-next/i);
+  });
+
   it("rejects start-dev with invalid bump progression", async () => {
     const { reg, events } = buildDeps();
     // current is 1.0.0; major bump must go to 2.0.0, not 2.1.0

--- a/src/storage/versioning/ceremonies.test.ts
+++ b/src/storage/versioning/ceremonies.test.ts
@@ -365,6 +365,56 @@ describe("ceremonies.promote", () => {
     expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("1.1.0");
   });
 
+  it("dry-run validates but writes nothing", async () => {
+    const { reg, events, runs } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 0,
+      notes: null,
+    });
+    const beforeEvents = await events.listForComponent("extractor", "D");
+
+    await promote({
+      reg,
+      events,
+      runs,
+      kind: "extractor",
+      id: "D",
+      force: true,
+      notes: null,
+      dryRun: true,
+    });
+
+    // No slot rotation.
+    expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("1.0.0");
+    expect((await reg.getNext("extractor", "D"))?.semver).toBe("2.0.0");
+    expect(await reg.getPrevious("extractor", "D")).toBeUndefined();
+    // No new event logged.
+    const afterEvents = await events.listForComponent("extractor", "D");
+    expect(afterEvents).toHaveLength(beforeEvents.length);
+  });
+
+  it("dry-run promote still throws on missing next slot", async () => {
+    const { reg, events, runs } = buildDeps();
+    await expect(
+      promote({
+        reg,
+        events,
+        runs,
+        kind: "extractor",
+        id: "D",
+        force: false,
+        notes: null,
+        dryRun: true,
+      })
+    ).rejects.toThrow(/no next slot/i);
+  });
+
   it("after promote, getActiveSlot returns the new current (not the next that was promoted)", async () => {
     const { reg, events, runs } = buildDeps();
     await startDev({
@@ -453,6 +503,47 @@ describe("ceremonies.rollback", () => {
       })
     ).rejects.toThrow(/no previous slot/i);
   });
+
+  it("dry-run validates but writes nothing", async () => {
+    const { reg, events, runs } = buildDeps();
+    // Set up: start-dev → promote → so previous=1.0.0, current=2.0.0.
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 0,
+      notes: null,
+    });
+    await promote({
+      reg,
+      events,
+      runs,
+      kind: "extractor",
+      id: "D",
+      force: true,
+      notes: null,
+    });
+    const beforeEvents = await events.listForComponent("extractor", "D");
+
+    await rollback({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      notes: null,
+      dryRun: true,
+    });
+
+    // Slots unchanged.
+    expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("2.0.0");
+    expect((await reg.getPrevious("extractor", "D"))?.semver).toBe("1.0.0");
+    // No new event.
+    const afterEvents = await events.listForComponent("extractor", "D");
+    expect(afterEvents).toHaveLength(beforeEvents.length);
+  });
 });
 
 describe("ceremonies.dropNext", () => {
@@ -501,5 +592,35 @@ describe("ceremonies.dropNext", () => {
         notes: null,
       })
     ).rejects.toThrow(/no next slot/i);
+  });
+
+  it("dry-run validates but writes nothing", async () => {
+    const { reg, events } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 0,
+      notes: null,
+    });
+    const beforeEvents = await events.listForComponent("extractor", "D");
+
+    await dropNext({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      notes: null,
+      dryRun: true,
+    });
+
+    // Next slot unchanged.
+    expect((await reg.getNext("extractor", "D"))?.semver).toBe("2.0.0");
+    // No new event.
+    const afterEvents = await events.listForComponent("extractor", "D");
+    expect(afterEvents).toHaveLength(beforeEvents.length);
   });
 });

--- a/src/storage/versioning/ceremonies.test.ts
+++ b/src/storage/versioning/ceremonies.test.ts
@@ -1,0 +1,409 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { dropNext, promote, rollback, startDev } from "./ceremonies";
+import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "./ComponentVersionSchema";
+import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "./ExtractorRunSchema";
+import { ExtractorRunRepo } from "./ExtractorRunRepo";
+import { VersionEventRepo } from "./VersionEventRepo";
+import { VERSION_EVENT_REPOSITORY_TOKEN } from "./VersionEventSchema";
+import { VersionRegistry } from "./VersionRegistry";
+
+function buildDeps() {
+  const reg = new VersionRegistry(
+    globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+  );
+  const events = new VersionEventRepo(
+    globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN)
+  );
+  const runs = new ExtractorRunRepo(
+    globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN)
+  );
+  return { reg, events, runs };
+}
+
+describe("ceremonies.startDev", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("major bump populates next slot and captures target_count", async () => {
+    const { reg, events } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 42,
+      notes: "first major dev cycle",
+    });
+    const next = await reg.getNext("extractor", "D");
+    expect(next?.semver).toBe("2.0.0");
+    expect(next?.bump_type).toBe("major");
+    expect(next?.target_count).toBe(42);
+    expect(next?.coverage_complete).toBe(false);
+
+    const evts = await events.listForComponent("extractor", "D");
+    expect(evts).toHaveLength(1);
+    expect(evts[0].event_type).toBe("start-dev");
+    expect(evts[0].from_semver).toBe("1.0.0");
+    expect(evts[0].to_semver).toBe("2.0.0");
+    expect(evts[0].bump_type).toBe("major");
+    expect(evts[0].target_count).toBe(42);
+    expect(evts[0].notes).toBe("first major dev cycle");
+  });
+
+  it("minor bump populates next slot with null target_count", async () => {
+    const { reg, events } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "1.1.0",
+      bump: "minor",
+      targetCount: null,
+      notes: null,
+    });
+    const next = await reg.getNext("extractor", "D");
+    expect(next?.semver).toBe("1.1.0");
+    expect(next?.bump_type).toBe("minor");
+    expect(next?.target_count).toBeNull();
+  });
+
+  it("patch bump updates current in place; no next slot created", async () => {
+    const { reg, events } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "1.0.1",
+      bump: "patch",
+      targetCount: null,
+      notes: null,
+    });
+    const current = await reg.getCurrent("extractor", "D");
+    expect(current?.semver).toBe("1.0.1");
+    const next = await reg.getNext("extractor", "D");
+    expect(next).toBeUndefined();
+
+    const evts = await events.listForComponent("extractor", "D");
+    expect(evts).toHaveLength(1);
+    expect(evts[0].event_type).toBe("promote");
+    expect(evts[0].bump_type).toBe("patch");
+    expect(evts[0].from_semver).toBe("1.0.0");
+    expect(evts[0].to_semver).toBe("1.0.1");
+  });
+
+  it("rejects start-dev when next already exists", async () => {
+    const { reg, events } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 42,
+      notes: null,
+    });
+    await expect(
+      startDev({
+        reg,
+        events,
+        kind: "extractor",
+        id: "D",
+        semver: "3.0.0",
+        bump: "major",
+        targetCount: 50,
+        notes: null,
+      })
+    ).rejects.toThrow(/next slot already exists.*drop-next/i);
+  });
+
+  it("rejects start-dev with invalid bump progression", async () => {
+    const { reg, events } = buildDeps();
+    // current is 1.0.0; major bump must go to 2.0.0, not 2.1.0
+    await expect(
+      startDev({
+        reg,
+        events,
+        kind: "extractor",
+        id: "D",
+        semver: "2.1.0",
+        bump: "major",
+        targetCount: 42,
+        notes: null,
+      })
+    ).rejects.toThrow(/reset minor/i);
+  });
+
+  it("rejects start-dev for unregistered component", async () => {
+    const { reg, events } = buildDeps();
+    await expect(
+      startDev({
+        reg,
+        events,
+        kind: "extractor",
+        id: "no-such-form",
+        semver: "1.0.0",
+        bump: "major",
+        targetCount: 0,
+        notes: null,
+      })
+    ).rejects.toThrow(/no extractor registered/i);
+  });
+});
+
+describe("ceremonies.promote", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("rotates slots: current → previous, next → current", async () => {
+    const { reg, events, runs } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 1, // one filing to satisfy the gate
+      notes: null,
+    });
+    // Seed one successful run at 2.0.0 to satisfy the major gate.
+    await runs.recordRun({
+      cik: 1234567,
+      accession_number: "0001234567-25-000001",
+      form: "D",
+      extractor_id: "D",
+      extractor_version: "2.0.0",
+      slot_at_run: "next",
+      success: true,
+      error: null,
+    });
+
+    await promote({
+      reg,
+      events,
+      runs,
+      kind: "extractor",
+      id: "D",
+      force: false,
+      notes: null,
+    });
+
+    expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("2.0.0");
+    expect((await reg.getPrevious("extractor", "D"))?.semver).toBe("1.0.0");
+    expect(await reg.getNext("extractor", "D")).toBeUndefined();
+  });
+
+  it("major-promote with insufficient coverage rejects without --force", async () => {
+    const { reg, events, runs } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 100,
+      notes: null,
+    });
+    // Only 1 successful run vs target_count of 100.
+    await runs.recordRun({
+      cik: 1234567,
+      accession_number: "0001234567-25-000001",
+      form: "D",
+      extractor_id: "D",
+      extractor_version: "2.0.0",
+      slot_at_run: "next",
+      success: true,
+      error: null,
+    });
+
+    await expect(
+      promote({
+        reg,
+        events,
+        runs,
+        kind: "extractor",
+        id: "D",
+        force: false,
+        notes: null,
+      })
+    ).rejects.toThrow(/coverage.*1\/100/i);
+  });
+
+  it("major-promote with --force overrides coverage gate", async () => {
+    const { reg, events, runs } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 100,
+      notes: null,
+    });
+    await promote({
+      reg,
+      events,
+      runs,
+      kind: "extractor",
+      id: "D",
+      force: true,
+      notes: "force-promoting with 0/100 for testing",
+    });
+    expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("2.0.0");
+  });
+
+  it("minor-promote has no coverage gate", async () => {
+    const { reg, events, runs } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "1.1.0",
+      bump: "minor",
+      targetCount: null,
+      notes: null,
+    });
+    await promote({
+      reg,
+      events,
+      runs,
+      kind: "extractor",
+      id: "D",
+      force: false,
+      notes: null,
+    });
+    expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("1.1.0");
+  });
+});
+
+describe("ceremonies.rollback", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("swaps current and previous slots", async () => {
+    const { reg, events, runs } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 0,
+      notes: null,
+    });
+    await promote({
+      reg,
+      events,
+      runs,
+      kind: "extractor",
+      id: "D",
+      force: true,
+      notes: null,
+    });
+    // Now current=2.0.0, previous=1.0.0. Roll back.
+    await rollback({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      notes: null,
+    });
+    expect((await reg.getCurrent("extractor", "D"))?.semver).toBe("1.0.0");
+    expect((await reg.getPrevious("extractor", "D"))?.semver).toBe("2.0.0");
+  });
+
+  it("rejects rollback when no previous slot exists", async () => {
+    const { reg, events } = buildDeps();
+    await expect(
+      rollback({
+        reg,
+        events,
+        kind: "extractor",
+        id: "D",
+        notes: null,
+      })
+    ).rejects.toThrow(/no previous slot/i);
+  });
+});
+
+describe("ceremonies.dropNext", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("clears the next slot", async () => {
+    const { reg, events } = buildDeps();
+    await startDev({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      semver: "2.0.0",
+      bump: "major",
+      targetCount: 0,
+      notes: null,
+    });
+    await dropNext({
+      reg,
+      events,
+      kind: "extractor",
+      id: "D",
+      notes: "abandoned",
+    });
+    expect(await reg.getNext("extractor", "D")).toBeUndefined();
+
+    const evts = await events.listForComponent("extractor", "D");
+    expect(evts[0].event_type).toBe("drop-next");
+    expect(evts[0].notes).toBe("abandoned");
+  });
+
+  it("rejects drop-next when no next slot exists", async () => {
+    const { reg, events } = buildDeps();
+    await expect(
+      dropNext({
+        reg,
+        events,
+        kind: "extractor",
+        id: "D",
+        notes: null,
+      })
+    ).rejects.toThrow(/no next slot/i);
+  });
+});

--- a/src/storage/versioning/ceremonies.ts
+++ b/src/storage/versioning/ceremonies.ts
@@ -50,6 +50,14 @@ function assertRegistered(kind: ComponentKind, id: string): void {
   }
 }
 
+/**
+ * Begin (or, for patch bumps, complete) a version cycle. Major and minor
+ * bumps populate the `next` slot; patch bumps update `current` in place
+ * and log a `promote` event directly (degenerate per spec D10). Validates
+ * bump progression, registration, existing-next-conflict, and (for major)
+ * non-negative target_count. Throws on any violation. When `dryRun: true`
+ * all validations run but no writes happen.
+ */
 export async function startDev(args: StartDevArgs): Promise<void> {
   const { reg, events, kind, id, semver, bump, targetCount, notes } = args;
   assertRegistered(kind, id);
@@ -130,6 +138,13 @@ export async function startDev(args: StartDevArgs): Promise<void> {
   });
 }
 
+/**
+ * Rotate the slots: previous := current, current := next, next is cleared.
+ * For major bumps, requires count of successful runs at next.semver to
+ * meet target_count unless `force: true`. Logs a `promote` event.
+ * When `dryRun: true`, validations and the coverage check run but no
+ * writes happen.
+ */
 export async function promote(args: PromoteArgs): Promise<void> {
   const { reg, events, runs, kind, id, force, notes } = args;
   assertRegistered(kind, id);
@@ -191,6 +206,12 @@ export async function promote(args: PromoteArgs): Promise<void> {
   });
 }
 
+/**
+ * Swap previous and current. Used to undo a recent promote when the new
+ * version turns out to be broken. Does not touch the next slot if one
+ * exists. Logs a `rollback` event. When `dryRun: true`, validations
+ * run but no slot writes happen.
+ */
 export async function rollback(args: RollbackArgs): Promise<void> {
   const { reg, events, kind, id, notes } = args;
   assertRegistered(kind, id);
@@ -230,6 +251,28 @@ export async function rollback(args: RollbackArgs): Promise<void> {
   });
 }
 
+/**
+ * Discards an in-flight dev cycle by clearing the next slot. The matching
+ * extractor_runs rows (`slot_at_run='next', extractor_version=<dropped>`)
+ * are NOT deleted — they remain for audit purposes and to satisfy the
+ * patch-gating reading-side rule (D7), which treats a row at "2.0.0" as
+ * good for any "2.0.x" gate going forward. Logs a `drop-next` event.
+ * When `dryRun: true`, validations run but no writes happen.
+ *
+ * Caveat for operators: if you drop-next a cycle and immediately re-run
+ * start-dev at the SAME semver, the major coverage gate will see the old
+ * cycle's successful runs as still counting (because countSuccessfulAtVersion
+ * is exact-match on the version string). To avoid this surprise:
+ *   - After abandonment of a buggy parser, bump to a new semver for the
+ *     retry (e.g. 2.0.0 → 2.0.1 if the parser change is patch-compatible,
+ *     or 2.1.0 / 3.0.0 if the parser logic differs meaningfully).
+ *   - OR manually clear extractor_runs for the abandoned version before
+ *     re-running (currently requires raw SQL; a `sec version reset-runs`
+ *     command would be a useful follow-up).
+ *
+ * Documented operator discipline matches spec D8 (single-operator
+ * assumption) and is acceptable for v1.
+ */
 export async function dropNext(args: DropNextArgs): Promise<void> {
   const { reg, events, kind, id, notes } = args;
   assertRegistered(kind, id);

--- a/src/storage/versioning/ceremonies.ts
+++ b/src/storage/versioning/ceremonies.ts
@@ -142,7 +142,12 @@ export async function promote(args: PromoteArgs): Promise<void> {
 
   // Major coverage gate.
   if (next.bump_type === "major" && !force) {
-    const target = next.target_count ?? 0;
+    if (next.target_count === null) {
+      throw new Error(
+        `${kind} '${id}' next slot has bump_type='major' but target_count is null — invalid state. Drop-next and re-run start-dev.`
+      );
+    }
+    const target = next.target_count;
     const successful = await runs.countSuccessfulAtVersion(id, next.semver);
     if (successful < target) {
       throw new Error(

--- a/src/storage/versioning/ceremonies.ts
+++ b/src/storage/versioning/ceremonies.ts
@@ -24,20 +24,24 @@ export interface StartDevArgs extends BaseArgs {
   /** Required for major bumps (the snapshot count); null for minor/patch. */
   readonly targetCount: number | null;
   readonly notes: string | null;
+  readonly dryRun?: boolean;
 }
 
 export interface PromoteArgs extends BaseArgs {
   readonly runs: ExtractorRunRepo;
   readonly force: boolean;
   readonly notes: string | null;
+  readonly dryRun?: boolean;
 }
 
 export interface RollbackArgs extends BaseArgs {
   readonly notes: string | null;
+  readonly dryRun?: boolean;
 }
 
 export interface DropNextArgs extends BaseArgs {
   readonly notes: string | null;
+  readonly dryRun?: boolean;
 }
 
 function assertRegistered(kind: ComponentKind, id: string): void {
@@ -70,6 +74,7 @@ export async function startDev(args: StartDevArgs): Promise<void> {
   if (progressionError) throw new Error(progressionError);
 
   if (bump === "patch") {
+    if (args.dryRun) return;
     // No next slot. Update current in place; log a single "promote" event.
     const fromSemver = current.semver;
     const startedAt = new Date().toISOString();
@@ -99,6 +104,8 @@ export async function startDev(args: StartDevArgs): Promise<void> {
       `major bump requires non-negative targetCount (got ${targetCount})`
     );
   }
+
+  if (args.dryRun) return;
 
   await reg.putSlot({
     component_kind: kind,
@@ -143,6 +150,8 @@ export async function promote(args: PromoteArgs): Promise<void> {
       );
     }
   }
+
+  if (args.dryRun) return;
 
   // Slot rotation (non-atomic by design — workglow's storage doesn't expose
   // transactions; the spec's single-operator assumption makes this safe).
@@ -190,6 +199,8 @@ export async function rollback(args: RollbackArgs): Promise<void> {
   const current = await reg.getCurrent(kind, id);
   if (!current) throw new Error(`No current slot for ${kind} '${id}'.`);
 
+  if (args.dryRun) return;
+
   // Swap by clearing both and re-writing with swapped slot values.
   await reg.clearSlot(kind, id, "previous");
   await reg.clearSlot(kind, id, "current");
@@ -220,6 +231,8 @@ export async function dropNext(args: DropNextArgs): Promise<void> {
 
   const next = await reg.getNext(kind, id);
   if (!next) throw new Error(`No next slot for ${kind} '${id}'. Nothing to drop.`);
+
+  if (args.dryRun) return;
 
   await reg.clearSlot(kind, id, "next");
 

--- a/src/storage/versioning/ceremonies.ts
+++ b/src/storage/versioning/ceremonies.ts
@@ -57,17 +57,13 @@ export async function startDev(args: StartDevArgs): Promise<void> {
     );
   }
 
-  // For major/minor bumps, reject if a next slot already exists BEFORE
-  // validating progression. (The progression check uses current.semver as
-  // the base; if next exists, the user has likely already moved on and the
-  // caller should drop-next first regardless of the proposed semver.)
-  if (bump !== "patch") {
-    const existingNext = await reg.getNext(kind, id);
-    if (existingNext) {
-      throw new Error(
-        `next slot already exists for ${kind} '${id}' (at ${existingNext.semver}). drop-next first.`
-      );
-    }
+  // Reject any new dev cycle (including patches) while one is in flight.
+  // Operators must drop-next or complete the existing cycle first.
+  const existingNext = await reg.getNext(kind, id);
+  if (existingNext) {
+    throw new Error(
+      `next slot already exists for ${kind} '${id}' (at ${existingNext.semver}). drop-next first.`
+    );
   }
 
   const progressionError = validateBumpProgression(current.semver, semver, bump);
@@ -97,14 +93,7 @@ export async function startDev(args: StartDevArgs): Promise<void> {
     return;
   }
 
-  // Major or minor: populate next slot.
-  const existingNext = await reg.getNext(kind, id);
-  if (existingNext) {
-    throw new Error(
-      `next slot already exists for ${kind} '${id}' (at ${existingNext.semver}). drop-next first.`
-    );
-  }
-
+  // Major-only: validate target_count.
   if (bump === "major" && (targetCount === null || targetCount < 0)) {
     throw new Error(
       `major bump requires non-negative targetCount (got ${targetCount})`
@@ -155,10 +144,10 @@ export async function promote(args: PromoteArgs): Promise<void> {
     }
   }
 
-  // Slot rotation:
-  // 1. Drop existing previous (if any).
-  // 2. Clear current's key, then rewrite into previous slot.
-  // 3. Clear next's key, then rewrite into current slot.
+  // Slot rotation (non-atomic by design — workglow's storage doesn't expose
+  // transactions; the spec's single-operator assumption makes this safe).
+  // Sequence: drop existing previous -> clear current -> write current as previous
+  // -> clear next -> write next as current.
   const previous = await reg.getPrevious(kind, id);
   if (previous) {
     await reg.clearSlot(kind, id, "previous");

--- a/src/storage/versioning/ceremonies.ts
+++ b/src/storage/versioning/ceremonies.ts
@@ -1,0 +1,247 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BumpType, ComponentKind } from "./ComponentVersionSchema";
+import { isRegisteredComponent } from "./componentRegistry";
+import type { ExtractorRunRepo } from "./ExtractorRunRepo";
+import { validateBumpProgression } from "./semver";
+import type { VersionEventRepo } from "./VersionEventRepo";
+import type { VersionRegistry } from "./VersionRegistry";
+
+interface BaseArgs {
+  readonly reg: VersionRegistry;
+  readonly events: VersionEventRepo;
+  readonly kind: ComponentKind;
+  readonly id: string;
+}
+
+export interface StartDevArgs extends BaseArgs {
+  readonly semver: string;
+  readonly bump: BumpType;
+  /** Required for major bumps (the snapshot count); null for minor/patch. */
+  readonly targetCount: number | null;
+  readonly notes: string | null;
+}
+
+export interface PromoteArgs extends BaseArgs {
+  readonly runs: ExtractorRunRepo;
+  readonly force: boolean;
+  readonly notes: string | null;
+}
+
+export interface RollbackArgs extends BaseArgs {
+  readonly notes: string | null;
+}
+
+export interface DropNextArgs extends BaseArgs {
+  readonly notes: string | null;
+}
+
+function assertRegistered(kind: ComponentKind, id: string): void {
+  if (!isRegisteredComponent(kind, id)) {
+    throw new Error(`No ${kind} registered: '${id}'`);
+  }
+}
+
+export async function startDev(args: StartDevArgs): Promise<void> {
+  const { reg, events, kind, id, semver, bump, targetCount, notes } = args;
+  assertRegistered(kind, id);
+
+  const current = await reg.getCurrent(kind, id);
+  if (!current) {
+    throw new Error(
+      `No current slot for ${kind} '${id}'. Run 'sec db setup' to bootstrap.`
+    );
+  }
+
+  // For major/minor bumps, reject if a next slot already exists BEFORE
+  // validating progression. (The progression check uses current.semver as
+  // the base; if next exists, the user has likely already moved on and the
+  // caller should drop-next first regardless of the proposed semver.)
+  if (bump !== "patch") {
+    const existingNext = await reg.getNext(kind, id);
+    if (existingNext) {
+      throw new Error(
+        `next slot already exists for ${kind} '${id}' (at ${existingNext.semver}). drop-next first.`
+      );
+    }
+  }
+
+  const progressionError = validateBumpProgression(current.semver, semver, bump);
+  if (progressionError) throw new Error(progressionError);
+
+  if (bump === "patch") {
+    // No next slot. Update current in place; log a single "promote" event.
+    const fromSemver = current.semver;
+    const startedAt = new Date().toISOString();
+    await reg.putSlot({
+      ...current,
+      semver,
+      started_at: startedAt,
+      bump_type: "patch",
+      target_count: null,
+    });
+    await events.recordEvent({
+      component_kind: kind,
+      component_id: id,
+      event_type: "promote",
+      from_semver: fromSemver,
+      to_semver: semver,
+      bump_type: "patch",
+      target_count: null,
+      notes,
+    });
+    return;
+  }
+
+  // Major or minor: populate next slot.
+  const existingNext = await reg.getNext(kind, id);
+  if (existingNext) {
+    throw new Error(
+      `next slot already exists for ${kind} '${id}' (at ${existingNext.semver}). drop-next first.`
+    );
+  }
+
+  if (bump === "major" && (targetCount === null || targetCount < 0)) {
+    throw new Error(
+      `major bump requires non-negative targetCount (got ${targetCount})`
+    );
+  }
+
+  await reg.putSlot({
+    component_kind: kind,
+    component_id: id,
+    slot: "next",
+    semver,
+    bump_type: bump,
+    started_at: new Date().toISOString(),
+    coverage_complete: false,
+    target_count: bump === "major" ? targetCount : null,
+  });
+
+  await events.recordEvent({
+    component_kind: kind,
+    component_id: id,
+    event_type: "start-dev",
+    from_semver: current.semver,
+    to_semver: semver,
+    bump_type: bump,
+    target_count: bump === "major" ? targetCount : null,
+    notes,
+  });
+}
+
+export async function promote(args: PromoteArgs): Promise<void> {
+  const { reg, events, runs, kind, id, force, notes } = args;
+  assertRegistered(kind, id);
+
+  const next = await reg.getNext(kind, id);
+  if (!next) throw new Error(`No next slot for ${kind} '${id}'. Nothing to promote.`);
+
+  const current = await reg.getCurrent(kind, id);
+  if (!current) throw new Error(`No current slot for ${kind} '${id}'.`);
+
+  // Major coverage gate.
+  if (next.bump_type === "major" && !force) {
+    const target = next.target_count ?? 0;
+    const successful = await runs.countSuccessfulAtVersion(id, next.semver);
+    if (successful < target) {
+      throw new Error(
+        `coverage ${successful}/${target} below 100% — use --force to promote anyway`
+      );
+    }
+  }
+
+  // Slot rotation:
+  // 1. Drop existing previous (if any).
+  // 2. Clear current's key, then rewrite into previous slot.
+  // 3. Clear next's key, then rewrite into current slot.
+  const previous = await reg.getPrevious(kind, id);
+  if (previous) {
+    await reg.clearSlot(kind, id, "previous");
+  }
+  await reg.clearSlot(kind, id, "current");
+  await reg.putSlot({
+    ...current,
+    slot: "previous",
+  });
+  await reg.clearSlot(kind, id, "next");
+  await reg.putSlot({
+    ...next,
+    slot: "current",
+    coverage_complete: true,
+    target_count: null,
+  });
+
+  await events.recordEvent({
+    component_kind: kind,
+    component_id: id,
+    event_type: "promote",
+    from_semver: current.semver,
+    to_semver: next.semver,
+    bump_type: next.bump_type,
+    target_count: null,
+    notes,
+  });
+}
+
+export async function rollback(args: RollbackArgs): Promise<void> {
+  const { reg, events, kind, id, notes } = args;
+  assertRegistered(kind, id);
+
+  const previous = await reg.getPrevious(kind, id);
+  if (!previous) {
+    throw new Error(
+      `No previous slot for ${kind} '${id}'. Nothing to roll back to.`
+    );
+  }
+  const current = await reg.getCurrent(kind, id);
+  if (!current) throw new Error(`No current slot for ${kind} '${id}'.`);
+
+  // Swap by clearing both and re-writing with swapped slot values.
+  await reg.clearSlot(kind, id, "previous");
+  await reg.clearSlot(kind, id, "current");
+  await reg.putSlot({
+    ...previous,
+    slot: "current",
+  });
+  await reg.putSlot({
+    ...current,
+    slot: "previous",
+  });
+
+  await events.recordEvent({
+    component_kind: kind,
+    component_id: id,
+    event_type: "rollback",
+    from_semver: current.semver,
+    to_semver: previous.semver,
+    bump_type: null,
+    target_count: null,
+    notes,
+  });
+}
+
+export async function dropNext(args: DropNextArgs): Promise<void> {
+  const { reg, events, kind, id, notes } = args;
+  assertRegistered(kind, id);
+
+  const next = await reg.getNext(kind, id);
+  if (!next) throw new Error(`No next slot for ${kind} '${id}'. Nothing to drop.`);
+
+  await reg.clearSlot(kind, id, "next");
+
+  await events.recordEvent({
+    component_kind: kind,
+    component_id: id,
+    event_type: "drop-next",
+    from_semver: next.semver,
+    to_semver: null,
+    bump_type: next.bump_type,
+    target_count: null,
+    notes,
+  });
+}

--- a/src/storage/versioning/componentRegistry.ts
+++ b/src/storage/versioning/componentRegistry.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ComponentKind } from "./ComponentVersionSchema";
+import { EXTRACTOR_IDS } from "./extractorIds";
+
+/**
+ * The set of (kind, id) pairs that the CLI accepts. Mutating ceremonies
+ * (start-dev / promote / rollback / drop-next) reject any (kind, id) not
+ * listed here. PR3 registers only extractors; PR4 will add resolvers.
+ */
+const REGISTERED: ReadonlyArray<{ kind: ComponentKind; id: string }> = [
+  ...EXTRACTOR_IDS.map((id) => ({ kind: "extractor" as const, id })),
+];
+
+export function isRegisteredComponent(kind: ComponentKind, id: string): boolean {
+  return REGISTERED.some((r) => r.kind === kind && r.id === id);
+}
+
+export function listRegisteredComponents(): ReadonlyArray<{
+  kind: ComponentKind;
+  id: string;
+}> {
+  return REGISTERED;
+}

--- a/src/storage/versioning/getActiveSlot.test.ts
+++ b/src/storage/versioning/getActiveSlot.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "./ComponentVersionSchema";
+import { getActiveSlot } from "./getActiveSlot";
+import { VersionRegistry } from "./VersionRegistry";
+
+describe("getActiveSlot", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("returns the current slot when only current exists", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    // setupAllDatabases bootstraps extractor:D at 1.0.0 in current.
+    const active = await getActiveSlot(reg, "extractor", "D");
+    expect(active).toEqual({ slot: "current", semver: "1.0.0" });
+  });
+
+  it("returns the next slot when next exists, regardless of bump type", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    await reg.putSlot({
+      component_kind: "extractor",
+      component_id: "D",
+      slot: "next",
+      semver: "2.0.0",
+      bump_type: "major",
+      started_at: "2026-05-21T00:00:00Z",
+      coverage_complete: false,
+      target_count: 100,
+    });
+    const active = await getActiveSlot(reg, "extractor", "D");
+    expect(active).toEqual({ slot: "next", semver: "2.0.0" });
+  });
+
+  it("returns undefined when neither slot exists", async () => {
+    const reg = new VersionRegistry(
+      globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+    );
+    const active = await getActiveSlot(reg, "extractor", "no-such-extractor");
+    expect(active).toBeUndefined();
+  });
+});

--- a/src/storage/versioning/getActiveSlot.ts
+++ b/src/storage/versioning/getActiveSlot.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ComponentKind, ComponentSlot } from "./ComponentVersionSchema";
+import type { VersionRegistry } from "./VersionRegistry";
+
+export interface ActiveSlot {
+  readonly slot: Extract<ComponentSlot, "current" | "next">;
+  readonly semver: string;
+}
+
+/**
+ * Resolves which slot's extractor version should be used right now.
+ *
+ * "Next if exists, else current" — per PR3 spec decision D9. When a dev cycle
+ * is in flight (next-slot row exists), all processing targets that slot. When
+ * no dev cycle is in flight, processing targets current.
+ *
+ * Returns undefined when the component has no current OR next slot — i.e. the
+ * component isn't registered yet. Callers should treat this as an error.
+ */
+export async function getActiveSlot(
+  reg: VersionRegistry,
+  kind: ComponentKind,
+  id: string
+): Promise<ActiveSlot | undefined> {
+  const next = await reg.getNext(kind, id);
+  if (next) return { slot: "next", semver: next.semver };
+  const current = await reg.getCurrent(kind, id);
+  if (current) return { slot: "current", semver: current.semver };
+  return undefined;
+}

--- a/src/storage/versioning/semver.test.ts
+++ b/src/storage/versioning/semver.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  parseSemver,
+  semverMajorMinor,
+  semverMajorMinorPrefix,
+  validateBumpProgression,
+} from "./semver";
+
+describe("parseSemver", () => {
+  it("parses valid semver", () => {
+    expect(parseSemver("0.0.1")).toEqual({ major: 0, minor: 0, patch: 1 });
+    expect(parseSemver("1.0.0")).toEqual({ major: 1, minor: 0, patch: 0 });
+    expect(parseSemver("12.34.56")).toEqual({ major: 12, minor: 34, patch: 56 });
+  });
+  it("returns undefined for malformed input", () => {
+    expect(parseSemver("")).toBeUndefined();
+    expect(parseSemver("1.0")).toBeUndefined();
+    expect(parseSemver("v1.0.0")).toBeUndefined();
+    expect(parseSemver("1.0.0-alpha")).toBeUndefined();
+    expect(parseSemver("foo")).toBeUndefined();
+  });
+});
+
+describe("semverMajorMinor", () => {
+  it("returns the major.minor pair", () => {
+    expect(semverMajorMinor("1.0.0")).toEqual({ major: 1, minor: 0 });
+    expect(semverMajorMinor("2.5.99")).toEqual({ major: 2, minor: 5 });
+  });
+  it("throws on malformed input", () => {
+    expect(() => semverMajorMinor("bad")).toThrow(/invalid semver/i);
+  });
+});
+
+describe("semverMajorMinorPrefix", () => {
+  it("returns 'M.N.' prefix string", () => {
+    expect(semverMajorMinorPrefix("1.0.0")).toBe("1.0.");
+    expect(semverMajorMinorPrefix("2.5.99")).toBe("2.5.");
+  });
+});
+
+describe("validateBumpProgression", () => {
+  it("accepts major bump", () => {
+    expect(validateBumpProgression("1.5.7", "2.0.0", "major")).toBeUndefined();
+    expect(validateBumpProgression("0.1.0", "1.0.0", "major")).toBeUndefined();
+  });
+  it("rejects major bump that doesn't reset minor/patch to 0", () => {
+    expect(validateBumpProgression("1.0.0", "2.1.0", "major")).toMatch(/reset minor/i);
+    expect(validateBumpProgression("1.0.0", "2.0.1", "major")).toMatch(/reset patch/i);
+  });
+  it("rejects major bump that doesn't increment major", () => {
+    expect(validateBumpProgression("1.0.0", "1.0.1", "major")).toMatch(/major must increment/i);
+  });
+
+  it("accepts minor bump", () => {
+    expect(validateBumpProgression("1.0.5", "1.1.0", "minor")).toBeUndefined();
+  });
+  it("rejects minor bump that doesn't reset patch", () => {
+    expect(validateBumpProgression("1.0.0", "1.1.5", "minor")).toMatch(/reset patch/i);
+  });
+  it("rejects minor bump that doesn't increment minor", () => {
+    expect(validateBumpProgression("1.0.0", "1.0.5", "minor")).toMatch(/minor must increment/i);
+    expect(validateBumpProgression("1.0.0", "2.0.0", "minor")).toMatch(/major must stay the same/i);
+  });
+
+  it("accepts patch bump", () => {
+    expect(validateBumpProgression("1.0.0", "1.0.1", "patch")).toBeUndefined();
+    expect(validateBumpProgression("1.0.99", "1.0.100", "patch")).toBeUndefined();
+  });
+  it("rejects patch bump that doesn't increment patch", () => {
+    expect(validateBumpProgression("1.0.0", "1.0.0", "patch")).toMatch(/patch must increment/i);
+    expect(validateBumpProgression("1.0.0", "1.1.0", "patch")).toMatch(/minor must stay the same/i);
+  });
+
+  it("rejects malformed input", () => {
+    expect(validateBumpProgression("bad", "1.0.0", "major")).toMatch(/invalid semver/i);
+    expect(validateBumpProgression("1.0.0", "bad", "major")).toMatch(/invalid semver/i);
+  });
+});

--- a/src/storage/versioning/semver.ts
+++ b/src/storage/versioning/semver.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BumpType } from "./ComponentVersionSchema";
+
+export interface SemverParts {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+}
+
+const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+/**
+ * Parses MAJOR.MINOR.PATCH. Returns undefined on malformed input. Pre-release
+ * and build metadata suffixes are intentionally unsupported in v1.
+ */
+export function parseSemver(s: string): SemverParts | undefined {
+  const m = SEMVER_RE.exec(s);
+  if (!m) return undefined;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+  };
+}
+
+/**
+ * Returns just the major/minor pair. Throws on malformed input.
+ */
+export function semverMajorMinor(s: string): { major: number; minor: number } {
+  const p = parseSemver(s);
+  if (!p) throw new Error(`invalid semver: ${s}`);
+  return { major: p.major, minor: p.minor };
+}
+
+/**
+ * Returns the "M.N." prefix string for SQL LIKE / startsWith matching.
+ */
+export function semverMajorMinorPrefix(s: string): string {
+  const { major, minor } = semverMajorMinor(s);
+  return `${major}.${minor}.`;
+}
+
+/**
+ * Returns undefined when the transition is valid; otherwise an error message
+ * describing what's wrong. Caller decides whether to throw or return.
+ *
+ * Rules:
+ *   major: major++ , minor=0, patch=0
+ *   minor: major same, minor++, patch=0
+ *   patch: major same, minor same, patch++
+ */
+export function validateBumpProgression(
+  fromSemver: string,
+  toSemver: string,
+  bump: BumpType
+): string | undefined {
+  const from = parseSemver(fromSemver);
+  const to = parseSemver(toSemver);
+  if (!from) return `invalid semver: ${fromSemver}`;
+  if (!to) return `invalid semver: ${toSemver}`;
+
+  if (bump === "major") {
+    if (to.major !== from.major + 1) return `major must increment by 1 (${fromSemver} → ${toSemver})`;
+    if (to.minor !== 0) return `major bump must reset minor to 0 (got ${toSemver})`;
+    if (to.patch !== 0) return `major bump must reset patch to 0 (got ${toSemver})`;
+    return undefined;
+  }
+
+  if (bump === "minor") {
+    if (to.major !== from.major) return `minor bump: major must stay the same (${fromSemver} → ${toSemver})`;
+    if (to.minor !== from.minor + 1) return `minor must increment by 1 (${fromSemver} → ${toSemver})`;
+    if (to.patch !== 0) return `minor bump must reset patch to 0 (got ${toSemver})`;
+    return undefined;
+  }
+
+  // patch
+  if (to.major !== from.major) return `patch bump: major must stay the same (${fromSemver} → ${toSemver})`;
+  if (to.minor !== from.minor) return `patch bump: minor must stay the same (${fromSemver} → ${toSemver})`;
+  if (to.patch !== from.patch + 1) return `patch must increment by 1 (${fromSemver} → ${toSemver})`;
+  return undefined;
+}

--- a/src/task/forms/ProcessAccessionDocFormTask.test.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.test.ts
@@ -85,6 +85,6 @@ describe("ProcessAccessionDocFormTask (versioned)", () => {
         { accessionNumber: "0001234567-25-000001" },
         { own: <T>(x: T): T => x } as any
       )
-    ).rejects.toThrow(/No current version.*extractor.*D/i);
+    ).rejects.toThrow(/No active slot.*extractor.*D/i);
   });
 });

--- a/src/task/forms/ProcessAccessionDocFormTask.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.ts
@@ -25,6 +25,7 @@ import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../storage/versioning/Com
 import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
 import { formToExtractorId } from "../../storage/versioning/extractorIds";
+import { getActiveSlot } from "../../storage/versioning/getActiveSlot";
 import { VersionRegistry } from "../../storage/versioning/VersionRegistry";
 import { SecFetchAccessionDocTask } from "./SecFetchAccessionDocTask";
 
@@ -114,13 +115,14 @@ export class ProcessAccessionDocFormTask extends Task<
     const versionRegistry = new VersionRegistry(
       globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
     );
-    const currentVersion = await versionRegistry.getCurrent("extractor", extractorId);
-    if (!currentVersion) {
+    const activeSlot = await getActiveSlot(versionRegistry, "extractor", extractorId);
+    if (!activeSlot) {
       throw new TaskError(
-        `No current version for extractor '${extractorId}'. Run 'sec db setup' to bootstrap.`
+        `No active slot for extractor '${extractorId}'. Run 'sec db setup' to bootstrap.`
       );
     }
-    const extractorVersion = currentVersion.semver;
+    const extractorVersion = activeSlot.semver;
+    const slotAtRun = activeSlot.slot;
 
     const runRepo = new ExtractorRunRepo(
       globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN)
@@ -201,7 +203,7 @@ export class ProcessAccessionDocFormTask extends Task<
               form: form!,
               extractor_id: extractorId,
               extractor_version: extractorVersion,
-              slot_at_run: "current",
+              slot_at_run: slotAtRun,
               success: true,
               error: null,
             });
@@ -214,7 +216,7 @@ export class ProcessAccessionDocFormTask extends Task<
               form: form!,
               extractor_id: extractorId,
               extractor_version: extractorVersion,
-              slot_at_run: "current",
+              slot_at_run: slotAtRun,
               success: false,
               error: message.slice(0, 4096),
             });

--- a/src/task/forms/UpdateAllFormsTask.ts
+++ b/src/task/forms/UpdateAllFormsTask.ts
@@ -12,6 +12,7 @@ import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../storage/versioning/Com
 import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
 import { formToExtractorId } from "../../storage/versioning/extractorIds";
+import { getActiveSlot } from "../../storage/versioning/getActiveSlot";
 import { VersionRegistry } from "../../storage/versioning/VersionRegistry";
 import { ProcessAccessionDocFormTask } from "./ProcessAccessionDocFormTask";
 
@@ -62,10 +63,9 @@ export class UpdateAllFormsTask extends Task<UpdateAllFormsTaskInput, UpdateAllF
     const formSet = new Set(input.form);
     const formsToProcess: Filing[] = [];
 
-    // Cache version lookups per extractor_id — multiple form variants
-    // (e.g. "C", "C/A", "C-W"…) share one extractor, so the version is the
-    // same across them. Avoids redundant component_versions queries.
-    const versionCache = new Map<string, string>();
+    // Cache active-slot lookups per extractor_id. Active slot is "next if a
+    // dev cycle is in flight, else current" — see getActiveSlot.
+    const slotCache = new Map<string, { slot: "current" | "next"; semver: string }>();
 
     for (const form of formSet) {
       const extractorId = formToExtractorId(form);
@@ -75,17 +75,18 @@ export class UpdateAllFormsTask extends Task<UpdateAllFormsTaskInput, UpdateAllF
         );
         continue;
       }
-      let extractorVersion = versionCache.get(extractorId);
-      if (extractorVersion === undefined) {
-        const current = await versionRegistry.getCurrent("extractor", extractorId);
-        if (!current) {
+      let active = slotCache.get(extractorId);
+      if (active === undefined) {
+        const resolved = await getActiveSlot(versionRegistry, "extractor", extractorId);
+        if (!resolved) {
           throw new Error(
-            `No current version for extractor '${extractorId}'. Run 'sec db setup' to bootstrap.`
+            `No active slot for extractor '${extractorId}'. Run 'sec db setup' to bootstrap.`
           );
         }
-        extractorVersion = current.semver;
-        versionCache.set(extractorId, extractorVersion);
+        active = resolved;
+        slotCache.set(extractorId, active);
       }
+      const extractorVersion = active.semver;
 
       const filings = (await filingRepo.query({ form })) ?? [];
       const unprocessed = await runRepo.listFilingsWithoutSuccessfulRun(


### PR DESCRIPTION
## Summary

Ships the version-bump ceremonies for SEC extractors. Builds on PR #106 (slot/version foundation) and PR #107 (extractor wiring at 1.0.0). Operators can now drive a full dev cycle: `start-dev` → run dev work → `coverage` → `promote` (or `rollback` / `drop-next`), with an audit log of every event.

## CLI surface (new)

```
sec version start-dev <kind> <id> <semver> --bump major|minor|patch [--notes "..."] [--dry-run]
sec version promote   <kind> <id> [--force] [--notes "..."] [--dry-run]
sec version rollback  <kind> <id> [--notes "..."] [--dry-run]
sec version drop-next <kind> <id> [--notes "..."] [--dry-run]
sec version coverage  <kind> <id> [--format table|json]
sec version history   <kind> <id> [--limit N] [--format table|json]
```

`<kind>` is `extractor | resolver` — kind-aware from day one even though PR3 registers only the 5 extractors. PR4 will register resolvers and the CLI starts working unchanged. The PR1/PR2 hidden `seed-test` is removed.

## Three ceremony flavors (per spec D4)

- **Major** — `start-dev` snapshots `target_count` (count of filings handled by this extractor). `update-forms` routes to the `next` slot, building successful runs against it. `promote` gates on `successful >= target_count`; `--force` overrides. Slot rotation: `previous := current`, `current := next`.
- **Minor** — same flow without the coverage gate. After promote, operator runs `update-forms` to backfill rows still at the previous version.
- **Patch** — degenerate: no `next` slot, no rotation. `current.semver` is updated in place; logs a single `promote` event for audit symmetry.

## Patch-gating reading-side fix

`ExtractorRunRepo.listFilingsWithoutSuccessfulRun` now matches on `(major, minor)` prefix instead of exact `extractor_version`. A row at `1.0.0` satisfies a `1.0.x` gate but not `1.1.x` or `2.0.0`. Patches no longer cause spurious reprocessing.

## What changes elsewhere

- `component_versions` gains a nullable `target_count: integer` column (populated only on `next`-slot rows with `bump_type='major'`).
- New `version_events` table — append-only audit log; one row per ceremony.
- `UpdateAllFormsTask` and `ProcessAccessionDocFormTask` route via `getActiveSlot(reg, "extractor", id)` — `next` if a dev cycle is in flight, else `current`. Backward-compatible when no `next` exists.
- The hidden `seed-test` subcommand from PR1 is removed.

## Test plan

- [x] `bun test` — 614 pass / 0 fail (12 new tests added: semver helpers, VersionEventRepo, getActiveSlot, ceremonies including end-to-end round-trip and dry-run validation, CLI ceremony subcommands).
- [x] `bun run build` — clean.
- [x] End-to-end smoke: `db setup` → `start-dev D 2.0.0 --bump major` → `coverage` → `promote --force` → `status` shows rotation → `history` shows both events → `rollback` → status shows swap. All verified manually.
- [x] Dry-run runs validations (e.g. `start-dev D 99.0.0 --bump patch --dry-run` exits non-zero with bump-progression error) and writes nothing — fixed during review when `--dry-run` was confirmed to be a global option, not per-subcommand.

## Forward-compat for PR4

- `componentRegistry.ts` is the seam — PR4 adds `...RESOLVER_IDS.map(...)` to the const array and the CLI starts working for resolvers.
- `snapshotTargetCount(kind, id)` rejects non-`extractor` kinds with a TODO comment pointing at the kind-aware strategy PR4 will need.
- All ceremonies are kind-generic; only the snapshot strategy is kind-specific today.

## Known follow-ups (not blocking)

- `--notes` text in the table view of `history` truncates at 40 chars without indication. Operators can use `--format json` for full notes.
- `getVersionCoverage` denominator is a frozen snapshot; new filings during a dev cycle are outside the gate (intentional per spec D8 — they'll be caught by `update-forms` after promote).
- `VersionEventRepo.recordEvent` uses `size() + 1` for ids; documented to require append-only semantics. A future delete-events command must migrate to UUIDs first.
- `listFilingsWithoutSuccessfulRun` materializes the successful-runs set in memory. At Form D's projected size (hundreds of thousands of filings), this can reach ~100-200 MB. A streaming / anti-join migration is the documented next-step.

## Plan and spec

- Plan: `prd/docs/superpowers/plans/2026-05-21-sec-versioning-pr3-promotion.md`
- Spec: `prd/docs/superpowers/specs/2026-05-21-sec-versioning-pr3-promotion-design.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAQMiENJGSmLi4HqE4pZ5t)_