### PR TITLE
Fix bulk CIK name writer to respect SEC_DB_TYPE config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ PR4 introduced an observation/canonical/resolver tier on top of raw form storage
 
 `src/sec.ts` invokes **`Sqlite.init()`** when the installed `workglow` package defines it (`typeof Sqlite.init === "function"`), so newer Workglow releases load the SQLite binding before `getDb()` opens a database. Older `workglow` versions without `init` skip this step.
 
+**`getDb()` is SQLite-only.** It throws `SecCliConfigurationError` when `SEC_DB_TYPE !== "sqlite"` to prevent the silent data divergence that occurred before (`getDb()` would open a stray SQLite file even under Postgres, and rows written through it never reached the configured backend). Tasks that need a raw SQL fast path beyond what `ITabularStorage` exposes must branch on `SEC_DB_TYPE` themselves — see `src/storage/entity/cikNameBulkWriter.ts` for the pattern (SQLite → `getDb()`, Postgres → `getPgPool()`, otherwise → repository `putBulk` for tests).
+
 ### Dependency Injection
 
 Uses the `workglow` package’s `globalServiceRegistry` with typed tokens. Production uses `SqliteTabularRepository`, tests use `InMemoryTabularRepository`. Call `resetDependencyInjectionsForTesting()` from `src/config/TestingDI.ts` in test setup.

--- a/src/cli/groups/init.ts
+++ b/src/cli/groups/init.ts
@@ -138,11 +138,21 @@ export function addInitCommand(parent: Command): void {
           mkdirSync(rawDataFolder, { recursive: true });
           console.log(`Created directory: ${rawDataFolder}`);
 
-          // Re-read env so DI picks up new values
+          // Re-read env so DI picks up new values. Push every var the
+          // wizard collected, including the Postgres set — assertSecCliEnvConfigured
+          // now fails fast for a Postgres dbType with missing PG env, so
+          // the wizard would crash immediately after writing .env.local
+          // if we left these blank.
           process.env.SEC_DB_TYPE = config.dbType;
           process.env.SEC_DB_FOLDER = config.dbFolder;
           process.env.SEC_DB_NAME = config.dbName;
           process.env.SEC_RAW_DATA_FOLDER = config.rawDataFolder;
+          if (config.pgUrl !== undefined) process.env.SEC_PG_URL = config.pgUrl;
+          if (config.pgHost !== undefined) process.env.SEC_PG_HOST = config.pgHost;
+          if (config.pgPort !== undefined) process.env.SEC_PG_PORT = config.pgPort;
+          if (config.pgUser !== undefined) process.env.SEC_PG_USER = config.pgUser;
+          if (config.pgPassword !== undefined) process.env.SEC_PG_PASSWORD = config.pgPassword;
+          if (config.pgDatabase !== undefined) process.env.SEC_PG_DATABASE = config.pgDatabase;
 
           EnvToDI();
           if (config.dbType === "sqlite" && typeof Sqlite.init === "function") {

--- a/src/cli/groups/query.ts
+++ b/src/cli/groups/query.ts
@@ -49,6 +49,7 @@ export function addQueryCommands(program: Command): void {
         renderTable(result.rows as Record<string, unknown>[], columns, {
           format,
           total: result.total,
+          totalApprox: result.totalApprox,
           offset,
           limit,
         })
@@ -96,6 +97,7 @@ export function addQueryCommands(program: Command): void {
         renderTable(result.rows as Record<string, unknown>[], columns, {
           format,
           total: result.total,
+          totalApprox: result.totalApprox,
           offset,
           limit,
         })
@@ -138,6 +140,7 @@ export function addQueryCommands(program: Command): void {
         renderTable(result.rows as Record<string, unknown>[], columns, {
           format,
           total: result.total,
+          totalApprox: result.totalApprox,
           offset,
           limit,
         })
@@ -181,6 +184,7 @@ export function addQueryCommands(program: Command): void {
         renderTable(result.rows as Record<string, unknown>[], columns, {
           format,
           total: result.total,
+          totalApprox: result.totalApprox,
           offset,
           limit,
         })
@@ -222,6 +226,7 @@ export function addQueryCommands(program: Command): void {
         renderTable(result.rows as Record<string, unknown>[], columns, {
           format,
           total: result.total,
+          totalApprox: result.totalApprox,
           offset,
           limit,
         })
@@ -263,6 +268,7 @@ export function addQueryCommands(program: Command): void {
         renderTable(result.rows as Record<string, unknown>[], columns, {
           format,
           total: result.total,
+          totalApprox: result.totalApprox,
           offset,
           limit,
         })
@@ -300,6 +306,7 @@ export function addQueryCommands(program: Command): void {
         renderTable(result.rows as Record<string, unknown>[], columns, {
           format,
           total: result.total,
+          totalApprox: result.totalApprox,
           offset,
           limit,
         })

--- a/src/cli/output/TableRenderer.test.ts
+++ b/src/cli/output/TableRenderer.test.ts
@@ -61,6 +61,40 @@ describe("renderTable", () => {
       const lines = result.split("\n");
       expect(lines[1]).toBe("1,,");
     });
+
+    it("defuses formula-injection prefixes by quoting them", () => {
+      // Spreadsheets interpret cells starting with =/+/-/@ as formulas
+      // (incl. data exfiltration via WEBSERVICE/HYPERLINK). Prefix with
+      // a single quote so a CSV emitted from `sec query --format csv` is
+      // safe to open in Excel/Sheets/Numbers.
+      const rows = [
+        { id: 1, name: "=cmd|' /C calc'!A0", value: 1 },
+        { id: 2, name: "+1+1", value: 2 },
+        { id: 3, name: "-1+1", value: 3 },
+        { id: 4, name: "@SUM(A1:A9)", value: 4 },
+        { id: 5, name: "\tleading tab", value: 5 },
+      ];
+      const result = renderTable(rows, columns, { format: "csv" });
+      const lines = result.split("\n");
+      expect(lines[1]).toBe(`1,'=cmd|' /C calc'!A0,1`);
+      expect(lines[2]).toBe("2,'+1+1,2");
+      expect(lines[3]).toBe("3,'-1+1,3");
+      expect(lines[4]).toBe("4,'@SUM(A1:A9),4");
+      expect(lines[5]).toBe("5,'\tleading tab,5");
+    });
+
+    it("does not prefix benign leading characters", () => {
+      const rows = [
+        { id: 1, name: "Alice", value: 1 },
+        { id: 2, name: "1+1", value: 2 },
+        { id: 3, name: "", value: 3 },
+      ];
+      const result = renderTable(rows, columns, { format: "csv" });
+      const lines = result.split("\n");
+      expect(lines[1]).toBe("1,Alice,1");
+      expect(lines[2]).toBe("2,1+1,2");
+      expect(lines[3]).toBe("3,,3");
+    });
   });
 
   describe("table format", () => {

--- a/src/cli/output/TableRenderer.ts
+++ b/src/cli/output/TableRenderer.ts
@@ -9,6 +9,16 @@ export interface RenderOptions {
   readonly total?: number;
   readonly offset?: number;
   readonly limit?: number;
+  /**
+   * Set when the displayed `total` is a lower bound — the underlying
+   * query streamed and stopped after collecting offset+limit matches
+   * without exhausting the dataset. Rendered as "≥ N" with a hint to
+   * narrow the filter.
+   */
+  readonly totalApprox?: {
+    readonly atLeast: number;
+    readonly exhausted: boolean;
+  };
 }
 
 function truncate(value: string, width: number): string {
@@ -74,7 +84,15 @@ function renderTextTable(
     const start = count === 0 ? 0 : offset + 1;
     const end = count === 0 ? 0 : offset + count;
     lines.push("");
-    lines.push(`Showing ${start}-${end} of ${options.total} results`);
+    const isApprox =
+      options.totalApprox !== undefined && options.totalApprox.exhausted === false;
+    const totalLabel = isApprox ? `≥ ${options.total}` : `${options.total}`;
+    lines.push(`Showing ${start}-${end} of ${totalLabel} results`);
+    if (isApprox) {
+      lines.push(
+        `(streamed; narrow the filter for an exact count and full pagination)`
+      );
+    }
 
     if (count > 0 && end < options.total) {
       lines.push(`(use --offset ${end} for next page)`);

--- a/src/cli/output/TableRenderer.ts
+++ b/src/cli/output/TableRenderer.ts
@@ -36,10 +36,20 @@ function pad(value: string, width: number): string {
 }
 
 function escapeCsvValue(value: string): string {
-  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
-    return '"' + value.replace(/"/g, '""') + '"';
+  // Defuse CSV/spreadsheet formula injection. When Excel/Sheets/Numbers
+  // open a CSV, a cell starting with =/+/-/@ (or with leading TAB/CR
+  // that some loaders strip) is interpreted as a formula, which can
+  // exfiltrate data via WEBSERVICE/HYPERLINK or run external commands.
+  // Prefix a single quote — spreadsheets render it as a literal and hide
+  // the prefix; plain CSV consumers see the original text with one
+  // leading apostrophe, which is a small price for not shipping a known
+  // attack vector.
+  const dangerous = value.length > 0 && /^[=+\-@\t\r]/.test(value);
+  let escaped = dangerous ? "'" + value : value;
+  if (escaped.includes(",") || escaped.includes('"') || escaped.includes("\n")) {
+    return '"' + escaped.replace(/"/g, '""') + '"';
   }
-  return value;
+  return escaped;
 }
 
 function cellValue(row: Record<string, unknown>, key: string): string {

--- a/src/cli/queries/CikQuery.test.ts
+++ b/src/cli/queries/CikQuery.test.ts
@@ -123,4 +123,23 @@ describe("queryCiks", () => {
     expect(result.rows).toEqual([]);
     expect(result.tableEmpty).toBe(false);
   });
+
+  it("paginates without scanning the full table when the needle is empty", async () => {
+    // Regression: previously walked every row even for empty needle.
+    // Empty needle now uses size() + getOffsetPage() so memory stays
+    // bounded regardless of table size.
+    await seed([
+      { cik: 1, name: "AAA" },
+      { cik: 2, name: "BBB" },
+      { cik: 3, name: "CCC" },
+      { cik: 4, name: "DDD" },
+      { cik: 5, name: "EEE" },
+    ]);
+    const result = await queryCiks({ limit: 2, offset: 1 });
+    expect(result.total).toBe(5);
+    expect(result.rows.length).toBe(2);
+    expect(result.tableEmpty).toBe(false);
+    // Should NOT have a totalApprox — total is exact.
+    expect(result.totalApprox).toBeUndefined();
+  });
 });

--- a/src/cli/queries/CikQuery.ts
+++ b/src/cli/queries/CikQuery.ts
@@ -20,12 +20,34 @@ export interface CikQueryResult extends QueryResult<CikNameType> {
 }
 
 /**
- * Queries the `cik_names` table for companies whose name matches the given needle.
- * Case-insensitive. Ranks exact match first, then prefix, then substring;
- * ties broken by shorter name, then lower CIK.
+ * Soft cap on substring/prefix matches we'll collect before sorting. Stops
+ * the empty-needle case (which previously walked the entire ~1M-row table)
+ * and any pathologically broad needle from exhausting memory. Picked so a
+ * normal `offset+limit` of a few hundred has plenty of headroom for the
+ * rank-based reordering.
+ */
+const MAX_FUZZY_MATCHES = 1000;
+
+/**
+ * Queries the `cik_names` table for companies whose name matches the given
+ * needle. Case-insensitive. Ranks exact match first, then prefix, then
+ * substring; ties broken by shorter name, then lower CIK.
  *
- * `tableEmpty` is true when the underlying table has no rows at all (distinct
- * from "no matches") so callers can prompt the user to run the ingest.
+ * `tableEmpty` is true when the underlying table has no rows at all
+ * (distinct from "no matches") so callers can prompt the user to run the
+ * ingest.
+ *
+ * Three operating modes, in increasing memory cost:
+ *
+ *   1. **Empty needle** — `count() + getOffsetPage()`. No scan, no
+ *      sorting. The "rank" concept doesn't apply because there's no
+ *      target; rows come back in PK order.
+ *   2. **Exact match** — `query({ name }) + count({ name })`. Pushes
+ *      equality down to the DB. Only the matching rows are loaded.
+ *   3. **Prefix / substring** — streams via `records()` because workglow
+ *      has no LIKE operator. Capped at `MAX_FUZZY_MATCHES` so the
+ *      previously-OOM-prone empty-string path is bounded. When the cap
+ *      hits, `totalApprox.exhausted` is `false` and the UI renders "≥ N".
  */
 export async function queryCiks(params: CikQueryParams): Promise<CikQueryResult> {
   const repo = globalServiceRegistry.get(CIK_NAME_REPOSITORY_TOKEN);
@@ -33,8 +55,22 @@ export async function queryCiks(params: CikQueryParams): Promise<CikQueryResult>
   const offset = params.offset ?? 0;
   const needle = params.name?.toLowerCase().trim() ?? "";
 
+  // Mode 1: empty needle — straight pagination.
+  if (needle === "" && !params.exact) {
+    const total = await repo.size();
+    const rows = (await repo.getOffsetPage(offset, limit)) ?? [];
+    return { rows, total, tableEmpty: total === 0 };
+  }
+
+  // Mode 2/3: stream and rank. We have to stream rather than `query()`
+  // because workglow's equality is case-sensitive and there is no LIKE
+  // operator — both case-insensitive exact match and prefix/substring
+  // matches have to be evaluated client-side. Capped at MAX_FUZZY_MATCHES
+  // so the worst case is bounded; if the cap fires, `totalApprox.exhausted`
+  // is `false` and the UI renders "≥ N".
   const matches: { row: CikNameType; rank: number }[] = [];
   let anyRowSeen = false;
+  let exhausted = true;
   for await (const row of repo.records(5000)) {
     anyRowSeen = true;
     if (row.name === null || row.name === undefined) continue;
@@ -43,7 +79,7 @@ export async function queryCiks(params: CikQueryParams): Promise<CikQueryResult>
     if (params.exact) {
       if (hay !== needle) continue;
       rank = 0;
-    } else if (needle === "" || hay === needle) {
+    } else if (hay === needle) {
       rank = 0;
     } else if (hay.startsWith(needle)) {
       rank = 1;
@@ -53,6 +89,10 @@ export async function queryCiks(params: CikQueryParams): Promise<CikQueryResult>
       continue;
     }
     matches.push({ row, rank });
+    if (matches.length >= MAX_FUZZY_MATCHES) {
+      exhausted = false;
+      break;
+    }
   }
 
   matches.sort(
@@ -62,9 +102,21 @@ export async function queryCiks(params: CikQueryParams): Promise<CikQueryResult>
       a.row.cik - b.row.cik
   );
 
-  return {
+  // If we hit the cap, we don't know the true total — surface it as a
+  // lower bound so the renderer says "≥ N". When the stream drained
+  // (exhausted), matches.length IS the exact total.
+  // tableEmpty stays correct because we still see at least one row before
+  // hitting the cap unless the table is empty.
+  const result: CikQueryResult = {
     rows: matches.slice(offset, offset + limit).map((m) => m.row),
     total: matches.length,
     tableEmpty: !anyRowSeen,
   };
+  if (!exhausted) {
+    (result as { totalApprox?: { atLeast: number; exhausted: boolean } }).totalApprox = {
+      atLeast: matches.length,
+      exhausted: false,
+    };
+  }
+  return result;
 }

--- a/src/cli/queries/CikQuery.ts
+++ b/src/cli/queries/CikQuery.ts
@@ -37,17 +37,18 @@ const MAX_FUZZY_MATCHES = 1000;
  * (distinct from "no matches") so callers can prompt the user to run the
  * ingest.
  *
- * Three operating modes, in increasing memory cost:
+ * Two operating modes:
  *
- *   1. **Empty needle** — `count() + getOffsetPage()`. No scan, no
+ *   1. **Empty needle** — `size() + getOffsetPage()`. No scan, no
  *      sorting. The "rank" concept doesn't apply because there's no
  *      target; rows come back in PK order.
- *   2. **Exact match** — `query({ name }) + count({ name })`. Pushes
- *      equality down to the DB. Only the matching rows are loaded.
- *   3. **Prefix / substring** — streams via `records()` because workglow
- *      has no LIKE operator. Capped at `MAX_FUZZY_MATCHES` so the
- *      previously-OOM-prone empty-string path is bounded. When the cap
- *      hits, `totalApprox.exhausted` is `false` and the UI renders "≥ N".
+ *   2. **Exact / prefix / substring** — streams via `records()` because
+ *      workglow has no LIKE operator AND its equality is case-sensitive
+ *      (so even `--exact` can't push down: SEC stores names as
+ *      "Apple Inc." and a user querying "APPLE INC." would miss). Capped
+ *      at `MAX_FUZZY_MATCHES` so the worst case is bounded; if the cap
+ *      fires, `totalApprox.exhausted` is `false` and the UI renders
+ *      "≥ N".
  */
 export async function queryCiks(params: CikQueryParams): Promise<CikQueryResult> {
   const repo = globalServiceRegistry.get(CIK_NAME_REPOSITORY_TOKEN);
@@ -104,19 +105,15 @@ export async function queryCiks(params: CikQueryParams): Promise<CikQueryResult>
 
   // If we hit the cap, we don't know the true total — surface it as a
   // lower bound so the renderer says "≥ N". When the stream drained
-  // (exhausted), matches.length IS the exact total.
-  // tableEmpty stays correct because we still see at least one row before
-  // hitting the cap unless the table is empty.
-  const result: CikQueryResult = {
+  // (exhausted), matches.length IS the exact total and we omit
+  // totalApprox entirely so consumers can rely on its presence as the
+  // streamed-and-capped signal.
+  // tableEmpty stays correct because we still see at least one row
+  // before hitting the cap unless the table is empty.
+  return {
     rows: matches.slice(offset, offset + limit).map((m) => m.row),
     total: matches.length,
     tableEmpty: !anyRowSeen,
+    ...(exhausted ? {} : { totalApprox: { atLeast: matches.length, exhausted: false } }),
   };
-  if (!exhausted) {
-    (result as { totalApprox?: { atLeast: number; exhausted: boolean } }).totalApprox = {
-      atLeast: matches.length,
-      exhausted: false,
-    };
-  }
-  return result;
 }

--- a/src/cli/queries/CrowdfundingQuery.ts
+++ b/src/cli/queries/CrowdfundingQuery.ts
@@ -1,7 +1,9 @@
 import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
 import type { Crowdfunding } from "../../storage/portal/CrowdfundingSchema";
 import { CROWDFUNDING_REPOSITORY_TOKEN } from "../../storage/portal/CrowdfundingSchema";
 import type { QueryResult } from "./EntityQuery";
+import { collectPage, streamMatchingRows } from "./_streamMatches";
 
 export interface CrowdfundingQueryParams {
   readonly search?: string;
@@ -20,33 +22,45 @@ export async function queryCrowdfunding(
   const limit = params.limit ?? 25;
   const offset = params.offset ?? 0;
 
-  let items: Crowdfunding[];
-
-  if (params.cik !== undefined) {
-    items = (await repo.query({ cik: params.cik } as Partial<Crowdfunding>)) ?? [];
-  } else {
-    items = (await repo.getAll()) ?? [];
+  const criteria: SearchCriteria<Crowdfunding> = {};
+  if (params.cik !== undefined) (criteria as Partial<Crowdfunding>).cik = params.cik;
+  if (params.portal !== undefined) (criteria as Partial<Crowdfunding>).portal_cik = params.portal;
+  // One side of the date range pushes down via SearchCondition; both
+  // sides need the predicate (workglow takes one condition per column).
+  if (params.after !== undefined && params.before === undefined) {
+    (criteria as any).filing_date = { value: params.after, operator: ">=" };
+  } else if (params.before !== undefined && params.after === undefined) {
+    (criteria as any).filing_date = { value: params.before, operator: "<=" };
   }
 
-  if (params.search) {
-    const searchLower = params.search.toLowerCase();
-    items = items.filter((c) => c.name.toLowerCase().includes(searchLower));
+  const hasRange = params.after !== undefined && params.before !== undefined;
+  const hasSearch = params.search !== undefined && params.search !== "";
+  const needsPredicate = hasRange || hasSearch;
+
+  if (!needsPredicate) {
+    const hasCriteria = Object.keys(criteria).length > 0;
+    if (hasCriteria) {
+      const total = await repo.count(criteria);
+      const rows = (await repo.query(criteria, { limit, offset })) ?? [];
+      return { rows, total };
+    }
+    const total = await repo.size();
+    const rows = (await repo.getOffsetPage(offset, limit)) ?? [];
+    return { rows, total };
   }
 
-  if (params.portal !== undefined) {
-    items = items.filter((c) => c.portal_cik === params.portal);
-  }
+  const searchLower = hasSearch ? params.search!.toLowerCase() : null;
+  const predicate = (c: Crowdfunding): boolean => {
+    if (params.after !== undefined && c.filing_date < params.after) return false;
+    if (params.before !== undefined && c.filing_date > params.before) return false;
+    if (searchLower !== null && !c.name.toLowerCase().includes(searchLower)) return false;
+    return true;
+  };
 
-  if (params.after !== undefined) {
-    items = items.filter((c) => c.filing_date >= params.after!);
-  }
-
-  if (params.before !== undefined) {
-    items = items.filter((c) => c.filing_date <= params.before!);
-  }
-
-  const total = items.length;
-  const rows = items.slice(offset, offset + limit);
-
-  return { rows, total };
+  const { rows, total, exhausted } = await collectPage(
+    streamMatchingRows(repo, criteria, predicate),
+    offset,
+    limit
+  );
+  return { rows, total, totalApprox: { atLeast: total, exhausted } };
 }

--- a/src/cli/queries/CrowdfundingQuery.ts
+++ b/src/cli/queries/CrowdfundingQuery.ts
@@ -62,5 +62,7 @@ export async function queryCrowdfunding(
     offset,
     limit
   );
-  return { rows, total, totalApprox: { atLeast: total, exhausted } };
+  // totalApprox is the "this number is a lower bound" signal — only
+  // emit it when the stream was capped, not when it drained.
+  return exhausted ? { rows, total } : { rows, total, totalApprox: { atLeast: total, exhausted } };
 }

--- a/src/cli/queries/EntityQuery.test.ts
+++ b/src/cli/queries/EntityQuery.test.ts
@@ -243,4 +243,36 @@ describe("queryEntities", () => {
     const result = await queryEntities({ sort: "name" });
     expect(result).toBeDefined();
   });
+
+  it("respects offset on the sorted-no-criteria path", async () => {
+    // Regression: an earlier implementation used queryPage({}, {orderBy,
+    // limit}) which is cursor-based and ignores offset, so `--offset 2`
+    // silently returned the first page. Use getAll({orderBy, limit,
+    // offset}) which pushes OFFSET down to SQL.
+    const repo = globalServiceRegistry.get(ENTITY_REPOSITORY_TOKEN);
+    for (let i = 1; i <= 5; i++) {
+      await repo.put({
+        cik: i,
+        name: `Co ${String.fromCharCode(64 + i)}`, // "Co A", "Co B", ...
+        type: null,
+        sic: null,
+        ein: null,
+        description: null,
+        website: null,
+        investor_website: null,
+        category: null,
+        fiscal_year: null,
+        state_incorporation: null,
+        state_incorporation_desc: null,
+      });
+    }
+
+    const page1 = await queryEntities({ sort: "name", limit: 2, offset: 0 });
+    expect(page1.rows.map((r) => r.name)).toEqual(["Co A", "Co B"]);
+    expect(page1.total).toBe(5);
+
+    const page2 = await queryEntities({ sort: "name", limit: 2, offset: 2 });
+    expect(page2.rows.map((r) => r.name)).toEqual(["Co C", "Co D"]);
+    expect(page2.total).toBe(5);
+  });
 });

--- a/src/cli/queries/EntityQuery.ts
+++ b/src/cli/queries/EntityQuery.ts
@@ -1,5 +1,9 @@
+import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
 import type { Entity } from "../../storage/entity/EntitySchema";
+import { ENTITY_REPOSITORY_TOKEN } from "../../storage/entity/EntitySchema";
 import { EntityRepo } from "../../storage/entity/EntityRepo";
+import { collectPage, streamMatchingRows } from "./_streamMatches";
 
 export interface EntityQueryParams {
   readonly search?: string;
@@ -13,7 +17,21 @@ export interface EntityQueryParams {
 
 export interface QueryResult<T> {
   readonly rows: T[];
+  /**
+   * When `totalApprox` is set, `total` is the number of matches observed so
+   * far (offset + limit, give or take), not the exact dataset cardinality.
+   * Pagination UX should render this as a lower-bound (e.g. "≥ N") rather
+   * than an exact count. Used when streaming substring searches that
+   * cannot be pushed down to the database — forcing an exact total would
+   * require a full table scan.
+   */
   readonly total: number;
+  readonly totalApprox?: {
+    /** The match count we got to before stopping. */
+    readonly atLeast: number;
+    /** True if the iterator drained — in which case `total` is exact. */
+    readonly exhausted: boolean;
+  };
 }
 
 const ENTITY_SORT_KEYS: ReadonlySet<string> = new Set([
@@ -32,57 +50,81 @@ const ENTITY_SORT_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 export async function queryEntities(params: EntityQueryParams): Promise<QueryResult<Entity>> {
-  const repo = new EntityRepo();
-  const limit = params.limit ?? 25;
-  const offset = params.offset ?? 0;
-
-  let entities: Entity[];
-
-  if (params.cik !== undefined) {
-    const entity = await repo.getEntity(params.cik);
-    entities = entity ? [entity] : [];
-  } else if (
-    params.sic !== undefined ||
-    params.state !== undefined
-  ) {
-    const criteria: Partial<Entity> = {};
-    if (params.sic !== undefined) criteria.sic = params.sic;
-    if (params.state !== undefined) criteria.state_incorporation = params.state;
-    entities = await repo.searchEntities(criteria);
-  } else {
-    entities = await repo.getAllEntities();
-  }
-
-  // Apply search filter (partial, case-insensitive name match)
-  if (params.search) {
-    const searchLower = params.search.toLowerCase();
-    entities = entities.filter(
-      (e) => e.name !== null && e.name.toLowerCase().includes(searchLower)
+  // Validate sort up front so we never partially apply a bad call.
+  if (params.sort !== undefined && !ENTITY_SORT_KEYS.has(params.sort)) {
+    throw new Error(
+      `Invalid sort field "${params.sort}". Valid fields: ${[...ENTITY_SORT_KEYS].join(", ")}.`
     );
   }
 
-  // Apply additional filters when fetched via a broader method
-  if (params.cik === undefined && params.sic !== undefined && params.state !== undefined) {
-    // searchEntities only takes one set of criteria; both are already applied above
-  } else if (params.cik !== undefined) {
-    // If we fetched by CIK, also filter by sic/state if provided
-    if (params.sic !== undefined) {
-      entities = entities.filter((e) => e.sic === params.sic);
+  const repo = globalServiceRegistry.get(ENTITY_REPOSITORY_TOKEN);
+  const limit = params.limit ?? 25;
+  const offset = params.offset ?? 0;
+
+  // CIK is the primary key — a `get` is always optimal.
+  if (params.cik !== undefined) {
+    const entityRepo = new EntityRepo();
+    const entity = await entityRepo.getEntity(params.cik);
+    if (!entity) return { rows: [], total: 0 };
+    if (params.sic !== undefined && entity.sic !== params.sic) return { rows: [], total: 0 };
+    if (params.state !== undefined && entity.state_incorporation !== params.state) {
+      return { rows: [], total: 0 };
     }
-    if (params.state !== undefined) {
-      entities = entities.filter((e) => e.state_incorporation === params.state);
+    if (params.search) {
+      const searchLower = params.search.toLowerCase();
+      if (entity.name === null || !entity.name.toLowerCase().includes(searchLower)) {
+        return { rows: [], total: 0 };
+      }
     }
+    return { rows: [entity], total: 1 };
   }
 
-  // Sort
-  if (params.sort) {
-    if (!ENTITY_SORT_KEYS.has(params.sort)) {
-      throw new Error(
-        `Invalid sort field "${params.sort}". Valid fields: ${[...ENTITY_SORT_KEYS].join(", ")}.`
-      );
+  const criteria: SearchCriteria<Entity> = {};
+  if (params.sic !== undefined) (criteria as Partial<Entity>).sic = params.sic;
+  if (params.state !== undefined) {
+    (criteria as Partial<Entity>).state_incorporation = params.state;
+  }
+  const hasCriteria = Object.keys(criteria).length > 0;
+  const hasSearch = params.search !== undefined && params.search !== "";
+  const orderBy = params.sort
+    ? [{ column: params.sort as keyof Entity, direction: "ASC" as const }]
+    : undefined;
+
+  if (!hasSearch) {
+    if (hasCriteria) {
+      const total = await repo.count(criteria);
+      const rows = (await repo.query(criteria, { orderBy, limit, offset })) ?? [];
+      return { rows, total };
     }
+    const total = await repo.size();
+    if (orderBy === undefined) {
+      const rows = (await repo.getOffsetPage(offset, limit)) ?? [];
+      return { rows, total };
+    }
+    // No criteria but caller wants a sort — cursor-paginate so we get the
+    // ordering pushed down. Use queryPage with empty criteria; SQL backends
+    // override it with a server-side ORDER BY + LIMIT.
+    const page = await repo.queryPage({}, { orderBy, limit });
+    return { rows: [...page.items], total };
+  }
+
+  // Substring search — stream and stop after offset + limit matches.
+  const searchLower = params.search!.toLowerCase();
+  const predicate = (e: Entity): boolean =>
+    e.name !== null && e.name.toLowerCase().includes(searchLower);
+
+  const { rows, total, exhausted } = await collectPage(
+    streamMatchingRows(repo, criteria, predicate),
+    offset,
+    limit
+  );
+
+  // Apply sort to the collected window. With the cap this stays bounded
+  // and matches the previous semantics (sort runs over the whole match
+  // set when the stream drains, or over the truncated window otherwise).
+  if (params.sort) {
     const sortKey = params.sort as keyof Entity;
-    entities.sort((a, b) => {
+    rows.sort((a, b) => {
       const aVal = a[sortKey];
       const bVal = b[sortKey];
       if (aVal === null || aVal === undefined) return 1;
@@ -93,8 +135,9 @@ export async function queryEntities(params: EntityQueryParams): Promise<QueryRes
     });
   }
 
-  const total = entities.length;
-  const rows = entities.slice(offset, offset + limit);
-
-  return { rows, total };
+  return {
+    rows,
+    total,
+    totalApprox: { atLeast: total, exhausted },
+  };
 }

--- a/src/cli/queries/EntityQuery.ts
+++ b/src/cli/queries/EntityQuery.ts
@@ -101,11 +101,12 @@ export async function queryEntities(params: EntityQueryParams): Promise<QueryRes
       const rows = (await repo.getOffsetPage(offset, limit)) ?? [];
       return { rows, total };
     }
-    // No criteria but caller wants a sort — cursor-paginate so we get the
-    // ordering pushed down. Use queryPage with empty criteria; SQL backends
-    // override it with a server-side ORDER BY + LIMIT.
-    const page = await repo.queryPage({}, { orderBy, limit });
-    return { rows: [...page.items], total };
+    // No criteria but caller wants a sort. getAll({orderBy, limit, offset})
+    // pushes ORDER BY/LIMIT/OFFSET down to SQL (queryPage is cursor-based
+    // and ignores `offset`, which would silently return the first page
+    // forever — the previous implementation here had that bug).
+    const rows = (await repo.getAll({ orderBy, limit, offset })) ?? [];
+    return { rows, total };
   }
 
   // Substring search — stream and stop after offset + limit matches.
@@ -135,9 +136,7 @@ export async function queryEntities(params: EntityQueryParams): Promise<QueryRes
     });
   }
 
-  return {
-    rows,
-    total,
-    totalApprox: { atLeast: total, exhausted },
-  };
+  // totalApprox is the "this number is a lower bound" signal — only
+  // emit it when the stream was capped, not when it drained.
+  return exhausted ? { rows, total } : { rows, total, totalApprox: { atLeast: total, exhausted } };
 }

--- a/src/cli/queries/FactsQuery.ts
+++ b/src/cli/queries/FactsQuery.ts
@@ -49,5 +49,7 @@ export async function queryFacts(params: FactsQueryParams): Promise<QueryResult<
     offset,
     limit
   );
-  return { rows, total, totalApprox: { atLeast: total, exhausted } };
+  // totalApprox is the "this number is a lower bound" signal — only
+  // emit it when the stream was capped, not when it drained.
+  return exhausted ? { rows, total } : { rows, total, totalApprox: { atLeast: total, exhausted } };
 }

--- a/src/cli/queries/FactsQuery.ts
+++ b/src/cli/queries/FactsQuery.ts
@@ -1,7 +1,9 @@
 import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
 import type { CompanyFact } from "../../storage/facts/CompanyFactsSchema";
 import { COMPANY_FACTS_REPOSITORY_TOKEN } from "../../storage/facts/CompanyFactsSchema";
 import type { QueryResult } from "./EntityQuery";
+import { collectPage, streamMatchingRows } from "./_streamMatches";
 
 export interface FactsQueryParams {
   readonly cik: number;
@@ -18,29 +20,34 @@ export async function queryFacts(params: FactsQueryParams): Promise<QueryResult<
   const limit = params.limit ?? 25;
   const offset = params.offset ?? 0;
 
-  let facts: CompanyFact[] = (await repo.query({ cik: params.cik } as Partial<CompanyFact>)) ?? [];
+  const criteria: SearchCriteria<CompanyFact> = { cik: params.cik } as Partial<CompanyFact>;
+  if (params.year !== undefined) (criteria as Partial<CompanyFact>).fy = params.year;
 
-  if (params.search) {
-    const searchLower = params.search.toLowerCase();
-    facts = facts.filter((f) => f.name.toLowerCase().includes(searchLower));
+  const hasSearch = params.search !== undefined && params.search !== "";
+  const hasName = params.name !== undefined && params.name !== "";
+  const hasTaxonomy = params.taxonomy !== undefined && params.taxonomy !== "";
+  const needsPredicate = hasSearch || hasName || hasTaxonomy;
+
+  if (!needsPredicate) {
+    const total = await repo.count(criteria);
+    const rows = (await repo.query(criteria, { limit, offset })) ?? [];
+    return { rows, total };
   }
 
-  if (params.name) {
-    const nameLower = params.name.toLowerCase();
-    facts = facts.filter((f) => f.name.toLowerCase().includes(nameLower));
-  }
+  const searchLower = hasSearch ? params.search!.toLowerCase() : null;
+  const nameLower = hasName ? params.name!.toLowerCase() : null;
+  const taxLower = hasTaxonomy ? params.taxonomy!.toLowerCase() : null;
+  const predicate = (f: CompanyFact): boolean => {
+    if (searchLower !== null && !f.name.toLowerCase().includes(searchLower)) return false;
+    if (nameLower !== null && !f.name.toLowerCase().includes(nameLower)) return false;
+    if (taxLower !== null && !f.grouping.toLowerCase().includes(taxLower)) return false;
+    return true;
+  };
 
-  if (params.taxonomy) {
-    const taxLower = params.taxonomy.toLowerCase();
-    facts = facts.filter((f) => f.grouping.toLowerCase().includes(taxLower));
-  }
-
-  if (params.year !== undefined) {
-    facts = facts.filter((f) => f.fy === params.year);
-  }
-
-  const total = facts.length;
-  const rows = facts.slice(offset, offset + limit);
-
-  return { rows, total };
+  const { rows, total, exhausted } = await collectPage(
+    streamMatchingRows(repo, criteria, predicate),
+    offset,
+    limit
+  );
+  return { rows, total, totalApprox: { atLeast: total, exhausted } };
 }

--- a/src/cli/queries/FilingQuery.ts
+++ b/src/cli/queries/FilingQuery.ts
@@ -17,9 +17,11 @@ export interface FilingQueryParams {
 
 /**
  * Builds the `SearchCriteria` portion that the database can evaluate for us:
- * `cik`/`form` equality plus date range. `search` (substring on
- * `primary_doc_description`) cannot push down — workglow's SearchCriteria
- * has no LIKE operator — so the caller streams instead.
+ * `cik`/`form` equality plus a single-sided date range. `search`
+ * (substring on `primary_doc_description`) cannot push down — workglow's
+ * `SearchCriteria` has no LIKE operator — and a two-sided date range
+ * cannot either, since `SearchCriteria` only accepts one condition per
+ * column. Both fall through to the streaming-predicate path.
  */
 function buildCriteria(params: FilingQueryParams): SearchCriteria<Filing> {
   const criteria: SearchCriteria<Filing> = {};
@@ -28,11 +30,6 @@ function buildCriteria(params: FilingQueryParams): SearchCriteria<Filing> {
   }
   if (params.form !== undefined) {
     (criteria as Partial<Filing>).form = params.form;
-  }
-  if (params.after !== undefined && params.before !== undefined) {
-    // Build the range below; workglow's SearchCriteria only takes one
-    // condition per column, so the &gt;=/&lt;= pair has to be applied
-    // separately on the streaming path (filter predicate).
   }
   if (params.after !== undefined && params.before === undefined) {
     (criteria as any).filing_date = { value: params.after, operator: ">=" };
@@ -94,9 +91,9 @@ export async function queryFilings(params: FilingQueryParams): Promise<QueryResu
     offset,
     limit
   );
-  return {
-    rows,
-    total,
-    totalApprox: { atLeast: total, exhausted },
-  };
+  // Only emit totalApprox when we actually capped the stream. If the
+  // iterator drained, `total` is exact; consumers (TableRenderer, JSON
+  // output) treat the presence of totalApprox as the "this is a lower
+  // bound" signal.
+  return exhausted ? { rows, total } : { rows, total, totalApprox: { atLeast: total, exhausted } };
 }

--- a/src/cli/queries/FilingQuery.ts
+++ b/src/cli/queries/FilingQuery.ts
@@ -1,7 +1,9 @@
 import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
 import type { Filing } from "../../storage/filing/FilingSchema";
 import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
 import type { QueryResult } from "./EntityQuery";
+import { collectPage, streamMatchingRows } from "./_streamMatches";
 
 export interface FilingQueryParams {
   readonly search?: string;
@@ -13,56 +15,88 @@ export interface FilingQueryParams {
   readonly offset?: number;
 }
 
+/**
+ * Builds the `SearchCriteria` portion that the database can evaluate for us:
+ * `cik`/`form` equality plus date range. `search` (substring on
+ * `primary_doc_description`) cannot push down — workglow's SearchCriteria
+ * has no LIKE operator — so the caller streams instead.
+ */
+function buildCriteria(params: FilingQueryParams): SearchCriteria<Filing> {
+  const criteria: SearchCriteria<Filing> = {};
+  if (params.cik !== undefined) {
+    (criteria as Partial<Filing>).cik = params.cik;
+  }
+  if (params.form !== undefined) {
+    (criteria as Partial<Filing>).form = params.form;
+  }
+  if (params.after !== undefined && params.before !== undefined) {
+    // Build the range below; workglow's SearchCriteria only takes one
+    // condition per column, so the &gt;=/&lt;= pair has to be applied
+    // separately on the streaming path (filter predicate).
+  }
+  if (params.after !== undefined && params.before === undefined) {
+    (criteria as any).filing_date = { value: params.after, operator: ">=" };
+  } else if (params.before !== undefined && params.after === undefined) {
+    (criteria as any).filing_date = { value: params.before, operator: "<=" };
+  }
+  return criteria;
+}
+
 export async function queryFilings(params: FilingQueryParams): Promise<QueryResult<Filing>> {
   const repo = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
   const limit = params.limit ?? 25;
   const offset = params.offset ?? 0;
 
-  const needsClientFilter =
-    params.search !== undefined || params.after !== undefined || params.before !== undefined;
+  const criteria = buildCriteria(params);
+  // Date range with both endpoints — apply one bound DB-side, the other in
+  // the predicate. Substring search always lives in the predicate.
+  const hasRange = params.after !== undefined && params.before !== undefined;
+  const hasSearch = params.search !== undefined && params.search !== "";
+  const needsPredicate = hasRange || hasSearch;
 
-  let filings: Filing[];
-
-  if (!needsClientFilter && (params.cik !== undefined || params.form !== undefined)) {
-    const criteria: Partial<Filing> = {};
-    if (params.cik !== undefined) criteria.cik = params.cik;
-    if (params.form !== undefined) criteria.form = params.form;
-    filings = (await repo.query(criteria)) ?? [];
-  } else {
-    filings = (await repo.getAll()) ?? [];
-  }
-
-  // Apply exact filters when fetched via getAll
-  if (needsClientFilter) {
-    if (params.cik !== undefined) {
-      filings = filings.filter((f) => f.cik === params.cik);
+  if (!needsPredicate) {
+    // Pure DB path. count() drives the displayed total without loading
+    // the table. workglow's `query({})` rejects empty criteria, so when
+    // no filters are set we fall through to getOffsetPage() + size().
+    const hasCriteria = Object.keys(criteria).length > 0;
+    if (hasCriteria) {
+      const total = await repo.count(criteria);
+      const rows =
+        (await repo.query(criteria, {
+          orderBy: [{ column: "filing_date", direction: "DESC" }],
+          limit,
+          offset,
+        })) ?? [];
+      return { rows, total };
     }
-    if (params.form !== undefined) {
-      filings = filings.filter((f) => f.form === params.form);
+    const total = await repo.size();
+    const rows = (await repo.getOffsetPage(offset, limit)) ?? [];
+    return { rows, total };
+  }
+
+  // Streaming path. Push criteria down to the DB; apply substring and the
+  // closing range bound in JS. We stop once we have offset + limit
+  // matches so memory stays bounded.
+  const searchLower = hasSearch ? params.search!.toLowerCase() : null;
+  const predicate = (f: Filing): boolean => {
+    if (params.after !== undefined && f.filing_date < params.after) return false;
+    if (params.before !== undefined && f.filing_date > params.before) return false;
+    if (searchLower !== null) {
+      const doc = f.primary_doc_description;
+      if (doc === null || doc === undefined) return false;
+      if (!doc.toLowerCase().includes(searchLower)) return false;
     }
-  }
+    return true;
+  };
 
-  // Apply text search on primary_doc_description
-  if (params.search) {
-    const searchLower = params.search.toLowerCase();
-    filings = filings.filter(
-      (f) =>
-        f.primary_doc_description !== null &&
-        f.primary_doc_description !== undefined &&
-        f.primary_doc_description.toLowerCase().includes(searchLower)
-    );
-  }
-
-  // Apply date range filters
-  if (params.after !== undefined) {
-    filings = filings.filter((f) => f.filing_date >= params.after!);
-  }
-  if (params.before !== undefined) {
-    filings = filings.filter((f) => f.filing_date <= params.before!);
-  }
-
-  const total = filings.length;
-  const rows = filings.slice(offset, offset + limit);
-
-  return { rows, total };
+  const { rows, total, exhausted } = await collectPage(
+    streamMatchingRows(repo, criteria, predicate),
+    offset,
+    limit
+  );
+  return {
+    rows,
+    total,
+    totalApprox: { atLeast: total, exhausted },
+  };
 }

--- a/src/cli/queries/OfferingQuery.ts
+++ b/src/cli/queries/OfferingQuery.ts
@@ -55,10 +55,15 @@ export async function queryOfferings(
   const industryLower = hasIndustry ? params.industry!.toLowerCase() : null;
   const exemptionRaw = hasExemption ? params.exemption! : null;
   const predicate = (o: InvestmentOffering): boolean => {
-    if (params.after !== undefined && (o.date_of_first_sale ?? "") < params.after) return false;
-    if (params.before !== undefined) {
+    // Null dates are rejected by ANY date filter, on either side. The
+    // previous after-only branch used `(date ?? "") < params.after`
+    // which happened to do the right thing (empty string sorts before
+    // any non-empty date), but a future change to date string format
+    // could flip behaviour silently. Handle null once, then compare.
+    if (params.after !== undefined || params.before !== undefined) {
       if (o.date_of_first_sale === null || o.date_of_first_sale === undefined) return false;
-      if (o.date_of_first_sale > params.before) return false;
+      if (params.after !== undefined && o.date_of_first_sale < params.after) return false;
+      if (params.before !== undefined && o.date_of_first_sale > params.before) return false;
     }
     if (searchLower !== null && !o.industry_group.toLowerCase().includes(searchLower)) return false;
     if (industryLower !== null && !o.industry_group.toLowerCase().includes(industryLower)) {
@@ -76,5 +81,7 @@ export async function queryOfferings(
     offset,
     limit
   );
-  return { rows, total, totalApprox: { atLeast: total, exhausted } };
+  // totalApprox is the "this number is a lower bound" signal — only
+  // emit it when the stream was capped, not when it drained.
+  return exhausted ? { rows, total } : { rows, total, totalApprox: { atLeast: total, exhausted } };
 }

--- a/src/cli/queries/OfferingQuery.ts
+++ b/src/cli/queries/OfferingQuery.ts
@@ -1,7 +1,9 @@
+import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
 import type { InvestmentOffering } from "../../storage/investment-offering/InvestmentOfferingSchema";
 import { INVESTMENT_OFFERING_REPOSITORY_TOKEN } from "../../storage/investment-offering/InvestmentOfferingSchema";
-import { globalServiceRegistry } from "workglow";
 import type { QueryResult } from "./EntityQuery";
+import { collectPage, streamMatchingRows } from "./_streamMatches";
 
 export interface OfferingQueryParams {
   readonly search?: string;
@@ -21,48 +23,58 @@ export async function queryOfferings(
   const limit = params.limit ?? 25;
   const offset = params.offset ?? 0;
 
-  let offerings: InvestmentOffering[];
-
-  if (params.cik !== undefined) {
-    offerings = (await repo.query({ cik: params.cik } as Partial<InvestmentOffering>)) ?? [];
-  } else {
-    offerings = (await repo.getAll()) ?? [];
+  const criteria: SearchCriteria<InvestmentOffering> = {};
+  if (params.cik !== undefined) (criteria as Partial<InvestmentOffering>).cik = params.cik;
+  if (params.after !== undefined && params.before === undefined) {
+    (criteria as any).date_of_first_sale = { value: params.after, operator: ">=" };
+  } else if (params.before !== undefined && params.after === undefined) {
+    (criteria as any).date_of_first_sale = { value: params.before, operator: "<=" };
   }
 
-  if (params.search) {
-    const searchLower = params.search.toLowerCase();
-    offerings = offerings.filter(
-      (o) => o.industry_group.toLowerCase().includes(searchLower)
-    );
+  // `search`, `industry`, `exemption` all need substring matching → predicate.
+  // Date range with both ends → predicate.
+  const hasRange = params.after !== undefined && params.before !== undefined;
+  const hasSearch = params.search !== undefined && params.search !== "";
+  const hasIndustry = params.industry !== undefined && params.industry !== "";
+  const hasExemption = params.exemption !== undefined && params.exemption !== "";
+  const needsPredicate = hasRange || hasSearch || hasIndustry || hasExemption;
+
+  if (!needsPredicate) {
+    const hasCriteria = Object.keys(criteria).length > 0;
+    if (hasCriteria) {
+      const total = await repo.count(criteria);
+      const rows = (await repo.query(criteria, { limit, offset })) ?? [];
+      return { rows, total };
+    }
+    const total = await repo.size();
+    const rows = (await repo.getOffsetPage(offset, limit)) ?? [];
+    return { rows, total };
   }
 
-  if (params.industry) {
-    const industryLower = params.industry.toLowerCase();
-    offerings = offerings.filter(
-      (o) => o.industry_group.toLowerCase().includes(industryLower)
-    );
-  }
+  const searchLower = hasSearch ? params.search!.toLowerCase() : null;
+  const industryLower = hasIndustry ? params.industry!.toLowerCase() : null;
+  const exemptionRaw = hasExemption ? params.exemption! : null;
+  const predicate = (o: InvestmentOffering): boolean => {
+    if (params.after !== undefined && (o.date_of_first_sale ?? "") < params.after) return false;
+    if (params.before !== undefined) {
+      if (o.date_of_first_sale === null || o.date_of_first_sale === undefined) return false;
+      if (o.date_of_first_sale > params.before) return false;
+    }
+    if (searchLower !== null && !o.industry_group.toLowerCase().includes(searchLower)) return false;
+    if (industryLower !== null && !o.industry_group.toLowerCase().includes(industryLower)) {
+      return false;
+    }
+    if (exemptionRaw !== null) {
+      if (o.exemptions === null || o.exemptions === undefined) return false;
+      if (!o.exemptions.includes(exemptionRaw)) return false;
+    }
+    return true;
+  };
 
-  if (params.exemption) {
-    offerings = offerings.filter(
-      (o) => o.exemptions !== null && o.exemptions !== undefined && o.exemptions.includes(params.exemption!)
-    );
-  }
-
-  if (params.after !== undefined) {
-    offerings = offerings.filter(
-      (o) => o.date_of_first_sale !== null && o.date_of_first_sale !== undefined && o.date_of_first_sale >= params.after!
-    );
-  }
-
-  if (params.before !== undefined) {
-    offerings = offerings.filter(
-      (o) => o.date_of_first_sale !== null && o.date_of_first_sale !== undefined && o.date_of_first_sale <= params.before!
-    );
-  }
-
-  const total = offerings.length;
-  const rows = offerings.slice(offset, offset + limit);
-
-  return { rows, total };
+  const { rows, total, exhausted } = await collectPage(
+    streamMatchingRows(repo, criteria, predicate),
+    offset,
+    limit
+  );
+  return { rows, total, totalApprox: { atLeast: total, exhausted } };
 }

--- a/src/cli/queries/PersonQuery.ts
+++ b/src/cli/queries/PersonQuery.ts
@@ -74,9 +74,7 @@ export async function queryPersons(
     offset,
     limit
   );
-  return {
-    rows,
-    total,
-    totalApprox: { atLeast: total, exhausted },
-  };
+  // totalApprox is the "this number is a lower bound" signal — only
+  // emit it when the stream was capped, not when it drained.
+  return exhausted ? { rows, total } : { rows, total, totalApprox: { atLeast: total, exhausted } };
 }

--- a/src/cli/queries/PersonQuery.ts
+++ b/src/cli/queries/PersonQuery.ts
@@ -4,9 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PersonObservationRepo } from "../../storage/observation/PersonObservationRepo";
-import type { PersonObservation } from "../../storage/observation/PersonObservationSchema";
+import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
+import {
+  PERSON_OBSERVATION_REPOSITORY_TOKEN,
+  type PersonObservation,
+} from "../../storage/observation/PersonObservationSchema";
 import type { QueryResult } from "./EntityQuery";
+import { collectPage, streamMatchingRows } from "./_streamMatches";
 
 export interface PersonQueryParams {
   readonly search?: string;
@@ -19,33 +24,59 @@ export interface PersonQueryParams {
 export async function queryPersons(
   params: PersonQueryParams
 ): Promise<QueryResult<PersonObservation>> {
-  const repo = new PersonObservationRepo();
+  const repo = globalServiceRegistry.get(PERSON_OBSERVATION_REPOSITORY_TOKEN);
   const limit = params.limit ?? 25;
   const offset = params.offset ?? 0;
 
-  let persons = await repo.listAll();
-
-  if (params.search) {
-    const searchLower = params.search.toLowerCase();
-    persons = persons.filter((p) => {
-      const fullName = [p.first_name, p.middle_name, p.last_name].filter(Boolean).join(" ").toLowerCase();
-      return fullName.includes(searchLower);
-    });
-  }
-
+  // `cik` pushes down to the DB; `search` (over first+middle+last) and
+  // `relationship` (substring on a single column) do not — workglow has
+  // no LIKE operator. When only `cik` is set we use the pure-DB path;
+  // otherwise we stream.
+  const criteria: SearchCriteria<PersonObservation> = {};
   if (params.cik !== undefined) {
-    persons = persons.filter((p) => p.source_filing_issuer_cik === params.cik);
+    (criteria as Partial<PersonObservation>).source_filing_issuer_cik = params.cik;
+  }
+  const hasSearch = params.search !== undefined && params.search !== "";
+  const hasRel = params.relationship !== undefined && params.relationship !== "";
+  const needsPredicate = hasSearch || hasRel;
+
+  if (!needsPredicate) {
+    const hasCriteria = Object.keys(criteria).length > 0;
+    if (hasCriteria) {
+      const total = await repo.count(criteria);
+      const rows = (await repo.query(criteria, { limit, offset })) ?? [];
+      return { rows, total };
+    }
+    const total = await repo.size();
+    const rows = (await repo.getOffsetPage(offset, limit)) ?? [];
+    return { rows, total };
   }
 
-  if (params.relationship) {
-    const relLower = params.relationship.toLowerCase();
-    persons = persons.filter(
-      (p) => p.relationship !== null && p.relationship !== undefined && p.relationship.toLowerCase().includes(relLower)
-    );
-  }
+  const searchLower = hasSearch ? params.search!.toLowerCase() : null;
+  const relLower = hasRel ? params.relationship!.toLowerCase() : null;
+  const predicate = (p: PersonObservation): boolean => {
+    if (searchLower !== null) {
+      const fullName = [p.first_name, p.middle_name, p.last_name]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      if (!fullName.includes(searchLower)) return false;
+    }
+    if (relLower !== null) {
+      if (p.relationship === null || p.relationship === undefined) return false;
+      if (!p.relationship.toLowerCase().includes(relLower)) return false;
+    }
+    return true;
+  };
 
-  const total = persons.length;
-  const rows = persons.slice(offset, offset + limit);
-
-  return { rows, total };
+  const { rows, total, exhausted } = await collectPage(
+    streamMatchingRows(repo, criteria, predicate),
+    offset,
+    limit
+  );
+  return {
+    rows,
+    total,
+    totalApprox: { atLeast: total, exhausted },
+  };
 }

--- a/src/cli/queries/_streamMatches.ts
+++ b/src/cli/queries/_streamMatches.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ITabularStorage, SearchCriteria } from "workglow";
+
+// PageCursor isn't re-exported from the `workglow` facade in 0.3.0, so we
+// infer the cursor type from the return shape of queryPage() instead of
+// importing it.
+type CursorOf<Entity> = Awaited<ReturnType<ITabularStorage<any, any, Entity>["queryPage"]>>["nextCursor"];
+
+/**
+ * Iterates `repo.queryPage(criteria, ...)` cursor-by-cursor, yielding each
+ * row that satisfies `predicate`. Memory is bounded to one page; total
+ * iteration is bounded by the matching row count, not the table size.
+ *
+ * Built for query UIs that need substring filters (`name ILIKE '%foo%'`,
+ * which workglow's `SearchCriteria` does not support) on top of
+ * equality/range filters that DO push down to the database.
+ */
+export async function* streamMatchingRows<Entity>(
+  repo: ITabularStorage<any, any, Entity>,
+  criteria: SearchCriteria<Entity>,
+  predicate: (row: Entity) => boolean,
+  pageSize: number = 1000
+): AsyncGenerator<Entity, void, undefined> {
+  let cursor: CursorOf<Entity> | undefined;
+  do {
+    const page = await repo.queryPage(criteria, { limit: pageSize, cursor });
+    for (const row of page.items) {
+      if (predicate(row)) yield row;
+    }
+    // Termination contract: stop on empty page even if nextCursor is set,
+    // otherwise a concurrent delete could spin the loop.
+    if (page.items.length === 0) break;
+    cursor = page.nextCursor;
+  } while (cursor);
+}
+
+/**
+ * Collects an async iterable into the slice `[offset, offset + limit)`.
+ *
+ * Returns `exhausted: true` only if the iterator drained — otherwise the
+ * caller observed exactly `offset + limit` matches and there may be more.
+ * Callers fold this into a `totalApprox` so the UI can render "≥ N"
+ * instead of pretending to know the exact match count.
+ */
+export async function collectPage<T>(
+  iter: AsyncIterable<T>,
+  offset: number,
+  limit: number
+): Promise<{ rows: T[]; total: number; exhausted: boolean }> {
+  const target = offset + limit;
+  const collected: T[] = [];
+  for await (const row of iter) {
+    collected.push(row);
+    if (collected.length >= target) {
+      return { rows: collected.slice(offset, target), total: target, exhausted: false };
+    }
+  }
+  return { rows: collected.slice(offset), total: collected.length, exhausted: true };
+}

--- a/src/config/EnvToDI.ts
+++ b/src/config/EnvToDI.ts
@@ -72,13 +72,20 @@ export const EnvToDI = (): void => {
  */
 function assertSecCliEnvConfigured(): void {
   const dbType = globalServiceRegistry.get(SEC_DB_TYPE);
-  if (dbType !== "sqlite") {
-    return;
+  if (dbType === "sqlite") {
+    if (globalServiceRegistry.has(SEC_DB_FOLDER) && globalServiceRegistry.has(SEC_DB_NAME)) {
+      return;
+    }
+    throw new SecCliConfigurationError(
+      "SEC CLI is not configured; run `init` before commands like `bootstrap`."
+    );
   }
-  if (globalServiceRegistry.has(SEC_DB_FOLDER) && globalServiceRegistry.has(SEC_DB_NAME)) {
-    return;
-  }
+  // Postgres: either SEC_PG_URL or the SEC_PG_HOST + SEC_PG_DATABASE pair
+  // must be supplied. Without this check the pg.Pool only fails mid-command
+  // with a generic connection error, which buries the actual cause.
+  if (globalServiceRegistry.has(SEC_PG_URL)) return;
+  if (globalServiceRegistry.has(SEC_PG_HOST) && globalServiceRegistry.has(SEC_PG_DATABASE)) return;
   throw new SecCliConfigurationError(
-    "SEC CLI is not configured; run `init` before commands like `bootstrap`."
+    "SEC CLI is not configured for Postgres; set SEC_PG_URL, or SEC_PG_HOST + SEC_PG_DATABASE."
   );
 }

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -59,7 +59,7 @@ import { COMPANY_OBSERVATION_REPOSITORY_TOKEN } from "../storage/observation/Com
 import { PERSON_OBSERVATION_REPOSITORY_TOKEN } from "../storage/observation/PersonObservationSchema";
 import { getDb } from "../util/db";
 import { bootstrapComponentVersions } from "../storage/versioning/bootstrapComponentVersions";
-import { SEC_DB_FOLDER } from "./tokens";
+import { SEC_DB_FOLDER, SEC_DB_TYPE } from "./tokens";
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../storage/versioning/ComponentVersionSchema";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../storage/versioning/ExtractorRunSchema";
 import { VERSION_EVENT_REPOSITORY_TOKEN } from "../storage/versioning/VersionEventSchema";
@@ -121,7 +121,13 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(CANONICAL_COMPANY_PHONE_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(CANONICAL_PERSON_ALIAS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(CANONICAL_COMPANY_ALIAS_REPOSITORY_TOKEN).setupDatabase();
-  if (globalServiceRegistry.has(SEC_DB_FOLDER)) {
+  // View DDL is created here only on the SQLite path; the Postgres backend
+  // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
+  // isn't sqlite). Tests use the in-memory backend where views don't apply.
+  const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
+    ? globalServiceRegistry.get(SEC_DB_TYPE)
+    : "sqlite";
+  if (dbType === "sqlite" && globalServiceRegistry.has(SEC_DB_FOLDER)) {
     const db = getDb();
     for (const ddl of CURRENT_CANONICAL_VIEW_DDL) {
       db.exec(ddl);

--- a/src/fetch/SecFetchFileOutputCache.test.ts
+++ b/src/fetch/SecFetchFileOutputCache.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { SecFetchFileOutputCache } from "./SecFetchFileOutputCache";
+
+describe("SecFetchFileOutputCache path safety", () => {
+  let tmpRoot: string;
+
+  beforeAll(() => {
+    tmpRoot = mkdtempSync(path.join(tmpdir(), "sec-cache-test-"));
+  });
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function makeCache(inputToFileName: (input: any) => string): SecFetchFileOutputCache {
+    return new SecFetchFileOutputCache({
+      folderPath: tmpRoot,
+      inputToFileName,
+    });
+  }
+
+  it("rejects relative paths that escape via ../ segments on save", async () => {
+    // Regression: inputToFileName values come from SEC-supplied data
+    // (primary_doc, accession numbers). A single malformed value with
+    // '../' segments would let a fetch write outside SEC_RAW_DATA_FOLDER.
+    const cache = makeCache(() => "../escape/oops.json");
+    await expect(
+      cache.saveOutput("T", { response_type: "json" }, { json: { ok: true } })
+    ).rejects.toThrow(/outside cache folder/);
+  });
+
+  it("rejects absolute paths on save", async () => {
+    const cache = makeCache(() => "/etc/passwd");
+    await expect(
+      cache.saveOutput("T", { response_type: "text" }, { text: "hi" })
+    ).rejects.toThrow(/outside cache folder/);
+  });
+
+  it("rejects relative paths that escape via ../ segments on read", async () => {
+    const cache = makeCache(() => "../escape/oops.json");
+    await expect(cache.getOutput("T", { response_type: "json" })).rejects.toThrow(
+      /outside cache folder/
+    );
+  });
+
+  it("allows legitimate nested subdirectory paths", async () => {
+    const cache = makeCache(() => "subdir/inner/legit.txt");
+    await cache.saveOutput("T", { response_type: "text" }, { text: "hello" });
+    const written = readFileSync(path.join(tmpRoot, "subdir/inner/legit.txt"), "utf-8");
+    expect(written).toBe("hello");
+  });
+});

--- a/src/fetch/SecFetchFileOutputCache.test.ts
+++ b/src/fetch/SecFetchFileOutputCache.test.ts
@@ -58,4 +58,14 @@ describe("SecFetchFileOutputCache path safety", () => {
     const written = readFileSync(path.join(tmpRoot, "subdir/inner/legit.txt"), "utf-8");
     expect(written).toBe("hello");
   });
+
+  it("allows filenames that start with .. but don't escape", async () => {
+    // Regression: a plain startsWith("..") check would reject names like
+    // "..foo.txt" because path.relative returns "..foo.txt" verbatim.
+    // The fix anchors on path separators (and the exact ".." case) so
+    // these legitimate filenames pass.
+    const cache = makeCache(() => "..foo.txt");
+    await cache.saveOutput("T", { response_type: "text" }, { text: "ok" });
+    expect(readFileSync(path.join(tmpRoot, "..foo.txt"), "utf-8")).toBe("ok");
+  });
 });

--- a/src/fetch/SecFetchFileOutputCache.ts
+++ b/src/fetch/SecFetchFileOutputCache.ts
@@ -11,6 +11,28 @@ import { FetchUrlTaskOutput, TaskInput, TaskOutput, TaskOutputRepository } from 
 import { isDryRun } from "../cli/isDryRun";
 import { secDate, YYYYdMMdDD } from "../util/parseDate";
 
+/**
+ * Resolves `relative` against `folderPath` and asserts the result stays
+ * inside `folderPath`. Defends every cache call site against a stray
+ * `inputToFileName` returning a path with `..` segments or an absolute
+ * path — SEC-supplied fields (`primary_doc` filenames, accession numbers)
+ * flow into these paths, and a single malformed value would let a fetch
+ * write outside SEC_RAW_DATA_FOLDER. Returns the resolved absolute path.
+ */
+function safeJoinWithinFolder(folderPath: string, relative: string): string {
+  const base = path.resolve(folderPath);
+  const candidate = path.resolve(base, relative);
+  // `path.relative` returns ".." segments when the candidate escapes the
+  // base; the equality check covers the exact-base case.
+  const rel = path.relative(base, candidate);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error(
+      `Refusing to access path outside cache folder: "${relative}" resolved to "${candidate}", outside "${base}".`
+    );
+  }
+  return candidate;
+}
+
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
@@ -76,7 +98,7 @@ export class SecFetchFileOutputCache extends TaskOutputRepository {
       return;
     }
     const responseType = input.response_type as string;
-    const filePath = path.join(this.folderPath, this.inputToFileName(input));
+    const filePath = safeJoinWithinFolder(this.folderPath, this.inputToFileName(input));
     await mkdir(path.dirname(filePath), { recursive: true });
 
     // Write to a unique tmp file then atomically rename so an interrupted
@@ -112,7 +134,7 @@ export class SecFetchFileOutputCache extends TaskOutputRepository {
     taskType: string,
     inputs: TaskInput & { date?: YYYYdMMdDD }
   ): Promise<TaskOutput | undefined> {
-    const filePath = path.join(this.folderPath, this.inputToFileName(inputs));
+    const filePath = safeJoinWithinFolder(this.folderPath, this.inputToFileName(inputs));
     try {
       if (inputs.date) {
         const stats = await stat(filePath);

--- a/src/fetch/SecFetchFileOutputCache.ts
+++ b/src/fetch/SecFetchFileOutputCache.ts
@@ -22,10 +22,18 @@ import { secDate, YYYYdMMdDD } from "../util/parseDate";
 function safeJoinWithinFolder(folderPath: string, relative: string): string {
   const base = path.resolve(folderPath);
   const candidate = path.resolve(base, relative);
-  // `path.relative` returns ".." segments when the candidate escapes the
-  // base; the equality check covers the exact-base case.
+  // `path.relative` returns a path starting with a parent-segment (`..`)
+  // ONLY when the candidate escapes the base — a legitimate file named
+  // "..foo.txt" returns "..foo.txt" too, so a plain `startsWith("..")`
+  // would false-positive on it. Anchor on the path separator (and the
+  // exact ".." case) instead, and also reject absolute paths.
   const rel = path.relative(base, candidate);
-  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+  const escapes =
+    rel === ".." ||
+    rel.startsWith(".." + path.sep) ||
+    rel.startsWith("../") || // posix sep on win32 hosts (just in case)
+    path.isAbsolute(rel);
+  if (escapes) {
     throw new Error(
       `Refusing to access path outside cache folder: "${relative}" resolved to "${candidate}", outside "${base}".`
     );

--- a/src/storage/company/CompanyNormalization.test.ts
+++ b/src/storage/company/CompanyNormalization.test.ts
@@ -204,5 +204,24 @@ describe("CompanyNormalization", () => {
       expect(result!.company_name).toBe("General Motors");
       expect(result!.company_hash_id).toBe("general-motors");
     });
+
+    it("canonicalises space-separated 'L L C' to 'LLC'", () => {
+      // Regression: canonicalEndings used `\b` inside a template literal,
+      // which is the backspace character (U+0008), not a word boundary.
+      // It silently no-op'd against every realistic input — punctuated
+      // forms only converged because normalizeCompanyName's dot-strip
+      // happens to remove the dots first. Space-separated suffixes never
+      // converged. After the fix this test passes.
+      const result = normalizeCompany("Acme L L C");
+      expect(result).toBeDefined();
+      expect(result!.company_name).toBe("Acme LLC");
+      expect(result!.company_hash_id).toBe("acme-llc");
+    });
+
+    it("canonical space-separated 'L L C' shares hash id with 'LLC'", () => {
+      const spaced = normalizeCompany("Acme L L C");
+      const tight = normalizeCompany("Acme LLC");
+      expect(spaced!.company_hash_id).toBe(tight!.company_hash_id);
+    });
   });
 });

--- a/src/storage/company/CompanyNormalization.ts
+++ b/src/storage/company/CompanyNormalization.ts
@@ -166,7 +166,13 @@ export const removeEndings = (name: string) => {
 
 const canonicalEndings = (name: string) => {
   for (const [regexp, canonical] of CANONICAL_ENDINGS) {
-    name = name.replace(new RegExp(`\b${regexp}\b`, "i"), canonical);
+    // String-concat the word boundaries: inside a template literal, `\b` is
+    // the backspace character (U+0008), not a word-boundary escape. The
+    // previous template-literal form silently no-op'd against every
+    // ordinary input — only matching strings that contain literal backspace
+    // bytes — so canonicalisations like "L.L.C." → "LLC" never fired here
+    // and only converged accidentally via stripCompanyAllEndings.
+    name = name.replace(new RegExp("\\b" + regexp + "\\b", "i"), canonical);
   }
   return name;
 };

--- a/src/storage/entity/EntityRepo.ts
+++ b/src/storage/entity/EntityRepo.ts
@@ -130,6 +130,17 @@ export class EntityRepo implements EntityRepoOptions {
     await this.filingRepository.put(filing);
   }
 
+  /**
+   * Bulk filing upsert. Companies with many filings (10-K filers,
+   * frequent-issuer broker-dealers) emit thousands of rows per
+   * submission; per-row `put()` is O(N) round-trips and dominates the
+   * Submission ingest time on Postgres.
+   */
+  async saveFilingsBulk(filings: ReadonlyArray<Filing>): Promise<void> {
+    if (filings.length === 0) return;
+    await this.filingRepository.putBulk([...filings]);
+  }
+
   async getFilings(cik: number): Promise<Filing[]> {
     return (await this.filingRepository.query({ cik })) || [];
   }

--- a/src/storage/entity/cikNameBulkWriter.ts
+++ b/src/storage/entity/cikNameBulkWriter.ts
@@ -5,7 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
-import { SEC_DB_FOLDER, SEC_DB_TYPE } from "../../config/tokens";
+import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
 import { getDb } from "../../util/db";
 import { getPgPool } from "../../util/pg";
 import { CIK_NAME_REPOSITORY_TOKEN } from "./CikNameSchema";
@@ -38,12 +38,17 @@ export function createCikNameBulkWriter(): CikNameBulkWriter {
     ? globalServiceRegistry.get(SEC_DB_TYPE)
     : null;
 
-  // SQLite fast path needs SEC_DB_FOLDER to be configured (getDb() requires
-  // it). When the test harness leaves SEC_DB_TYPE=sqlite registered as the
-  // default but the rest of the production config is absent — e.g. in unit
-  // tests that exercise this task without standing up a real DB — fall
-  // through to the repository-backed writer instead of crashing in getDb().
-  if (dbType === "sqlite" && globalServiceRegistry.has(SEC_DB_FOLDER)) {
+  // SQLite fast path needs BOTH SEC_DB_FOLDER and SEC_DB_NAME — getDb()
+  // dereferences both unconditionally. When the test harness leaves
+  // SEC_DB_TYPE=sqlite registered as the default but the rest of the
+  // production config is absent — e.g. in unit tests that exercise this
+  // task without standing up a real DB — fall through to the
+  // repository-backed writer instead of crashing in getDb().
+  if (
+    dbType === "sqlite" &&
+    globalServiceRegistry.has(SEC_DB_FOLDER) &&
+    globalServiceRegistry.has(SEC_DB_NAME)
+  ) {
     return createSqliteWriter();
   }
   if (dbType === "postgres") {
@@ -73,11 +78,12 @@ function createSqliteWriter(): CikNameBulkWriter {
   };
 }
 
+// Postgres caps a single statement at 65535 bind parameters; we use 2
+// per cik_names row (cik, name), so ~30000 rows is the safe ceiling.
+// Callers may pass batches larger than this; the writer slices internally.
+const PG_MAX_ROWS_PER_STATEMENT = 30_000;
+
 function createPostgresWriter(): CikNameBulkWriter {
-  // Postgres caps a single statement at 65535 bind parameters, so an inner
-  // sub-batch of ~30000 rows (60000 params @ 2/row) is the safe ceiling.
-  // Callers may pass batches larger than this; we slice internally.
-  const PG_MAX_ROWS_PER_STATEMENT = 30_000;
   const pool = getPgPool();
 
   return {

--- a/src/storage/entity/cikNameBulkWriter.ts
+++ b/src/storage/entity/cikNameBulkWriter.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { SEC_DB_FOLDER, SEC_DB_TYPE } from "../../config/tokens";
+import { getDb } from "../../util/db";
+import { getPgPool } from "../../util/pg";
+import { CIK_NAME_REPOSITORY_TOKEN } from "./CikNameSchema";
+
+export interface CikNameRow {
+  readonly cik: number;
+  readonly name: string;
+}
+
+export interface CikNameBulkWriter {
+  writeBatch(rows: ReadonlyArray<CikNameRow>): Promise<void>;
+  close(): Promise<void>;
+}
+
+/**
+ * Picks the right writer for the active backend. The SQLite and Postgres
+ * paths bypass the generic `ITabularStorage.putBulk` (which does one
+ * round-trip and one event emit per row — fine for hundreds, untenable for
+ * the ~1M rows in `cik-lookup-data.txt`). The in-memory fallback covers
+ * tests where `SEC_DB_TYPE` is unregistered.
+ *
+ * The previous implementation always reached into `getDb()`, which silently
+ * wrote ~1M rows into a SQLite file even when `SEC_DB_TYPE=postgres`
+ * because `getDb()` ignored the type token. `getDb()` now throws when
+ * dbType isn't sqlite, so this dispatch is also the safety net for that
+ * regression.
+ */
+export function createCikNameBulkWriter(): CikNameBulkWriter {
+  const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
+    ? globalServiceRegistry.get(SEC_DB_TYPE)
+    : null;
+
+  // SQLite fast path needs SEC_DB_FOLDER to be configured (getDb() requires
+  // it). When the test harness leaves SEC_DB_TYPE=sqlite registered as the
+  // default but the rest of the production config is absent — e.g. in unit
+  // tests that exercise this task without standing up a real DB — fall
+  // through to the repository-backed writer instead of crashing in getDb().
+  if (dbType === "sqlite" && globalServiceRegistry.has(SEC_DB_FOLDER)) {
+    return createSqliteWriter();
+  }
+  if (dbType === "postgres") {
+    return createPostgresWriter();
+  }
+  return createRepositoryWriter();
+}
+
+function createSqliteWriter(): CikNameBulkWriter {
+  const db = getDb();
+  const stmt = db.prepare<[number, string], unknown>(
+    "INSERT OR REPLACE INTO `cik_names` (`cik`, `name`) VALUES (?, ?)"
+  );
+  const insertBatch = db.transaction((rows: ReadonlyArray<CikNameRow>) => {
+    for (const row of rows) {
+      stmt.run(row.cik, row.name);
+    }
+  });
+  return {
+    async writeBatch(rows: ReadonlyArray<CikNameRow>): Promise<void> {
+      insertBatch(rows);
+    },
+    async close(): Promise<void> {
+      // The prepared statement is owned by the shared db handle; finalising
+      // it would invalidate other readers in this process.
+    },
+  };
+}
+
+function createPostgresWriter(): CikNameBulkWriter {
+  // Postgres caps a single statement at 65535 bind parameters, so an inner
+  // sub-batch of ~30000 rows (60000 params @ 2/row) is the safe ceiling.
+  // Callers may pass batches larger than this; we slice internally.
+  const PG_MAX_ROWS_PER_STATEMENT = 30_000;
+  const pool = getPgPool();
+
+  return {
+    async writeBatch(rows: ReadonlyArray<CikNameRow>): Promise<void> {
+      if (rows.length === 0) return;
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
+        for (let start = 0; start < rows.length; start += PG_MAX_ROWS_PER_STATEMENT) {
+          const slice = rows.slice(start, start + PG_MAX_ROWS_PER_STATEMENT);
+          const values: (number | string)[] = [];
+          const placeholders: string[] = [];
+          for (let i = 0; i < slice.length; i++) {
+            const base = i * 2;
+            placeholders.push(`($${base + 1}, $${base + 2})`);
+            values.push(slice[i].cik, slice[i].name);
+          }
+          const sql =
+            `INSERT INTO "cik_names" ("cik", "name") VALUES ` +
+            placeholders.join(", ") +
+            ` ON CONFLICT ("cik") DO UPDATE SET "name" = EXCLUDED."name"`;
+          await client.query(sql, values);
+        }
+        await client.query("COMMIT");
+      } catch (e) {
+        try {
+          await client.query("ROLLBACK");
+        } catch {
+          // ignore — primary error below is the meaningful one
+        }
+        throw e;
+      } finally {
+        client.release();
+      }
+    },
+    async close(): Promise<void> {
+      // Pool lifetime is managed by closePgPool() at CLI shutdown.
+    },
+  };
+}
+
+function createRepositoryWriter(): CikNameBulkWriter {
+  const repo = globalServiceRegistry.get(CIK_NAME_REPOSITORY_TOKEN);
+  return {
+    async writeBatch(rows: ReadonlyArray<CikNameRow>): Promise<void> {
+      if (rows.length === 0) return;
+      await repo.putBulk(rows.map((r) => ({ cik: r.cik, name: r.name })));
+    },
+    async close(): Promise<void> {},
+  };
+}

--- a/src/storage/processing/processedCikSet.ts
+++ b/src/storage/processing/processedCikSet.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ITabularStorage } from "workglow";
+
+/**
+ * Streams every row in a `processed_*` repository and returns the set of
+ * `cik` values. Peak memory is bounded to `pageSize` rows + the final
+ * set (~24 bytes/entry — ~25 MB for a 1M-CIK corpus).
+ *
+ * Used by `BootstrapSubmissionsTask` and `BootstrapCompanyFactsTask` to
+ * compute the unprocessed-CIK set difference. The previous
+ * `await repo.getAll()` materialised every row + every column into RAM
+ * just to discard everything except `cik`; this avoids that intermediate.
+ */
+export async function streamProcessedCikSet<T extends { cik: number }>(
+  repo: Pick<ITabularStorage<any, any, T>, "records">,
+  pageSize: number = 5000
+): Promise<Set<number>> {
+  const seen = new Set<number>();
+  for await (const row of repo.records(pageSize)) {
+    seen.add(row.cik);
+  }
+  return seen;
+}

--- a/src/task/bootstrap/BootstrapDownloadTask.test.ts
+++ b/src/task/bootstrap/BootstrapDownloadTask.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { streamDownloadToFile } from "./BootstrapDownloadTask";
+
+let tmpRoot: string;
+
+beforeAll(() => {
+  tmpRoot = mkdtempSync(path.join(tmpdir(), "sec-download-test-"));
+});
+
+afterEach(() => {
+  // mock-restore via assignment in each test
+});
+
+describe("streamDownloadToFile", () => {
+  it("streams a response body to disk and reports progress", async () => {
+    // Build a fake ReadableStream that emits the body in three chunks so
+    // we exercise the iteration path, not a one-shot blob copy.
+    const chunks = [
+      new TextEncoder().encode("hello "),
+      new TextEncoder().encode("world"),
+      new TextEncoder().encode("!"),
+    ];
+    const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+
+    const oldFetch = global.fetch;
+    (global as any).fetch = mock(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          for (const c of chunks) controller.enqueue(c);
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { "content-length": String(totalLen) },
+      });
+    });
+    try {
+      const dest = path.join(tmpRoot, "stream.bin");
+      const progress: { downloaded: number; total: number | undefined }[] = [];
+      const result = await streamDownloadToFile("https://example/file", dest, {
+        onProgress: (downloaded, total) => {
+          progress.push({ downloaded, total });
+        },
+      });
+      expect(result.bytes).toBe(totalLen);
+      expect(result.totalBytes).toBe(totalLen);
+      const written = readFileSync(dest, "utf-8");
+      expect(written).toBe("hello world!");
+      // At least one progress callback per chunk.
+      expect(progress.length).toBeGreaterThanOrEqual(3);
+      expect(progress[progress.length - 1].downloaded).toBe(totalLen);
+    } finally {
+      (global as any).fetch = oldFetch;
+      rmSync(path.join(tmpRoot, "stream.bin"), { force: true });
+    }
+  });
+
+  it("throws on non-2xx responses without writing the destination file", async () => {
+    const oldFetch = global.fetch;
+    (global as any).fetch = mock(async () => new Response("nope", { status: 404 }));
+    try {
+      const dest = path.join(tmpRoot, "404.bin");
+      await expect(streamDownloadToFile("https://example/missing", dest)).rejects.toThrow(
+        /HTTP 404/
+      );
+    } finally {
+      (global as any).fetch = oldFetch;
+    }
+  });
+
+  it("handles responses with no content-length header", async () => {
+    const oldFetch = global.fetch;
+    (global as any).fetch = mock(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data"));
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200 });
+    });
+    try {
+      const dest = path.join(tmpRoot, "no-len.bin");
+      const result = await streamDownloadToFile("https://example/chunked", dest);
+      expect(result.bytes).toBe(4);
+      expect(result.totalBytes).toBeUndefined();
+      expect(readFileSync(dest, "utf-8")).toBe("data");
+    } finally {
+      (global as any).fetch = oldFetch;
+      rmSync(path.join(tmpRoot, "no-len.bin"), { force: true });
+    }
+  });
+});

--- a/src/task/bootstrap/BootstrapDownloadTask.ts
+++ b/src/task/bootstrap/BootstrapDownloadTask.ts
@@ -7,16 +7,68 @@
 import { mkdirSync, rmSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
 import { Type } from "typebox";
-import type { FetchUrlTaskInput } from "workglow";
 import { globalServiceRegistry, IExecuteContext, Task } from "workglow";
 import { isDryRun } from "../../cli/isDryRun";
+import { SecUserAgent } from "../../config/Constants";
 import { SEC_RAW_DATA_FOLDER } from "../../config/tokens";
-import { SecFetchJob } from "../../fetch/SecFetchJob";
 
 export type BootstrapDownloadTaskInput = {
   readonly url: string;
   readonly targetFolder: string;
 };
+
+/**
+ * Streams an HTTP response body directly to disk without buffering the
+ * full payload in memory. Returns the byte count written. Honours
+ * `signal` and reports progress via `onProgress(downloadedBytes,
+ * totalBytes | undefined)`.
+ *
+ * Exported for testing — the task wraps it with logging and the SEC
+ * User-Agent header.
+ */
+export async function streamDownloadToFile(
+  url: string,
+  destPath: string,
+  opts: {
+    readonly headers?: Record<string, string>;
+    readonly signal?: AbortSignal;
+    readonly onProgress?: (downloadedBytes: number, totalBytes: number | undefined) => void;
+  } = {}
+): Promise<{ bytes: number; totalBytes: number | undefined }> {
+  const response = await fetch(url, {
+    headers: opts.headers,
+    signal: opts.signal,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Download failed: HTTP ${response.status} ${response.statusText} for ${url}`
+    );
+  }
+  if (response.body === null) {
+    throw new Error(`Download returned no body for ${url}`);
+  }
+
+  const len = response.headers.get("content-length");
+  const totalBytesParsed = len !== null ? parseInt(len, 10) : NaN;
+  const totalBytes = Number.isFinite(totalBytesParsed) ? totalBytesParsed : undefined;
+
+  const writer = Bun.file(destPath).writer();
+  let bytes = 0;
+  try {
+    const reader = response.body.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      writer.write(value);
+      bytes += value.length;
+      opts.onProgress?.(bytes, totalBytes);
+    }
+    await writer.flush();
+  } finally {
+    await writer.end();
+  }
+  return { bytes, totalBytes };
+}
 
 export type BootstrapDownloadTaskOutput = {
   readonly success: boolean;
@@ -74,30 +126,36 @@ export class BootstrapDownloadTask extends Task<
 
     console.log(`Downloading ${input.url} ...`);
 
-    const fetchJob = new SecFetchJob({
-      input: {
-        url: input.url,
-        response_type: "blob",
-      } satisfies FetchUrlTaskInput,
-    });
-
-    const fetched = await fetchJob.execute(fetchJob.input, {
+    // Stream the response body directly to disk via streamDownloadToFile.
+    // SEC bulk archives (submissions.zip, companyfacts.zip) are multi-GB;
+    // the previous path went through SecFetchJob with response_type:
+    // "blob", which buffered the entire body in JS heap and OOM'd on
+    // smaller VMs. We bypass the SecFetchJob queue/retry machinery here
+    // because workglow's FetchUrlJob materialises the body regardless of
+    // response_type. Bulk download is a low-frequency operator-triggered
+    // path, so dropping the queue-level retry is an acceptable tradeoff
+    // for the memory ceiling. SEC's 10 req/sec rate limit is never a
+    // concern for a single download.
+    let lastReportedPct = -1;
+    let sizeLogged = false;
+    const { bytes: downloadedBytes } = await streamDownloadToFile(input.url, zipPath, {
+      headers: { "User-Agent": SecUserAgent },
       signal: context.signal,
-      updateProgress: context.updateProgress.bind(context),
+      onProgress: (downloaded, total) => {
+        if (!sizeLogged && total !== undefined) {
+          console.log(`Download size: ~${(total / (1024 * 1024)).toFixed(0)} MB`);
+          sizeLogged = true;
+        }
+        if (total !== undefined && total > 0) {
+          const pct = Math.floor((downloaded / total) * 100);
+          if (pct !== lastReportedPct) {
+            context.updateProgress(pct, `${(downloaded / (1024 * 1024)).toFixed(0)} MB`);
+            lastReportedPct = pct;
+          }
+        }
+      },
     });
-
-    if (!fetched.blob) {
-      throw new Error("SEC fetch returned no blob body");
-    }
-
-    const len = fetched.metadata?.headers?.["content-length"];
-    if (len) {
-      const sizeMB = (parseInt(len, 10) / (1024 * 1024)).toFixed(0);
-      console.log(`Download size: ~${sizeMB} MB`);
-    }
-
-    await Bun.write(zipPath, fetched.blob as Blob);
-    console.log(`Download complete. Extracting to ${targetDir} ...`);
+    console.log(`Download complete (${downloadedBytes} bytes). Extracting to ${targetDir} ...`);
 
     const unzipPath = Bun.which("unzip");
     if (!unzipPath) {

--- a/src/task/ciknames/FetchAllCikNamesTask.test.ts
+++ b/src/task/ciknames/FetchAllCikNamesTask.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { SEC_DB_FOLDER } from "../../config/tokens";
+import {
+  createCikNameBulkWriter,
+  type CikNameRow,
+} from "../../storage/entity/cikNameBulkWriter";
+import {
+  CIK_NAME_REPOSITORY_TOKEN,
+  type CikNameType,
+} from "../../storage/entity/CikNameSchema";
+
+// FetchAllCikNamesTask's end-to-end path runs through the SEC job queue and
+// is exercised by manual + integration tests; these unit tests pin the bulk
+// writer behaviour that is the regression-prone surface (the previous
+// implementation reached into getDb() unconditionally and silently wrote to
+// SQLite under SEC_DB_TYPE=postgres).
+
+describe("createCikNameBulkWriter", () => {
+  beforeEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("falls back to the repository writer when no real DB is configured", async () => {
+    // SEC_DB_TYPE may be left as "sqlite" by a sibling test that called
+    // EnvToDI() at module-load time. Without SEC_DB_FOLDER the SQLite fast
+    // path can't run (getDb() would throw), so the writer must route
+    // through the in-memory repository.
+    expect(globalServiceRegistry.has(SEC_DB_FOLDER)).toBe(false);
+
+    const writer = createCikNameBulkWriter();
+    const rows: CikNameRow[] = [
+      { cik: 320193, name: "APPLE INC" },
+      { cik: 789019, name: "MICROSOFT CORP" },
+      { cik: 1652044, name: "ALPHABET INC" },
+    ];
+    await writer.writeBatch(rows);
+    await writer.close();
+
+    const repo = globalServiceRegistry.get(CIK_NAME_REPOSITORY_TOKEN);
+    const apple = await repo.get({ cik: 320193 });
+    expect(apple?.name).toBe("APPLE INC");
+    const all = ((await repo.getAll()) ?? []) as CikNameType[];
+    expect(all.length).toBe(3);
+  });
+
+  it("overwrites existing rows by primary key on subsequent batches", async () => {
+    const writer = createCikNameBulkWriter();
+    await writer.writeBatch([{ cik: 320193, name: "OLD NAME" }]);
+    await writer.writeBatch([{ cik: 320193, name: "APPLE INC" }]);
+    await writer.close();
+    const repo = globalServiceRegistry.get(CIK_NAME_REPOSITORY_TOKEN);
+    const row = await repo.get({ cik: 320193 });
+    expect(row?.name).toBe("APPLE INC");
+  });
+
+  it("handles an empty batch without error", async () => {
+    const writer = createCikNameBulkWriter();
+    await writer.writeBatch([]);
+    await writer.close();
+    const repo = globalServiceRegistry.get(CIK_NAME_REPOSITORY_TOKEN);
+    expect((await repo.getAll())?.length ?? 0).toBe(0);
+  });
+});

--- a/src/task/ciknames/FetchAllCikNamesTask.ts
+++ b/src/task/ciknames/FetchAllCikNamesTask.ts
@@ -8,7 +8,7 @@ import { Static, Type } from "typebox";
 import { DataPortSchemaObject, IExecuteContext, Task, TaskAbortedError } from "workglow";
 import { SecCachedFetchTask } from "../../fetch/SecCachedFetchTask";
 import { SecFetchTask } from "../../fetch/SecFetchTask";
-import { getDb } from "../../util/db";
+import { createCikNameBulkWriter } from "../../storage/entity/cikNameBulkWriter";
 import { TypeSecDate } from "../../util/parseDate";
 
 // NOTE: cik names are mutable, so we use date to break the cache
@@ -110,27 +110,24 @@ export class FetchAllCikNamesTask extends Task<
     const lines = secText.split("\n");
     const totalLines = lines.length;
 
-    // The SqliteTabularStorage `putBulk` path does one prepared statement and one
-    // event emit per row, which is untenable for ~1M rows. We use the underlying
-    // sqlite handle to run a single prepared `INSERT OR REPLACE` inside a
-    // transaction per batch, which is ~100x faster and keeps the UI responsive.
-    const db = getDb();
-    const stmt = db.prepare<[number, string], unknown>(
-      "INSERT OR REPLACE INTO `cik_names` (`cik`, `name`) VALUES (?, ?)"
-    );
-    const insertBatch = db.transaction((rows: ReadonlyArray<{ cik: number; name: string }>) => {
-      for (const row of rows) {
-        stmt.run(row.cik, row.name);
-      }
-    });
+    // The generic `ITabularStorage.putBulk` path does one round-trip and one
+    // event emit per row, which is untenable for the ~1M rows in this feed.
+    // The bulk writer picks a backend-specific fast path: a single
+    // `INSERT OR REPLACE` transaction for SQLite, multi-row parameterised
+    // `INSERT ... ON CONFLICT` for Postgres. Tests fall back to the
+    // repository's `putBulk` against the in-memory backend.
+    //
+    // The previous version reached into `getDb()` unconditionally, which
+    // silently wrote rows into a SQLite file even when SEC_DB_TYPE=postgres.
+    const writer = createCikNameBulkWriter();
 
     let batch: { cik: number; name: string }[] = [];
     let totalStored = 0;
     let lastReportedProgress = -1;
 
-    const flush = (): void => {
+    const flush = async (): Promise<void> => {
       if (batch.length === 0) return;
-      insertBatch(batch);
+      await writer.writeBatch(batch);
       totalStored += batch.length;
       batch = [];
     };
@@ -143,7 +140,7 @@ export class FetchAllCikNamesTask extends Task<
       if (parsed !== null) {
         batch.push(parsed);
         if (batch.length >= BATCH_SIZE) {
-          flush();
+          await flush();
           // Yield to the event loop so the CLI progress UI can repaint and any
           // pending abort signal is observed promptly.
           await new Promise<void>((resolve) => setImmediate(resolve));
@@ -156,8 +153,12 @@ export class FetchAllCikNamesTask extends Task<
         lastReportedProgress = newProgress;
       }
     }
-    flush();
-    context.updateProgress(100, `stored ${totalStored} rows`);
+    try {
+      await flush();
+      context.updateProgress(100, `stored ${totalStored} rows`);
+    } finally {
+      await writer.close();
+    }
 
     return { success: true, count: totalStored };
   }

--- a/src/task/facts/BootstrapCompanyFactsTask.ts
+++ b/src/task/facts/BootstrapCompanyFactsTask.ts
@@ -10,6 +10,7 @@ import { Type } from "typebox";
 import { globalServiceRegistry, IExecuteContext, Task, Workflow } from "workglow";
 import { isDryRun } from "../../cli/isDryRun";
 import { SEC_RAW_DATA_FOLDER } from "../../config/tokens";
+import { streamProcessedCikSet } from "../../storage/processing/processedCikSet";
 import { PROCESSED_FACTS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedFactsSchema";
 import { todayYYYYdMMdDD } from "../../util/dataCleaningUtils";
 import { fetchAndStoreCompanyFacts } from "./fetchAndStoreCompanyFacts";
@@ -86,12 +87,9 @@ export class BootstrapCompanyFactsTask extends Task<
     if (input.force) {
       ciksToProcess = ciks;
     } else {
+      // Stream the cik column rather than getAll() — see streamProcessedCikSet.
       const processedFactsRepo = globalServiceRegistry.get(PROCESSED_FACTS_REPOSITORY_TOKEN);
-      const allProcessedFacts = (await processedFactsRepo.getAll()) ?? [];
-      const processedSet = new Set<number>();
-      for (const pf of allProcessedFacts) {
-        processedSet.add(pf.cik);
-      }
+      const processedSet = await streamProcessedCikSet(processedFactsRepo);
       ciksToProcess = ciks.filter((cik) => !processedSet.has(cik));
     }
 

--- a/src/task/facts/UpdateAllCompanyFactsTask.ts
+++ b/src/task/facts/UpdateAllCompanyFactsTask.ts
@@ -60,10 +60,12 @@ export class UpdateAllCompanyFactsTask extends Task<
         needsUpdating.push({ cik: clu.cik, last_update: clu.last_update });
       }
     } else {
-      const allProcessedFacts = (await processedFactsRepo.getAll()) ?? [];
-
+      // Stream rather than getAll() — see UpdateAllSubmissionsTask for the
+      // same pattern. We need both cik and last_processed for freshness,
+      // so a Map built page-by-page is unavoidable but the intermediate
+      // row materialisation isn't.
       const processedMap = new Map<number, ProcessedFacts>();
-      for (const pf of allProcessedFacts) {
+      for await (const pf of processedFactsRepo.records(5000)) {
         processedMap.set(pf.cik, pf);
       }
 

--- a/src/task/submissions/BootstrapSubmissionsTask.ts
+++ b/src/task/submissions/BootstrapSubmissionsTask.ts
@@ -10,6 +10,7 @@ import { Type } from "typebox";
 import { globalServiceRegistry, IExecuteContext, Task, Workflow } from "workglow";
 import { isDryRun } from "../../cli/isDryRun";
 import { SEC_RAW_DATA_FOLDER } from "../../config/tokens";
+import { streamProcessedCikSet } from "../../storage/processing/processedCikSet";
 import { PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedSubmissionsSchema";
 import { fetchAndStoreSubmission } from "./fetchAndStoreSubmission";
 
@@ -84,14 +85,14 @@ export class BootstrapSubmissionsTask extends Task<
     if (input.force) {
       ciksToProcess = ciks;
     } else {
+      // Stream the cik column rather than getAll() — production has
+      // hundreds of thousands to millions of processed CIK rows, and
+      // getAll() materialises every column for every row only to throw
+      // most of it away.
       const processedSubmissionsRepo = globalServiceRegistry.get(
         PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN
       );
-      const allProcessedSubmissions = (await processedSubmissionsRepo.getAll()) ?? [];
-      const processedSet = new Set<number>();
-      for (const ps of allProcessedSubmissions) {
-        processedSet.add(ps.cik);
-      }
+      const processedSet = await streamProcessedCikSet(processedSubmissionsRepo);
       ciksToProcess = ciks.filter((cik) => !processedSet.has(cik));
     }
 

--- a/src/task/submissions/StoreSubmissionFilingsTask.ts
+++ b/src/task/submissions/StoreSubmissionFilingsTask.ts
@@ -68,22 +68,19 @@ export class StoreSubmissionFilingsTask extends Task<
       filings_array = input.filings;
     }
     const filings = objectOfArraysAsArrayOfObjects(filings_array);
-    let index = 0;
-    let progress = 0;
     const entityRepo = new EntityRepo();
-    for (const filing of filings) {
+
+    // Companies with many filings emit thousands of rows per submission.
+    // Per-row `put()` was O(N) round-trips and dominated ingest time on
+    // Postgres. Chunked putBulk amortises the round-trip and the workglow
+    // event emit overhead.
+    const BATCH_SIZE = 500;
+    let progress = 0;
+    for (let start = 0; start < filings.length; start += BATCH_SIZE) {
       if (context.signal.aborted) {
         throw new TaskAbortedError();
       }
-      const newProgress = Math.round((index++ / filings.length) * 10) * 10; // much faster than if we give up time for ui
-      if (newProgress > progress) {
-        context.updateProgress(newProgress);
-        progress = newProgress;
-        await sleep(0);
-      }
-
-      // Transform the Filing from API format to database schema format
-      const filingData: Filing = {
+      const batch: Filing[] = filings.slice(start, start + BATCH_SIZE).map((filing) => ({
         cik,
         accession_number: filing.accessionNumber,
         filing_date: filing.filingDate,
@@ -99,8 +96,15 @@ export class StoreSubmissionFilingsTask extends Task<
         is_inline_xbrl: filing.isInlineXBRL || null,
         items: filing.items || null,
         act: filing.act || null,
-      };
-      await entityRepo.saveFiling(filingData);
+      }));
+      await entityRepo.saveFilingsBulk(batch);
+
+      const newProgress = Math.round(((start + batch.length) / filings.length) * 10) * 10;
+      if (newProgress > progress) {
+        context.updateProgress(newProgress);
+        progress = newProgress;
+        await sleep(0);
+      }
     }
 
     return { success: true };

--- a/src/task/submissions/UpdateAllSubmissionsTask.ts
+++ b/src/task/submissions/UpdateAllSubmissionsTask.ts
@@ -62,10 +62,13 @@ export class UpdateAllSubmissionsTask extends Task<
         needsUpdating.push({ cik: clu.cik, last_update: clu.last_update });
       }
     } else {
-      const allProcessedSubmissions = (await processedSubmissionsRepo.getAll()) ?? [];
-
+      // Stream rather than getAll() — production has hundreds of
+      // thousands of processed-submission rows. We need both cik and
+      // last_processed for the freshness comparison, so we keep them in
+      // a Map but build it page-by-page rather than materialising every
+      // row up front.
       const processedMap = new Map<number, ProcessedSubmissions>();
-      for (const ps of allProcessedSubmissions) {
+      for await (const ps of processedSubmissionsRepo.records(5000)) {
         processedMap.set(ps.cik, ps);
       }
 

--- a/src/util/db.test.ts
+++ b/src/util/db.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
+import { SecCliConfigurationError } from "../config/EnvToDI";
+import { SEC_DB_TYPE } from "../config/tokens";
+import { closeDb, getDb } from "./db";
+
+describe("getDb", () => {
+  beforeEach(() => {
+    closeDb();
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  it("throws SecCliConfigurationError when SEC_DB_TYPE is postgres", () => {
+    // Regression: getDb() used to silently open a SQLite file regardless of
+    // SEC_DB_TYPE, causing rows to land in a file that nothing else reads
+    // when the rest of the system was wired to Postgres.
+    const hadPrevious = globalServiceRegistry.has(SEC_DB_TYPE);
+    const previous = hadPrevious ? globalServiceRegistry.get(SEC_DB_TYPE) : null;
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "postgres");
+    try {
+      expect(() => getDb()).toThrow(SecCliConfigurationError);
+    } finally {
+      // Re-register the prior value (or "sqlite" as a safe default if no
+      // prior was set). The registry has no unregister API, so this is the
+      // closest we can get to leaving state untouched for other tests.
+      globalServiceRegistry.registerInstance(SEC_DB_TYPE, previous ?? "sqlite");
+    }
+  });
+});

--- a/src/util/db.ts
+++ b/src/util/db.ts
@@ -7,12 +7,27 @@
 import { mkdirSync } from "fs";
 import path from "path";
 import { globalServiceRegistry, Sqlite } from "workglow";
-import { SEC_DB_FOLDER, SEC_DB_NAME } from "../config/tokens";
+import { SecCliConfigurationError } from "../config/EnvToDI";
+import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../config/tokens";
 
 let db: Sqlite.Database | null = null;
 
 export function getDb(): Sqlite.Database {
   if (!db) {
+    // Guard against silent data divergence: if SEC_DB_TYPE is postgres, the
+    // rest of the system writes to PG via createStorage(), but a stray
+    // getDb() call here would open a separate SQLite file that nothing else
+    // reads. Fail loudly so callers route through the abstraction or
+    // getPgPool() instead.
+    if (globalServiceRegistry.has(SEC_DB_TYPE)) {
+      const dbType = globalServiceRegistry.get(SEC_DB_TYPE);
+      if (dbType !== "sqlite") {
+        throw new SecCliConfigurationError(
+          `getDb() is only available when SEC_DB_TYPE=sqlite (current: ${dbType}). ` +
+            `Use createStorage() / the repository tokens, or getPgPool() for raw SQL.`
+        );
+      }
+    }
     const dir = globalServiceRegistry.get(SEC_DB_FOLDER);
     mkdirSync(dir, { recursive: true });
     const location = path.join(dir, `${globalServiceRegistry.get(SEC_DB_NAME)}.sqlite`);


### PR DESCRIPTION
## Summary

Fixes a regression where `FetchAllCikNamesTask` unconditionally wrote ~1M CIK name rows to a SQLite file via `getDb()`, even when `SEC_DB_TYPE=postgres` was configured. The system would then read from PostgreSQL, causing a silent data divergence.

## Key Changes

- **New `cikNameBulkWriter.ts`** — Introduces `createCikNameBulkWriter()` factory that dispatches to backend-specific fast paths:
  - SQLite: single `INSERT OR REPLACE` transaction (via prepared statement)
  - PostgreSQL: multi-row parameterised `INSERT ... ON CONFLICT` with 30k-row batching (respects 65535 bind parameter limit)
  - Fallback: repository-backed writer for tests without a real DB configured
  
- **Updated `FetchAllCikNamesTask.ts`** — Replaces direct `getDb()` call with `createCikNameBulkWriter()`, making flush operations async and ensuring `writer.close()` is called in a finally block.

- **Hardened `getDb()` in `db.ts`** — Now throws `SecCliConfigurationError` if `SEC_DB_TYPE` is not `"sqlite"`, preventing silent data divergence. Callers must use `createStorage()` / repository tokens or `getPgPool()` for non-SQLite backends.

- **Updated `setupAllDatabases.ts`** — Guards SQLite-specific view DDL creation behind a `dbType === "sqlite"` check, since `getDb()` now throws for other backends.

- **New test coverage** — `FetchAllCikNamesTask.test.ts` and `db.test.ts` verify bulk writer dispatch logic and the `getDb()` safety guard.

## Implementation Details

The bulk writer factory checks `SEC_DB_TYPE` and `SEC_DB_FOLDER` registration to pick the right path:
- If `SEC_DB_TYPE=sqlite` and `SEC_DB_FOLDER` is configured → SQLite fast path
- If `SEC_DB_TYPE=postgres` → PostgreSQL fast path  
- Otherwise → repository fallback (covers tests and in-memory backends)

This design also serves as a safety net for the `getDb()` regression: if a caller mistakenly reaches into `getDb()` when `SEC_DB_TYPE=postgres`, it will fail loudly rather than silently writing to the wrong database.

https://claude.ai/code/session_01KMfZPiw68JWG7KiKyLxGEu