### PR TITLE
feat(forms): ingest Section 16 (3/4/5) and Form 144 ownership filings

### DIFF
--- a/src/cli/groups/version.test.ts
+++ b/src/cli/groups/version.test.ts
@@ -50,7 +50,7 @@ describe("sec version CLI", () => {
         .filter((r: { component_kind: string }) => r.component_kind === "extractor")
         .map((r: { component_id: string }) => r.component_id)
         .sort();
-      expect(ids).toEqual(["1-A", "1-K", "1-Z", "3", "4", "5", "C", "D"]);
+      expect(ids).toEqual(["1-A", "1-K", "1-Z", "144", "3", "4", "5", "C", "D"]);
       const extractorRows = parsed.filter(
         (r: { component_kind: string }) => r.component_kind === "extractor"
       );

--- a/src/cli/groups/version.test.ts
+++ b/src/cli/groups/version.test.ts
@@ -44,13 +44,13 @@ describe("sec version CLI", () => {
       const status = await runCli(["version", "status", "--format", "json"], dir);
       expect(status.exitCode).toBe(0);
       const parsed = JSON.parse(status.stdout);
-      // PR2 wires bootstrapExtractorVersions() into db setup; expect the
-      // five extractor ids registered at 1.0.0 in the current slot.
+      // PR2 wires bootstrapExtractorVersions() into db setup; expect every
+      // extractor id registered at 1.0.0 in the current slot.
       const ids = parsed
         .filter((r: { component_kind: string }) => r.component_kind === "extractor")
         .map((r: { component_id: string }) => r.component_id)
         .sort();
-      expect(ids).toEqual(["1-A", "1-K", "1-Z", "C", "D"]);
+      expect(ids).toEqual(["1-A", "1-K", "1-Z", "3", "4", "5", "C", "D"]);
       const extractorRows = parsed.filter(
         (r: { component_kind: string }) => r.component_kind === "extractor"
       );

--- a/src/cli/queries/DbStatus.ts
+++ b/src/cli/queries/DbStatus.ts
@@ -9,6 +9,11 @@ import { INVESTMENT_OFFERING_REPOSITORY_TOKEN } from "../../storage/investment-o
 import { PHONE_REPOSITORY_TOKEN } from "../../storage/phone/PhoneSchema";
 import { CROWDFUNDING_REPOSITORY_TOKEN } from "../../storage/portal/CrowdfundingSchema";
 import { PORTAL_REPOSITORY_TOKEN } from "../../storage/portal/PortalSchema";
+import {
+  SECTION16_FILING_REPOSITORY_TOKEN,
+  SECTION16_HOLDING_REPOSITORY_TOKEN,
+  SECTION16_TRANSACTION_REPOSITORY_TOKEN,
+} from "../../storage/section16/Section16Schema";
 import { PROCESSED_FACTS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedFactsSchema";
 import { PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedSubmissionsSchema";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
@@ -90,6 +95,9 @@ const TABLE_TOKENS: ReadonlyArray<{
   { table: "canonical_company", token: CANONICAL_COMPANY_REPOSITORY_TOKEN as any },
   { table: "person_identity_link", token: PERSON_IDENTITY_LINK_REPOSITORY_TOKEN as any },
   { table: "company_identity_link", token: COMPANY_IDENTITY_LINK_REPOSITORY_TOKEN as any },
+  { table: "section16_filings", token: SECTION16_FILING_REPOSITORY_TOKEN as any },
+  { table: "section16_transactions", token: SECTION16_TRANSACTION_REPOSITORY_TOKEN as any },
+  { table: "section16_holdings", token: SECTION16_HOLDING_REPOSITORY_TOKEN as any },
 ];
 
 export async function getDbStats(): Promise<TableStat[]> {

--- a/src/cli/queries/DbStatus.ts
+++ b/src/cli/queries/DbStatus.ts
@@ -14,6 +14,11 @@ import {
   SECTION16_HOLDING_REPOSITORY_TOKEN,
   SECTION16_TRANSACTION_REPOSITORY_TOKEN,
 } from "../../storage/section16/Section16Schema";
+import {
+  FORM144_ACQUISITION_REPOSITORY_TOKEN,
+  FORM144_FILING_REPOSITORY_TOKEN,
+  FORM144_RECENT_SALE_REPOSITORY_TOKEN,
+} from "../../storage/form144/Form144Schema";
 import { PROCESSED_FACTS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedFactsSchema";
 import { PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedSubmissionsSchema";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
@@ -98,6 +103,9 @@ const TABLE_TOKENS: ReadonlyArray<{
   { table: "section16_filings", token: SECTION16_FILING_REPOSITORY_TOKEN as any },
   { table: "section16_transactions", token: SECTION16_TRANSACTION_REPOSITORY_TOKEN as any },
   { table: "section16_holdings", token: SECTION16_HOLDING_REPOSITORY_TOKEN as any },
+  { table: "form144_filings", token: FORM144_FILING_REPOSITORY_TOKEN as any },
+  { table: "form144_acquisitions", token: FORM144_ACQUISITION_REPOSITORY_TOKEN as any },
+  { table: "form144_recent_sales", token: FORM144_RECENT_SALE_REPOSITORY_TOKEN as any },
 ];
 
 export async function getDbStats(): Promise<TableStat[]> {

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -105,6 +105,17 @@ import {
   PortalSchema,
 } from "../storage/portal/PortalSchema";
 import {
+  SECTION16_FILING_REPOSITORY_TOKEN,
+  SECTION16_HOLDING_REPOSITORY_TOKEN,
+  SECTION16_TRANSACTION_REPOSITORY_TOKEN,
+  Section16FilingPrimaryKeyNames,
+  Section16FilingSchema,
+  Section16HoldingPrimaryKeyNames,
+  Section16HoldingSchema,
+  Section16TransactionPrimaryKeyNames,
+  Section16TransactionSchema,
+} from "../storage/section16/Section16Schema";
+import {
   CIK_LAST_UPDATE_REPOSITORY_TOKEN,
   CikLastUpdatePrimaryKeyNames,
   CikLastUpdateSchema,
@@ -355,6 +366,31 @@ export const DefaultDI = () => {
       CrowdfundingHistoryPrimaryKeyNames,
       [["cik", "file_number"]]
     )
+  );
+
+  // ------------------------------ Section 16 (Forms 3/4/5) --------------------------------
+  globalServiceRegistry.registerInstance(
+    SECTION16_FILING_REPOSITORY_TOKEN,
+    createStorage("section16_filings", Section16FilingSchema, Section16FilingPrimaryKeyNames, [
+      ["issuer_cik"],
+      ["form"],
+    ])
+  );
+  globalServiceRegistry.registerInstance(
+    SECTION16_TRANSACTION_REPOSITORY_TOKEN,
+    createStorage(
+      "section16_transactions",
+      Section16TransactionSchema,
+      Section16TransactionPrimaryKeyNames,
+      [["accession_number"], ["issuer_cik"]]
+    )
+  );
+  globalServiceRegistry.registerInstance(
+    SECTION16_HOLDING_REPOSITORY_TOKEN,
+    createStorage("section16_holdings", Section16HoldingSchema, Section16HoldingPrimaryKeyNames, [
+      ["accession_number"],
+      ["issuer_cik"],
+    ])
   );
 
   // ------------------------------ Change Log --------------------------------

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -116,6 +116,17 @@ import {
   Section16TransactionSchema,
 } from "../storage/section16/Section16Schema";
 import {
+  FORM144_ACQUISITION_REPOSITORY_TOKEN,
+  FORM144_FILING_REPOSITORY_TOKEN,
+  FORM144_RECENT_SALE_REPOSITORY_TOKEN,
+  Form144AcquisitionPrimaryKeyNames,
+  Form144AcquisitionSchema,
+  Form144FilingPrimaryKeyNames,
+  Form144FilingSchema,
+  Form144RecentSalePrimaryKeyNames,
+  Form144RecentSaleSchema,
+} from "../storage/form144/Form144Schema";
+import {
   CIK_LAST_UPDATE_REPOSITORY_TOKEN,
   CikLastUpdatePrimaryKeyNames,
   CikLastUpdateSchema,
@@ -388,6 +399,31 @@ export const DefaultDI = () => {
   globalServiceRegistry.registerInstance(
     SECTION16_HOLDING_REPOSITORY_TOKEN,
     createStorage("section16_holdings", Section16HoldingSchema, Section16HoldingPrimaryKeyNames, [
+      ["accession_number"],
+      ["issuer_cik"],
+    ])
+  );
+
+  // ------------------------------ Form 144 --------------------------------
+  globalServiceRegistry.registerInstance(
+    FORM144_FILING_REPOSITORY_TOKEN,
+    createStorage("form144_filings", Form144FilingSchema, Form144FilingPrimaryKeyNames, [
+      ["issuer_cik"],
+      ["form"],
+    ])
+  );
+  globalServiceRegistry.registerInstance(
+    FORM144_ACQUISITION_REPOSITORY_TOKEN,
+    createStorage(
+      "form144_acquisitions",
+      Form144AcquisitionSchema,
+      Form144AcquisitionPrimaryKeyNames,
+      [["accession_number"], ["issuer_cik"]]
+    )
+  );
+  globalServiceRegistry.registerInstance(
+    FORM144_RECENT_SALE_REPOSITORY_TOKEN,
+    createStorage("form144_recent_sales", Form144RecentSaleSchema, Form144RecentSalePrimaryKeyNames, [
       ["accession_number"],
       ["issuer_cik"],
     ])

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -103,6 +103,17 @@ import {
   PortalSchema,
 } from "../storage/portal/PortalSchema";
 import {
+  SECTION16_FILING_REPOSITORY_TOKEN,
+  SECTION16_HOLDING_REPOSITORY_TOKEN,
+  SECTION16_TRANSACTION_REPOSITORY_TOKEN,
+  Section16FilingPrimaryKeyNames,
+  Section16FilingSchema,
+  Section16HoldingPrimaryKeyNames,
+  Section16HoldingSchema,
+  Section16TransactionPrimaryKeyNames,
+  Section16TransactionSchema,
+} from "../storage/section16/Section16Schema";
+import {
   CIK_LAST_UPDATE_REPOSITORY_TOKEN,
   CikLastUpdatePrimaryKeyNames,
   CikLastUpdateSchema,
@@ -361,6 +372,30 @@ export function resetDependencyInjectionsForTesting() {
     CROWDFUNDING_HISTORY_REPOSITORY_TOKEN,
     new InMemoryTabularStorage(CrowdfundingHistorySchema, CrowdfundingHistoryPrimaryKeyNames, [
       ["cik", "file_number"],
+    ])
+  );
+
+  // Initialize Section 16 (Forms 3/4/5) repositories
+  globalServiceRegistry.registerInstance(
+    SECTION16_FILING_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(Section16FilingSchema, Section16FilingPrimaryKeyNames, [
+      ["issuer_cik"],
+      ["form"],
+    ])
+  );
+  globalServiceRegistry.registerInstance(
+    SECTION16_TRANSACTION_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(
+      Section16TransactionSchema,
+      Section16TransactionPrimaryKeyNames,
+      [["accession_number"], ["issuer_cik"]]
+    )
+  );
+  globalServiceRegistry.registerInstance(
+    SECTION16_HOLDING_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(Section16HoldingSchema, Section16HoldingPrimaryKeyNames, [
+      ["accession_number"],
+      ["issuer_cik"],
     ])
   );
 

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -114,6 +114,17 @@ import {
   Section16TransactionSchema,
 } from "../storage/section16/Section16Schema";
 import {
+  FORM144_ACQUISITION_REPOSITORY_TOKEN,
+  FORM144_FILING_REPOSITORY_TOKEN,
+  FORM144_RECENT_SALE_REPOSITORY_TOKEN,
+  Form144AcquisitionPrimaryKeyNames,
+  Form144AcquisitionSchema,
+  Form144FilingPrimaryKeyNames,
+  Form144FilingSchema,
+  Form144RecentSalePrimaryKeyNames,
+  Form144RecentSaleSchema,
+} from "../storage/form144/Form144Schema";
+import {
   CIK_LAST_UPDATE_REPOSITORY_TOKEN,
   CikLastUpdatePrimaryKeyNames,
   CikLastUpdateSchema,
@@ -394,6 +405,29 @@ export function resetDependencyInjectionsForTesting() {
   globalServiceRegistry.registerInstance(
     SECTION16_HOLDING_REPOSITORY_TOKEN,
     new InMemoryTabularStorage(Section16HoldingSchema, Section16HoldingPrimaryKeyNames, [
+      ["accession_number"],
+      ["issuer_cik"],
+    ])
+  );
+
+  // Initialize Form 144 repositories
+  globalServiceRegistry.registerInstance(
+    FORM144_FILING_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(Form144FilingSchema, Form144FilingPrimaryKeyNames, [
+      ["issuer_cik"],
+      ["form"],
+    ])
+  );
+  globalServiceRegistry.registerInstance(
+    FORM144_ACQUISITION_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(Form144AcquisitionSchema, Form144AcquisitionPrimaryKeyNames, [
+      ["accession_number"],
+      ["issuer_cik"],
+    ])
+  );
+  globalServiceRegistry.registerInstance(
+    FORM144_RECENT_SALE_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(Form144RecentSaleSchema, Form144RecentSalePrimaryKeyNames, [
       ["accession_number"],
       ["issuer_cik"],
     ])

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -32,6 +32,11 @@ import {
   CROWDFUNDING_REPOSITORY_TOKEN,
 } from "../storage/portal/CrowdfundingSchema";
 import { PORTAL_REPOSITORY_TOKEN } from "../storage/portal/PortalSchema";
+import {
+  SECTION16_FILING_REPOSITORY_TOKEN,
+  SECTION16_HOLDING_REPOSITORY_TOKEN,
+  SECTION16_TRANSACTION_REPOSITORY_TOKEN,
+} from "../storage/section16/Section16Schema";
 import { CIK_LAST_UPDATE_REPOSITORY_TOKEN } from "../storage/processing/CikLastUpdateSchema";
 import { PROCESSED_FACTS_REPOSITORY_TOKEN } from "../storage/processing/ProcessedFactsSchema";
 import { PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN } from "../storage/processing/ProcessedSubmissionsSchema";
@@ -95,6 +100,9 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(CROWDFUNDING_OFFERINGS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(CROWDFUNDING_REPORTS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(CROWDFUNDING_HISTORY_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(SECTION16_FILING_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(SECTION16_TRANSACTION_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(SECTION16_HOLDING_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(CHANGE_LOG_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(PORTAL_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(REGA_OFFERING_REPOSITORY_TOKEN).setupDatabase();

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -37,6 +37,11 @@ import {
   SECTION16_HOLDING_REPOSITORY_TOKEN,
   SECTION16_TRANSACTION_REPOSITORY_TOKEN,
 } from "../storage/section16/Section16Schema";
+import {
+  FORM144_ACQUISITION_REPOSITORY_TOKEN,
+  FORM144_FILING_REPOSITORY_TOKEN,
+  FORM144_RECENT_SALE_REPOSITORY_TOKEN,
+} from "../storage/form144/Form144Schema";
 import { CIK_LAST_UPDATE_REPOSITORY_TOKEN } from "../storage/processing/CikLastUpdateSchema";
 import { PROCESSED_FACTS_REPOSITORY_TOKEN } from "../storage/processing/ProcessedFactsSchema";
 import { PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN } from "../storage/processing/ProcessedSubmissionsSchema";
@@ -103,6 +108,9 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(SECTION16_FILING_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(SECTION16_TRANSACTION_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(SECTION16_HOLDING_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(FORM144_FILING_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(FORM144_ACQUISITION_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(FORM144_RECENT_SALE_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(CHANGE_LOG_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(PORTAL_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(REGA_OFFERING_REPOSITORY_TOKEN).setupDatabase();

--- a/src/sec/forms/insider-trading/Form_144.schema.ts
+++ b/src/sec/forms/insider-trading/Form_144.schema.ts
@@ -65,9 +65,12 @@ const BROKER_DETAILS_TYPE = Type.Object({
 const SECURITIES_INFORMATION_TYPE = Type.Object({
   securitiesClassTitle: Type.Optional(Type.String()),
   brokerOrMarketmakerDetails: Type.Optional(BROKER_DETAILS_TYPE),
-  noOfUnitsSold: Type.Optional(Type.Number()),
-  aggregateMarketValue: Type.Optional(Type.Number()),
-  noOfUnitsOutstanding: Type.Optional(Type.Number()),
+  // Numeric leaves are kept as raw strings and coerced in storage. Typing them
+  // as Type.Number() would let Value.Convert turn an empty element ("") into a
+  // fabricated 0, indistinguishable from a real zero.
+  noOfUnitsSold: Type.Optional(Type.String()),
+  aggregateMarketValue: Type.Optional(Type.String()),
+  noOfUnitsOutstanding: Type.Optional(Type.String()),
   approxSaleDate: Type.Optional(Type.String()),
   securitiesExchangeName: Type.Optional(Type.String()),
 });
@@ -78,7 +81,7 @@ const SECURITIES_TO_BE_SOLD_TYPE = Type.Object({
   natureOfAcquisitionTransaction: Type.Optional(Type.String()),
   nameOfPersonfromWhomAcquired: Type.Optional(Type.String()),
   isGiftTransaction: Type.Optional(Type.String()),
-  amountOfSecuritiesAcquired: Type.Optional(Type.Number()),
+  amountOfSecuritiesAcquired: Type.Optional(Type.String()),
   paymentDate: Type.Optional(Type.String()),
   natureOfPayment: Type.Optional(Type.String()),
 });
@@ -92,8 +95,8 @@ const SECURITIES_SOLD_PAST_3_MONTHS_TYPE = Type.Object({
   sellerDetails: Type.Optional(SELLER_DETAILS_TYPE),
   securitiesClassTitle: Type.Optional(Type.String()),
   saleDate: Type.Optional(Type.String()),
-  amountOfSecuritiesSold: Type.Optional(Type.Number()),
-  grossProceeds: Type.Optional(Type.Number()),
+  amountOfSecuritiesSold: Type.Optional(Type.String()),
+  grossProceeds: Type.Optional(Type.String()),
 });
 
 const NOTICE_SIGNATURE_TYPE = Type.Object({

--- a/src/sec/forms/insider-trading/Form_144.schema.ts
+++ b/src/sec/forms/insider-trading/Form_144.schema.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Schema for the EDGAR Form 144 (and 144/A) "Notice of Proposed Sale of
+// Securities" XML. Since 2022 these are filed electronically under the
+// shared edgar/ownership namespace, with a `com:` common namespace for
+// address parts. The parser runs with removeNSPrefix, so `com:street1`
+// arrives as `street1`.
+//
+// Unlike the ownership forms (3/4/5), Form 144 leaves are plain text rather
+// than `{ value }` wrappers, and dates are US-format strings (MM/DD/YYYY),
+// stored verbatim rather than coerced to ISO.
+
+import { Static, Type } from "typebox";
+
+const ADDRESS_TYPE = Type.Object({
+  street1: Type.Optional(Type.String()),
+  street2: Type.Optional(Type.String()),
+  city: Type.Optional(Type.String()),
+  stateOrCountry: Type.Optional(Type.String()),
+  zipCode: Type.Optional(Type.String()),
+});
+
+const FILER_CREDENTIALS_TYPE = Type.Object({
+  cik: Type.Optional(Type.String()),
+  ccc: Type.Optional(Type.String()),
+});
+
+const FILER_INFO_TYPE = Type.Object({
+  filer: Type.Optional(
+    Type.Object({
+      filerCredentials: Type.Optional(FILER_CREDENTIALS_TYPE),
+    })
+  ),
+  liveTestFlag: Type.Optional(Type.String()),
+});
+
+const HEADER_DATA_TYPE = Type.Object({
+  submissionType: Type.Optional(Type.String()),
+  filerInfo: Type.Optional(FILER_INFO_TYPE),
+});
+
+const RELATIONSHIPS_TO_ISSUER_TYPE = Type.Object({
+  relationshipToIssuer: Type.Optional(Type.Array(Type.String())),
+});
+
+const ISSUER_INFO_TYPE = Type.Object({
+  issuerCik: Type.Optional(Type.String()),
+  issuerName: Type.Optional(Type.String()),
+  secFileNumber: Type.Optional(Type.String()),
+  issuerAddress: Type.Optional(ADDRESS_TYPE),
+  issuerContactPhone: Type.Optional(Type.String()),
+  nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold: Type.Optional(Type.String()),
+  relationshipsToIssuer: Type.Optional(RELATIONSHIPS_TO_ISSUER_TYPE),
+});
+
+const BROKER_DETAILS_TYPE = Type.Object({
+  name: Type.Optional(Type.String()),
+  address: Type.Optional(ADDRESS_TYPE),
+});
+
+const SECURITIES_INFORMATION_TYPE = Type.Object({
+  securitiesClassTitle: Type.Optional(Type.String()),
+  brokerOrMarketmakerDetails: Type.Optional(BROKER_DETAILS_TYPE),
+  noOfUnitsSold: Type.Optional(Type.Number()),
+  aggregateMarketValue: Type.Optional(Type.Number()),
+  noOfUnitsOutstanding: Type.Optional(Type.Number()),
+  approxSaleDate: Type.Optional(Type.String()),
+  securitiesExchangeName: Type.Optional(Type.String()),
+});
+
+const SECURITIES_TO_BE_SOLD_TYPE = Type.Object({
+  securitiesClassTitle: Type.Optional(Type.String()),
+  acquiredDate: Type.Optional(Type.String()),
+  natureOfAcquisitionTransaction: Type.Optional(Type.String()),
+  nameOfPersonfromWhomAcquired: Type.Optional(Type.String()),
+  isGiftTransaction: Type.Optional(Type.String()),
+  amountOfSecuritiesAcquired: Type.Optional(Type.Number()),
+  paymentDate: Type.Optional(Type.String()),
+  natureOfPayment: Type.Optional(Type.String()),
+});
+
+const SELLER_DETAILS_TYPE = Type.Object({
+  name: Type.Optional(Type.String()),
+  address: Type.Optional(ADDRESS_TYPE),
+});
+
+const SECURITIES_SOLD_PAST_3_MONTHS_TYPE = Type.Object({
+  sellerDetails: Type.Optional(SELLER_DETAILS_TYPE),
+  securitiesClassTitle: Type.Optional(Type.String()),
+  saleDate: Type.Optional(Type.String()),
+  amountOfSecuritiesSold: Type.Optional(Type.Number()),
+  grossProceeds: Type.Optional(Type.Number()),
+});
+
+const NOTICE_SIGNATURE_TYPE = Type.Object({
+  noticeDate: Type.Optional(Type.String()),
+  signature: Type.Optional(Type.String()),
+});
+
+const FORM_DATA_TYPE = Type.Object({
+  issuerInfo: Type.Optional(ISSUER_INFO_TYPE),
+  securitiesInformation: Type.Optional(SECURITIES_INFORMATION_TYPE),
+  securitiesToBeSold: Type.Optional(Type.Array(SECURITIES_TO_BE_SOLD_TYPE)),
+  nothingToReportFlagOnSecuritiesSoldInPast3Months: Type.Optional(Type.String()),
+  securitiesSoldInPast3Months: Type.Optional(Type.Array(SECURITIES_SOLD_PAST_3_MONTHS_TYPE)),
+  noticeSignature: Type.Optional(NOTICE_SIGNATURE_TYPE),
+});
+
+export const Form144Schema = Type.Object({
+  headerData: Type.Optional(HEADER_DATA_TYPE),
+  formData: Type.Optional(FORM_DATA_TYPE),
+});
+
+export type Form144 = Static<typeof Form144Schema>;
+
+// Wrapper matching the XML root element so the parser's array-path detection
+// produces `edgarSubmission.*` jpaths.
+export const Form144SubmissionSchema = Type.Object({
+  edgarSubmission: Form144Schema,
+});
+
+export type Form144Submission = Static<typeof Form144SubmissionSchema>;

--- a/src/sec/forms/insider-trading/Form_144.storage.test.ts
+++ b/src/sec/forms/insider-trading/Form_144.storage.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { Form_144 } from "./Form_144";
+import { processForm144 } from "./Form_144.storage";
+import { Form144Repo } from "../../../storage/form144/Form144Repo";
+import { CompanyObservationRepo } from "../../../storage/observation/CompanyObservationRepo";
+import { PersonObservationRepo } from "../../../storage/observation/PersonObservationRepo";
+import { resetDependencyInjectionsForTesting } from "../../../config/TestingDI";
+import { setupAllDatabases } from "../../../config/setupAllDatabases";
+import { accessionFromFixtureName } from "../../../util/accession";
+import { parseCikSafely } from "../../../util/parseCik";
+
+const CASES = [
+  { dir: "form-144", form: "144" as const },
+  { dir: "form-144-a", form: "144/A" as const },
+];
+
+function listFixtures(dir: string): string[] {
+  return readdirSync(join(__dirname, "mock_data", dir)).filter((f) =>
+    f.endsWith("-primary_doc.xml")
+  );
+}
+
+describe("Form 144 storage", () => {
+  let repo: Form144Repo;
+
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+    repo = new Form144Repo();
+  });
+
+  it("parses and stores every fixture without error", async () => {
+    const errors: Array<{ file: string; error: string }> = [];
+    let count = 0;
+
+    for (const { dir, form } of CASES) {
+      for (const file of listFixtures(dir)) {
+        count++;
+        const accession = accessionFromFixtureName(file);
+        try {
+          const xml = readFileSync(join(__dirname, "mock_data", dir, file), "utf-8");
+          const doc = await Form_144.parse(form, xml);
+          await processForm144({
+            cik: parseCikSafely(doc.formData?.issuerInfo?.issuerCik),
+            file_number: "",
+            accession_number: accession,
+            filing_date: "2026-05-27",
+            primary_doc: file,
+            form,
+            doc,
+          });
+          const filing = await repo.getFiling(accession);
+          expect(filing).toBeDefined();
+          expect(filing!.form).toBe(form);
+        } catch (error) {
+          errors.push({ file, error: error instanceof Error ? error.message : String(error) });
+        }
+      }
+    }
+
+    expect(count).toBeGreaterThan(0);
+    expect(errors).toEqual([]);
+  });
+
+  it("stores the filing header, acquisitions, and trailing-3-month sales", async () => {
+    const accession = "0001663266-26-000003";
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-144", "000166326626000003-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_144.parse("144", xml);
+    await processForm144({
+      cik: 1534263,
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "144",
+      doc,
+    });
+
+    const filing = await repo.getFiling(accession);
+    expect(filing?.issuer_name).toBe("HF Sinclair");
+    expect(filing?.issuer_cik).toBe(1534263);
+    expect(filing?.person_for_whose_account).toBe("Go Timothy");
+    expect(filing?.relationships_to_issuer).toBe("Former Employee");
+    expect(filing?.broker_name).toBe("Pershing Advisor Solutions");
+    expect(filing?.no_of_units_sold).toBe(129915);
+    expect(filing?.aggregate_market_value).toBe(9019409.69);
+    expect(filing?.approx_sale_date).toBe("05/26/2026");
+    expect(filing?.securities_exchange_name).toBe("NYSE");
+    expect(filing?.nothing_to_report_past_3_months).toBe(false);
+
+    const acquisitions = await repo.getAcquisitions(accession);
+    expect(acquisitions.length).toBe(2);
+    expect(acquisitions[0].nature_of_acquisition).toBe("Vested Stock");
+    expect(acquisitions[0].amount_acquired).toBe(66505);
+    expect(acquisitions[0].is_gift).toBe(false);
+
+    const sales = await repo.getRecentSales(accession);
+    expect(sales.length).toBe(2);
+    expect(sales[0].seller_name).toBe("Timothy Go");
+    expect(sales[0].amount_sold).toBe(16814);
+    expect(sales[0].gross_proceeds).toBe(1123856.61);
+  });
+
+  it("observes the issuer + broker as companies and the seller as a person", async () => {
+    const accession = "0001663266-26-000003";
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-144", "000166326626000003-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_144.parse("144", xml);
+    await processForm144({
+      cik: 1534263,
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "144",
+      doc,
+    });
+
+    const persons = (await new PersonObservationRepo().listByAccession(accession)).map(
+      (p) => p.last_name
+    );
+    const companies = (await new CompanyObservationRepo().listByAccession(accession)).map(
+      (c) => c.name
+    );
+
+    expect(persons).toContain("Go Timothy");
+    expect(companies).toContain("HF Sinclair");
+    expect(companies).toContain("Pershing Advisor Solutions");
+  });
+
+  it("stores a nothing-to-report amendment with acquisitions but no sales", async () => {
+    const accession = "0001663266-26-000004";
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-144-a", "000166326626000004-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_144.parse("144/A", xml);
+    await processForm144({
+      cik: parseCikSafely(doc.formData?.issuerInfo?.issuerCik),
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "144/A",
+      doc,
+    });
+
+    const filing = await repo.getFiling(accession);
+    expect(filing?.nothing_to_report_past_3_months).toBe(true);
+    expect((await repo.getRecentSales(accession)).length).toBe(0);
+    expect((await repo.getAcquisitions(accession)).length).toBeGreaterThan(0);
+  });
+
+  it("clears stale rows when re-extracted with fewer acquisitions", async () => {
+    const accession = "0001663266-26-000003";
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-144", "000166326626000003-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_144.parse("144", xml);
+    const args = {
+      cik: 1534263,
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "144" as const,
+    };
+
+    await processForm144({ ...args, doc });
+    expect((await repo.getAcquisitions(accession)).length).toBe(2);
+    expect((await repo.getRecentSales(accession)).length).toBe(2);
+
+    // Re-extract with the detail tables trimmed, as a parser change would.
+    const fewer = {
+      ...doc,
+      formData: {
+        ...doc.formData,
+        securitiesToBeSold: doc.formData!.securitiesToBeSold!.slice(0, 1),
+        securitiesSoldInPast3Months: undefined,
+      },
+    };
+    await processForm144({ ...args, doc: fewer });
+
+    expect((await repo.getAcquisitions(accession)).length).toBe(1);
+    expect((await repo.getRecentSales(accession)).length).toBe(0);
+  });
+});

--- a/src/sec/forms/insider-trading/Form_144.storage.test.ts
+++ b/src/sec/forms/insider-trading/Form_144.storage.test.ts
@@ -164,6 +164,31 @@ describe("Form 144 storage", () => {
     expect((await repo.getAcquisitions(accession)).length).toBeGreaterThan(0);
   });
 
+  it("stores null (not a fabricated 0) for an empty numeric element", async () => {
+    const accession = "0001663266-26-000003";
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-144", "000166326626000003-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_144.parse("144", xml);
+    // Simulate a filing that emits an empty <aggregateMarketValue/> element.
+    doc.formData!.securitiesInformation!.aggregateMarketValue = "";
+    await processForm144({
+      cik: 1534263,
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "144",
+      doc,
+    });
+
+    const filing = await repo.getFiling(accession);
+    expect(filing?.aggregate_market_value).toBeNull();
+    // A populated sibling field still coerces to its real number.
+    expect(filing?.no_of_units_sold).toBe(129915);
+  });
+
   it("clears stale rows when re-extracted with fewer acquisitions", async () => {
     const accession = "0001663266-26-000003";
     const xml = readFileSync(

--- a/src/sec/forms/insider-trading/Form_144.storage.ts
+++ b/src/sec/forms/insider-trading/Form_144.storage.ts
@@ -1,0 +1,296 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { AddressRepo } from "../../../storage/address/AddressRepo";
+import type { AddressImport } from "../../../storage/address/AddressNormalization";
+import { hasCompanyEnding } from "../../../storage/company/CompanyNormalization";
+import { isBadPersonField } from "../../../types/edgar/bad-data";
+import { parseCikSafely } from "../../../util/parseCik";
+import { EntityObserver } from "../../../resolver/EntityObserver";
+import { PersonResolver } from "../../../resolver/PersonResolver";
+import { CompanyResolver } from "../../../resolver/CompanyResolver";
+import { PersonObservationRepo } from "../../../storage/observation/PersonObservationRepo";
+import { CompanyObservationRepo } from "../../../storage/observation/CompanyObservationRepo";
+import { PersonIdentityLinkRepo } from "../../../storage/canonical/PersonIdentityLinkRepo";
+import { CompanyIdentityLinkRepo } from "../../../storage/canonical/CompanyIdentityLinkRepo";
+import { CanonicalPersonRepo } from "../../../storage/canonical/CanonicalPersonRepo";
+import { CanonicalCompanyRepo } from "../../../storage/canonical/CanonicalCompanyRepo";
+import { CanonicalPersonAliasRepo } from "../../../storage/canonical/CanonicalPersonAliasRepo";
+import { CanonicalCompanyAliasRepo } from "../../../storage/canonical/CanonicalCompanyAliasRepo";
+import { CanonicalPersonAddressRepo } from "../../../storage/canonical/CanonicalPersonAddressRepo";
+import { CanonicalPersonPhoneRepo } from "../../../storage/canonical/CanonicalPersonPhoneRepo";
+import { CanonicalCompanyAddressRepo } from "../../../storage/canonical/CanonicalCompanyAddressRepo";
+import { CanonicalCompanyPhoneRepo } from "../../../storage/canonical/CanonicalCompanyPhoneRepo";
+import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../../storage/versioning/ComponentVersionSchema";
+import { VersionRegistry } from "../../../storage/versioning/VersionRegistry";
+import { getActiveSlot } from "../../../storage/versioning/getActiveSlot";
+import { formToExtractorId } from "../../../storage/versioning/extractorIds";
+import { Form144Repo } from "../../../storage/form144/Form144Repo";
+import type { Form144 } from "./Form_144.schema";
+
+type AddressShape = NonNullable<
+  NonNullable<Form144["formData"]>["issuerInfo"]
+>["issuerAddress"];
+
+function str(s: string | undefined | null): string | null {
+  if (s === undefined || s === null) return null;
+  const t = String(s).trim();
+  return t === "" ? null : t;
+}
+
+function num(n: number | string | undefined | null): number | null {
+  if (n === undefined || n === null || n === "") return null;
+  const v = typeof n === "number" ? n : Number(n);
+  return Number.isFinite(v) ? v : null;
+}
+
+// EDGAR Y/N flags.
+function toBoolYN(raw: string | undefined): boolean {
+  return str(raw)?.toUpperCase() === "Y";
+}
+
+function buildAddress(addr: AddressShape): AddressImport | null {
+  if (!addr) return null;
+  const street1 = str(addr.street1);
+  const city = str(addr.city);
+  if (!street1 && !city) return null;
+  return {
+    street1,
+    street2: str(addr.street2),
+    city,
+    stateOrCountry: str(addr.stateOrCountry),
+    zipCode: str(addr.zipCode),
+  };
+}
+
+// The account holder is named in a "person" field but can be a trust/entity.
+// Treat as a company only when the name carries a company ending; otherwise a
+// person. (Form 144 has no structured person/entity flag.)
+function accountHolderIsCompany(name: string): boolean {
+  const cleaned = name
+    .trim()
+    .replace(/[.,]+$/, "")
+    .replace(/\s+[A-Z]$/, "")
+    .trim();
+  return hasCompanyEnding(cleaned);
+}
+
+export async function processForm144({
+  accession_number,
+  filing_date,
+  form,
+  doc,
+}: {
+  cik: number;
+  file_number: string;
+  accession_number: string;
+  filing_date: string;
+  primary_doc: string;
+  form: string;
+  doc: Form144;
+}): Promise<void> {
+  const versionRegistry = new VersionRegistry(
+    globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+  );
+
+  const [personSlot, companySlot] = await Promise.all([
+    getActiveSlot(versionRegistry, "resolver", "person"),
+    getActiveSlot(versionRegistry, "resolver", "company"),
+  ]);
+
+  const activeResolverPersonVersion = personSlot?.semver ?? "1.0.0";
+  const activeResolverCompanyVersion = companySlot?.semver ?? "1.0.0";
+  const extractor_version = "1.0.0";
+  const extractor_id = formToExtractorId(form) ?? "144";
+
+  const formData = doc.formData ?? {};
+  const issuerInfo = formData.issuerInfo;
+  const issuer_cik = parseCikSafely(issuerInfo?.issuerCik);
+
+  const personResolver = new PersonResolver({
+    canonicalPersonRepo: new CanonicalPersonRepo(),
+    canonicalPersonAliasRepo: new CanonicalPersonAliasRepo(),
+    activeResolverVersion: activeResolverPersonVersion,
+  });
+  const companyResolver = new CompanyResolver({
+    canonicalCompanyRepo: new CanonicalCompanyRepo(),
+    canonicalCompanyAliasRepo: new CanonicalCompanyAliasRepo(),
+    activeResolverVersion: activeResolverCompanyVersion,
+  });
+
+  const observer = new EntityObserver({
+    personObservationRepo: new PersonObservationRepo(),
+    companyObservationRepo: new CompanyObservationRepo(),
+    personIdentityLinkRepo: new PersonIdentityLinkRepo(),
+    companyIdentityLinkRepo: new CompanyIdentityLinkRepo(),
+    personResolver,
+    companyResolver,
+    canonicalPersonAddressRepo: new CanonicalPersonAddressRepo(),
+    canonicalPersonPhoneRepo: new CanonicalPersonPhoneRepo(),
+    canonicalCompanyAddressRepo: new CanonicalCompanyAddressRepo(),
+    canonicalCompanyPhoneRepo: new CanonicalCompanyPhoneRepo(),
+    activeResolverPersonVersion,
+    activeResolverCompanyVersion,
+  });
+
+  const addressRepo = new AddressRepo();
+  const repo = new Form144Repo();
+
+  const securitiesInfo = formData.securitiesInformation;
+  const broker = securitiesInfo?.brokerOrMarketmakerDetails;
+  const relationships = (issuerInfo?.relationshipsToIssuer?.relationshipToIssuer ?? [])
+    .map((r) => str(r))
+    .filter((r): r is string => r !== null);
+  const recentSales = formData.securitiesSoldInPast3Months ?? [];
+
+  // --- Filing header (folds in the single securitiesInformation block) ---
+  await repo.saveFiling({
+    accession_number,
+    form,
+    submission_type: str(doc.headerData?.submissionType),
+    issuer_cik,
+    issuer_name: str(issuerInfo?.issuerName) ?? "",
+    sec_file_number: str(issuerInfo?.secFileNumber),
+    person_for_whose_account: str(issuerInfo?.nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold),
+    relationships_to_issuer: relationships.length ? relationships.join(", ") : null,
+    securities_class_title: str(securitiesInfo?.securitiesClassTitle),
+    broker_name: str(broker?.name),
+    no_of_units_sold: num(securitiesInfo?.noOfUnitsSold),
+    aggregate_market_value: num(securitiesInfo?.aggregateMarketValue),
+    no_of_units_outstanding: num(securitiesInfo?.noOfUnitsOutstanding),
+    approx_sale_date: str(securitiesInfo?.approxSaleDate),
+    securities_exchange_name: str(securitiesInfo?.securitiesExchangeName),
+    nothing_to_report_past_3_months: toBoolYN(
+      formData.nothingToReportFlagOnSecuritiesSoldInPast3Months
+    ),
+    notice_date: str(formData.noticeSignature?.noticeDate),
+    filing_date: filing_date || null,
+  });
+
+  // --- Entities: issuer (0), account holder (1), broker (2) ---
+  const issuerName = str(issuerInfo?.issuerName);
+  if (issuerName) {
+    let issuerAddressId: string | null = null;
+    const issuerAddr = buildAddress(issuerInfo?.issuerAddress);
+    if (issuerAddr) {
+      try {
+        issuerAddressId = (await addressRepo.saveAddress(issuerAddr)).address_hash_id;
+      } catch (error) {
+        console.warn(`Failed to save Form 144 issuer address for ${issuerName}:`, error);
+      }
+    }
+    await observer.observeCompany({
+      accession_number,
+      extractor_id,
+      extractor_version,
+      observation_index: 0,
+      cik: issuer_cik || null,
+      name: issuerName,
+      address_id: issuerAddressId,
+      source_context: JSON.stringify({ relation: "form144:issuer" }),
+    });
+  }
+
+  const accountName = str(issuerInfo?.nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold);
+  if (accountName && !isBadPersonField(accountName)) {
+    // The account holder's address isn't in issuerInfo; the trailing-3-month
+    // sellerDetails block carries it for the same seller, so reuse it when present.
+    let accountAddressId: string | null = null;
+    const sellerAddr = buildAddress(recentSales[0]?.sellerDetails?.address);
+    if (sellerAddr) {
+      try {
+        accountAddressId = (await addressRepo.saveAddress(sellerAddr)).address_hash_id;
+      } catch (error) {
+        console.warn(`Failed to save Form 144 seller address for ${accountName}:`, error);
+      }
+    }
+    const relationship = relationships.length ? relationships.join(", ") : "form144:seller";
+    if (accountHolderIsCompany(accountName)) {
+      await observer.observeCompany({
+        accession_number,
+        extractor_id,
+        extractor_version,
+        observation_index: 1,
+        cik: null,
+        name: accountName,
+        address_id: accountAddressId,
+        source_context: JSON.stringify({ relation: "form144:seller", relationships }),
+      });
+    } else {
+      await observer.observePerson({
+        accession_number,
+        extractor_id,
+        extractor_version,
+        observation_index: 1,
+        source_filing_issuer_cik: issuer_cik || null,
+        last_name: accountName,
+        relationship,
+        address_id: accountAddressId,
+        source_context: JSON.stringify({ relation: "form144:seller", relationships }),
+      });
+    }
+  }
+
+  const brokerName = str(broker?.name);
+  if (brokerName) {
+    let brokerAddressId: string | null = null;
+    const brokerAddr = buildAddress(broker?.address);
+    if (brokerAddr) {
+      try {
+        brokerAddressId = (await addressRepo.saveAddress(brokerAddr)).address_hash_id;
+      } catch (error) {
+        console.warn(`Failed to save Form 144 broker address for ${brokerName}:`, error);
+      }
+    }
+    await observer.observeCompany({
+      accession_number,
+      extractor_id,
+      extractor_version,
+      observation_index: 2,
+      cik: null,
+      name: brokerName,
+      address_id: brokerAddressId,
+      source_context: JSON.stringify({ relation: "form144:broker" }),
+    });
+  }
+
+  // --- Detail tables (clear-before-write keeps re-extraction idempotent) ---
+  await repo.clearAcquisitions(accession_number);
+  await repo.clearRecentSales(accession_number);
+
+  const acquisitions = formData.securitiesToBeSold ?? [];
+  for (let i = 0; i < acquisitions.length; i++) {
+    const a = acquisitions[i];
+    await repo.saveAcquisition({
+      accession_number,
+      acquisition_index: i,
+      issuer_cik,
+      securities_class_title: str(a.securitiesClassTitle),
+      acquired_date: str(a.acquiredDate),
+      nature_of_acquisition: str(a.natureOfAcquisitionTransaction),
+      name_of_person_from_whom_acquired: str(a.nameOfPersonfromWhomAcquired),
+      is_gift: a.isGiftTransaction !== undefined ? toBoolYN(a.isGiftTransaction) : null,
+      amount_acquired: num(a.amountOfSecuritiesAcquired),
+      payment_date: str(a.paymentDate),
+      nature_of_payment: str(a.natureOfPayment),
+    });
+  }
+
+  for (let i = 0; i < recentSales.length; i++) {
+    const s = recentSales[i];
+    await repo.saveRecentSale({
+      accession_number,
+      sale_index: i,
+      issuer_cik,
+      seller_name: str(s.sellerDetails?.name),
+      securities_class_title: str(s.securitiesClassTitle),
+      sale_date: str(s.saleDate),
+      amount_sold: num(s.amountOfSecuritiesSold),
+      gross_proceeds: num(s.grossProceeds),
+    });
+  }
+}

--- a/src/sec/forms/insider-trading/Form_144.storage.ts
+++ b/src/sec/forms/insider-trading/Form_144.storage.ts
@@ -53,6 +53,15 @@ function toBoolYN(raw: string | undefined): boolean {
   return str(raw)?.toUpperCase() === "Y";
 }
 
+// Every observed Form 144 carries exactly one securitiesInformation/broker
+// block, so the schema models them as single objects. Guard anyway: if a
+// filing ever repeats the element, fast-xml-parser yields an array, and
+// reading a field off it would silently null the whole proposed-sale block —
+// fall back to the first block instead.
+function firstOf<T>(x: T | readonly T[] | undefined): T | undefined {
+  return Array.isArray(x) ? x[0] : (x as T | undefined);
+}
+
 function buildAddress(addr: AddressShape): AddressImport | null {
   if (!addr) return null;
   const street1 = str(addr.street1);
@@ -197,17 +206,11 @@ export async function processForm144({
 
   const accountName = str(issuerInfo?.nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold);
   if (accountName && !isBadPersonField(accountName)) {
-    // The account holder's address isn't in issuerInfo; the trailing-3-month
-    // sellerDetails block carries it for the same seller, so reuse it when present.
-    let accountAddressId: string | null = null;
-    const sellerAddr = buildAddress(recentSales[0]?.sellerDetails?.address);
-    if (sellerAddr) {
-      try {
-        accountAddressId = (await addressRepo.saveAddress(sellerAddr)).address_hash_id;
-      } catch (error) {
-        console.warn(`Failed to save Form 144 seller address for ${accountName}:`, error);
-      }
-    }
+    // Form 144 carries no address for the account holder. The trailing-3-month
+    // sellerDetails block has an address, but its seller can be a different
+    // party and its name is in the opposite order ("Timothy Go" vs the account
+    // holder's "Go Timothy"), so it can't be reliably matched — don't risk
+    // attaching the wrong address to the canonical person.
     const relationship = relationships.length ? relationships.join(", ") : "form144:seller";
     if (accountHolderIsCompany(accountName)) {
       await observer.observeCompany({
@@ -217,7 +220,6 @@ export async function processForm144({
         observation_index: 1,
         cik: null,
         name: accountName,
-        address_id: accountAddressId,
         source_context: JSON.stringify({ relation: "form144:seller", relationships }),
       });
     } else {
@@ -229,7 +231,6 @@ export async function processForm144({
         source_filing_issuer_cik: issuer_cik || null,
         last_name: accountName,
         relationship,
-        address_id: accountAddressId,
         source_context: JSON.stringify({ relation: "form144:seller", relationships }),
       });
     }
@@ -273,7 +274,7 @@ export async function processForm144({
       acquired_date: str(a.acquiredDate),
       nature_of_acquisition: str(a.natureOfAcquisitionTransaction),
       name_of_person_from_whom_acquired: str(a.nameOfPersonfromWhomAcquired),
-      is_gift: a.isGiftTransaction !== undefined ? toBoolYN(a.isGiftTransaction) : null,
+      is_gift: str(a.isGiftTransaction) !== null ? toBoolYN(a.isGiftTransaction) : null,
       amount_acquired: num(a.amountOfSecuritiesAcquired),
       payment_date: str(a.paymentDate),
       nature_of_payment: str(a.natureOfPayment),

--- a/src/sec/forms/insider-trading/Form_144.test.ts
+++ b/src/sec/forms/insider-trading/Form_144.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { Form_144 } from "./Form_144";
+
+const CASES = [
+  { dir: "form-144", form: "144" as const, expectType: "144" },
+  { dir: "form-144-a", form: "144/A" as const, expectType: "144/A" },
+];
+
+function listFixtures(dir: string): string[] {
+  return readdirSync(join(__dirname, "mock_data", dir)).filter((f) =>
+    f.endsWith("-primary_doc.xml")
+  );
+}
+
+describe("Form 144 parsing", () => {
+  for (const { dir, form, expectType } of CASES) {
+    it(`parses every ${form} fixture in mock_data/${dir}`, async () => {
+      const files = listFixtures(dir);
+      expect(files.length).toBeGreaterThan(0);
+
+      for (const file of files) {
+        const xml = readFileSync(join(__dirname, "mock_data", dir, file), "utf-8");
+        const doc = await Form_144.parse(form, xml);
+
+        expect(doc.headerData?.submissionType).toBe(expectType);
+        expect(doc.formData?.issuerInfo?.issuerCik).toMatch(/^\d+$/);
+        expect(doc.formData?.issuerInfo?.issuerName).toBeTruthy();
+      }
+    });
+  }
+
+  it("forces repeating tables into arrays and coerces numbers / strips com: prefix", async () => {
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-144", "000166326626000003-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_144.parse("144", xml);
+    const fd = doc.formData!;
+
+    expect(Array.isArray(fd.securitiesToBeSold)).toBe(true);
+    expect(fd.securitiesToBeSold!.length).toBe(2);
+    expect(Array.isArray(fd.securitiesSoldInPast3Months)).toBe(true);
+    expect(fd.securitiesSoldInPast3Months!.length).toBe(2);
+    expect(Array.isArray(fd.issuerInfo?.relationshipsToIssuer?.relationshipToIssuer)).toBe(true);
+
+    expect(fd.securitiesInformation?.noOfUnitsSold).toBe(129915);
+    expect(fd.securitiesInformation?.aggregateMarketValue).toBe(9019409.69);
+    // com:street1 -> street1 after removeNSPrefix
+    expect(fd.issuerInfo?.issuerAddress?.street1).toBe("2323 Victory Avenue Suite 1400");
+    expect(fd.securitiesSoldInPast3Months?.[0]?.sellerDetails?.address?.city).toBe("Dallas");
+  });
+
+  it("parses an amendment with nothing-to-report and no recent sales", async () => {
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-144-a", "000166326626000004-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_144.parse("144/A", xml);
+    expect(doc.formData?.nothingToReportFlagOnSecuritiesSoldInPast3Months).toBe("Y");
+    expect(doc.formData?.securitiesSoldInPast3Months).toBeUndefined();
+  });
+
+  it("rejects a mismatched form symbol", async () => {
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-144", "000166326626000003-primary_doc.xml"),
+      "utf-8"
+    );
+    // @ts-expect-error intentionally passing a symbol Form_144 does not handle
+    await expect(Form_144.parse("4", xml)).rejects.toThrow();
+  });
+});

--- a/src/sec/forms/insider-trading/Form_144.test.ts
+++ b/src/sec/forms/insider-trading/Form_144.test.ts
@@ -51,8 +51,9 @@ describe("Form 144 parsing", () => {
     expect(fd.securitiesSoldInPast3Months!.length).toBe(2);
     expect(Array.isArray(fd.issuerInfo?.relationshipsToIssuer?.relationshipToIssuer)).toBe(true);
 
-    expect(fd.securitiesInformation?.noOfUnitsSold).toBe(129915);
-    expect(fd.securitiesInformation?.aggregateMarketValue).toBe(9019409.69);
+    // Numeric leaves are kept as raw strings; storage coerces them.
+    expect(fd.securitiesInformation?.noOfUnitsSold).toBe("129915");
+    expect(fd.securitiesInformation?.aggregateMarketValue).toBe("9019409.69");
     // com:street1 -> street1 after removeNSPrefix
     expect(fd.issuerInfo?.issuerAddress?.street1).toBe("2323 Victory Avenue Suite 1400");
     expect(fd.securitiesSoldInPast3Months?.[0]?.sellerDetails?.address?.city).toBe("Dallas");

--- a/src/sec/forms/insider-trading/Form_144.ts
+++ b/src/sec/forms/insider-trading/Form_144.ts
@@ -4,11 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import Value from "typebox/value";
 import { Form } from "../Form";
+import {
+  Form144,
+  Form144Schema,
+  Form144Submission,
+  Form144SubmissionSchema,
+} from "./Form_144.schema";
 
 export class Form_144 extends Form {
   static readonly name = "Notice of Proposed Sale of Securities";
   static readonly description =
-    'This form must be filed by "insiders" prior to their intended sale of restricted stock. A Form 144 is NOT an EDGAR electronic filing; each 144 is filed by the seller in paper during the day at the SEC.';
+    'Filed by "insiders" to give notice of a proposed sale of restricted or control securities under Rule 144. Filed electronically as XML since 2022.';
   static readonly forms = ["144", "144/A"] as const;
+
+  static async parse(form: (typeof Form_144.forms)[number], xml: string): Promise<Form144> {
+    if (!Form_144.forms.includes(form)) {
+      throw new Error(`Invalid form: ${form}`);
+    }
+    const parser = Form_144.getParser(Form144SubmissionSchema);
+    const json = parser.parse(xml) as Form144Submission;
+    return Value.Convert(Form144Schema, json.edgarSubmission) as Form144;
+  }
 }

--- a/src/sec/forms/insider-trading/Form_3.ts
+++ b/src/sec/forms/insider-trading/Form_3.ts
@@ -4,11 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import Value from "typebox/value";
 import { Form } from "../Form";
+import {
+  OwnershipDocument,
+  OwnershipDocumentSchema,
+  OwnershipDocumentSubmission,
+  OwnershipDocumentSubmissionSchema,
+} from "./OwnershipDocument.schema";
 
 export class Form_3 extends Form {
   static readonly name = "Initial Statement of Beneficial Ownership";
   static readonly description =
     "An initial filing of equity securities filed by every director, officer, or owner of more than ten percent of a class of equity securities.";
   static readonly forms = ["3", "3/A"] as const;
+
+  static async parse(
+    form: (typeof Form_3.forms)[number],
+    xml: string
+  ): Promise<OwnershipDocument> {
+    if (!Form_3.forms.includes(form)) {
+      throw new Error(`Invalid form: ${form}`);
+    }
+    const parser = Form_3.getParser(OwnershipDocumentSubmissionSchema);
+    const json = parser.parse(xml) as OwnershipDocumentSubmission;
+    return Value.Convert(OwnershipDocumentSchema, json.ownershipDocument) as OwnershipDocument;
+  }
 }

--- a/src/sec/forms/insider-trading/Form_4.ts
+++ b/src/sec/forms/insider-trading/Form_4.ts
@@ -4,11 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import Value from "typebox/value";
 import { Form } from "../Form";
+import {
+  OwnershipDocument,
+  OwnershipDocumentSchema,
+  OwnershipDocumentSubmission,
+  OwnershipDocumentSubmissionSchema,
+} from "./OwnershipDocument.schema";
 
 export class Form_4 extends Form {
   static readonly name = "Statement of Changes in Beneficial Ownership";
   static readonly description =
     "Any changes to a previously filed form 3 are reported in this filing.";
   static readonly forms = ["4", "4/A"] as const;
+
+  static async parse(
+    form: (typeof Form_4.forms)[number],
+    xml: string
+  ): Promise<OwnershipDocument> {
+    if (!Form_4.forms.includes(form)) {
+      throw new Error(`Invalid form: ${form}`);
+    }
+    const parser = Form_4.getParser(OwnershipDocumentSubmissionSchema);
+    const json = parser.parse(xml) as OwnershipDocumentSubmission;
+    return Value.Convert(OwnershipDocumentSchema, json.ownershipDocument) as OwnershipDocument;
+  }
 }

--- a/src/sec/forms/insider-trading/Form_5.ts
+++ b/src/sec/forms/insider-trading/Form_5.ts
@@ -4,11 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import Value from "typebox/value";
 import { Form } from "../Form";
+import {
+  OwnershipDocument,
+  OwnershipDocumentSchema,
+  OwnershipDocumentSubmission,
+  OwnershipDocumentSubmissionSchema,
+} from "./OwnershipDocument.schema";
 
 export class Form_5 extends Form {
   static readonly name = "Annual Statement of Beneficial Ownership";
   static readonly description =
     "An annual statement of ownership of securities filed by every director, officer, or owner of more than ten percent of a class of equity securities.";
   static readonly forms = ["5", "5/A"] as const;
+
+  static async parse(
+    form: (typeof Form_5.forms)[number],
+    xml: string
+  ): Promise<OwnershipDocument> {
+    if (!Form_5.forms.includes(form)) {
+      throw new Error(`Invalid form: ${form}`);
+    }
+    const parser = Form_5.getParser(OwnershipDocumentSubmissionSchema);
+    const json = parser.parse(xml) as OwnershipDocumentSubmission;
+    return Value.Convert(OwnershipDocumentSchema, json.ownershipDocument) as OwnershipDocument;
+  }
 }

--- a/src/sec/forms/insider-trading/OwnershipDocument.schema.ts
+++ b/src/sec/forms/insider-trading/OwnershipDocument.schema.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Shared schema for the EDGAR "ownershipDocument" used by Section 16 Forms
+// 3, 4, and 5 (and their /A amendments). Form 3 reports initial holdings,
+// Form 4 reports transactions, Form 5 is the annual statement (holdings +
+// late transactions). All three share this single namespace.
+//
+// EDGAR wraps most leaf values as `<field><value>X</value></field>` with an
+// optional sibling `<footnoteId id="Fn"/>`. Attributes are dropped by the
+// parser (ignoreAttributes), so footnote ids are not modeled. Numeric and
+// boolean-ish fields are coerced leniently in storage via the unwrap helpers
+// because empty elements (e.g. `<deemedExecutionDate/>`) parse to "".
+
+import { Static, Type } from "typebox";
+
+// A `{ value }` wrapper around a string-bearing leaf.
+const VALUE_STRING = Type.Object({
+  value: Type.Optional(Type.String()),
+});
+
+// A `{ value }` wrapper around a numeric leaf. Convert coerces "10000" -> 10000.
+const VALUE_NUMBER = Type.Object({
+  value: Type.Optional(Type.Number()),
+});
+
+const ISSUER_TYPE = Type.Object({
+  issuerCik: Type.Optional(Type.String()),
+  issuerName: Type.Optional(Type.String()),
+  issuerTradingSymbol: Type.Optional(Type.String()),
+  issuerForeignTradingSymbol: Type.Optional(Type.String()),
+});
+
+const REPORTING_OWNER_ID_TYPE = Type.Object({
+  rptOwnerCik: Type.Optional(Type.String()),
+  rptOwnerCcc: Type.Optional(Type.String()),
+  rptOwnerName: Type.Optional(Type.String()),
+});
+
+const REPORTING_OWNER_ADDRESS_TYPE = Type.Object({
+  rptOwnerNonUSAddressFlag: Type.Optional(Type.String()),
+  rptOwnerStreet1: Type.Optional(Type.String()),
+  rptOwnerStreet2: Type.Optional(Type.String()),
+  rptOwnerCity: Type.Optional(Type.String()),
+  rptOwnerState: Type.Optional(Type.String()),
+  rptOwnerZipCode: Type.Optional(Type.String()),
+  rptOwnerStateDescription: Type.Optional(Type.String()),
+  rptOwnerNonUSStateTerritory: Type.Optional(Type.String()),
+  rptOwnerCountry: Type.Optional(Type.String()),
+});
+
+const REPORTING_OWNER_RELATIONSHIP_TYPE = Type.Object({
+  isDirector: Type.Optional(Type.String()),
+  isOfficer: Type.Optional(Type.String()),
+  isTenPercentOwner: Type.Optional(Type.String()),
+  isOther: Type.Optional(Type.String()),
+  officerTitle: Type.Optional(Type.String()),
+  otherText: Type.Optional(Type.String()),
+});
+
+const REPORTING_OWNER_TYPE = Type.Object({
+  reportingOwnerId: Type.Optional(REPORTING_OWNER_ID_TYPE),
+  reportingOwnerAddress: Type.Optional(REPORTING_OWNER_ADDRESS_TYPE),
+  reportingOwnerRelationship: Type.Optional(REPORTING_OWNER_RELATIONSHIP_TYPE),
+});
+
+const TRANSACTION_CODING_TYPE = Type.Object({
+  transactionFormType: Type.Optional(Type.String()),
+  transactionCode: Type.Optional(Type.String()),
+  equitySwapInvolved: Type.Optional(Type.String()),
+});
+
+const TRANSACTION_AMOUNTS_TYPE = Type.Object({
+  transactionShares: Type.Optional(VALUE_NUMBER),
+  transactionPricePerShare: Type.Optional(VALUE_NUMBER),
+  transactionAcquiredDisposedCode: Type.Optional(VALUE_STRING),
+});
+
+const POST_TRANSACTION_AMOUNTS_TYPE = Type.Object({
+  sharesOwnedFollowingTransaction: Type.Optional(VALUE_NUMBER),
+  valueOwnedFollowingTransaction: Type.Optional(VALUE_NUMBER),
+});
+
+const OWNERSHIP_NATURE_TYPE = Type.Object({
+  directOrIndirectOwnership: Type.Optional(VALUE_STRING),
+  natureOfOwnership: Type.Optional(VALUE_STRING),
+});
+
+const UNDERLYING_SECURITY_TYPE = Type.Object({
+  underlyingSecurityTitle: Type.Optional(VALUE_STRING),
+  underlyingSecurityShares: Type.Optional(VALUE_NUMBER),
+  underlyingSecurityValue: Type.Optional(VALUE_NUMBER),
+});
+
+const NON_DERIVATIVE_TRANSACTION_TYPE = Type.Object({
+  securityTitle: Type.Optional(VALUE_STRING),
+  transactionDate: Type.Optional(VALUE_STRING),
+  deemedExecutionDate: Type.Optional(VALUE_STRING),
+  transactionCoding: Type.Optional(TRANSACTION_CODING_TYPE),
+  transactionAmounts: Type.Optional(TRANSACTION_AMOUNTS_TYPE),
+  postTransactionAmounts: Type.Optional(POST_TRANSACTION_AMOUNTS_TYPE),
+  ownershipNature: Type.Optional(OWNERSHIP_NATURE_TYPE),
+});
+
+const NON_DERIVATIVE_HOLDING_TYPE = Type.Object({
+  securityTitle: Type.Optional(VALUE_STRING),
+  postTransactionAmounts: Type.Optional(POST_TRANSACTION_AMOUNTS_TYPE),
+  ownershipNature: Type.Optional(OWNERSHIP_NATURE_TYPE),
+});
+
+const NON_DERIVATIVE_TABLE_TYPE = Type.Object({
+  nonDerivativeTransaction: Type.Optional(Type.Array(NON_DERIVATIVE_TRANSACTION_TYPE)),
+  nonDerivativeHolding: Type.Optional(Type.Array(NON_DERIVATIVE_HOLDING_TYPE)),
+});
+
+const DERIVATIVE_TRANSACTION_TYPE = Type.Object({
+  securityTitle: Type.Optional(VALUE_STRING),
+  conversionOrExercisePrice: Type.Optional(VALUE_NUMBER),
+  transactionDate: Type.Optional(VALUE_STRING),
+  deemedExecutionDate: Type.Optional(VALUE_STRING),
+  transactionCoding: Type.Optional(TRANSACTION_CODING_TYPE),
+  transactionAmounts: Type.Optional(TRANSACTION_AMOUNTS_TYPE),
+  exerciseDate: Type.Optional(VALUE_STRING),
+  expirationDate: Type.Optional(VALUE_STRING),
+  underlyingSecurity: Type.Optional(UNDERLYING_SECURITY_TYPE),
+  postTransactionAmounts: Type.Optional(POST_TRANSACTION_AMOUNTS_TYPE),
+  ownershipNature: Type.Optional(OWNERSHIP_NATURE_TYPE),
+});
+
+const DERIVATIVE_HOLDING_TYPE = Type.Object({
+  securityTitle: Type.Optional(VALUE_STRING),
+  conversionOrExercisePrice: Type.Optional(VALUE_NUMBER),
+  exerciseDate: Type.Optional(VALUE_STRING),
+  expirationDate: Type.Optional(VALUE_STRING),
+  underlyingSecurity: Type.Optional(UNDERLYING_SECURITY_TYPE),
+  postTransactionAmounts: Type.Optional(POST_TRANSACTION_AMOUNTS_TYPE),
+  ownershipNature: Type.Optional(OWNERSHIP_NATURE_TYPE),
+});
+
+const DERIVATIVE_TABLE_TYPE = Type.Object({
+  derivativeTransaction: Type.Optional(Type.Array(DERIVATIVE_TRANSACTION_TYPE)),
+  derivativeHolding: Type.Optional(Type.Array(DERIVATIVE_HOLDING_TYPE)),
+});
+
+const FOOTNOTE_TYPE = Type.Object({
+  // `id` is an XML attribute (dropped by the parser); only the text remains.
+  "#text": Type.Optional(Type.String()),
+});
+
+const FOOTNOTES_TYPE = Type.Object({
+  footnote: Type.Optional(Type.Array(FOOTNOTE_TYPE)),
+});
+
+const OWNER_SIGNATURE_TYPE = Type.Object({
+  signatureName: Type.Optional(Type.String()),
+  signatureDate: Type.Optional(Type.String()),
+});
+
+export const OwnershipDocumentSchema = Type.Object({
+  schemaVersion: Type.Optional(Type.String()),
+  documentType: Type.Optional(Type.String()),
+  periodOfReport: Type.Optional(Type.String()),
+  notSubjectToSection16: Type.Optional(Type.String()),
+  noSecuritiesOwned: Type.Optional(Type.String()),
+  form3HoldingsReported: Type.Optional(Type.String()),
+  form4TransactionsReported: Type.Optional(Type.String()),
+  aff10b5One: Type.Optional(Type.String()),
+  issuer: Type.Optional(ISSUER_TYPE),
+  reportingOwner: Type.Optional(Type.Array(REPORTING_OWNER_TYPE)),
+  nonDerivativeTable: Type.Optional(NON_DERIVATIVE_TABLE_TYPE),
+  derivativeTable: Type.Optional(DERIVATIVE_TABLE_TYPE),
+  footnotes: Type.Optional(FOOTNOTES_TYPE),
+  remarks: Type.Optional(Type.String()),
+  ownerSignature: Type.Optional(Type.Array(OWNER_SIGNATURE_TYPE)),
+});
+
+export type OwnershipDocument = Static<typeof OwnershipDocumentSchema>;
+
+// Wrapper matching the XML root element, so the parser's array-path
+// detection produces `ownershipDocument.*` jpaths.
+export const OwnershipDocumentSubmissionSchema = Type.Object({
+  ownershipDocument: OwnershipDocumentSchema,
+});
+
+export type OwnershipDocumentSubmission = Static<typeof OwnershipDocumentSubmissionSchema>;

--- a/src/sec/forms/insider-trading/OwnershipDocument.storage.test.ts
+++ b/src/sec/forms/insider-trading/OwnershipDocument.storage.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { Form_3 } from "./Form_3";
+import { Form_4 } from "./Form_4";
+import { Form_5 } from "./Form_5";
+import { processOwnershipForm } from "./OwnershipDocument.storage";
+import { Section16Repo } from "../../../storage/section16/Section16Repo";
+import { CompanyObservationRepo } from "../../../storage/observation/CompanyObservationRepo";
+import { PersonObservationRepo } from "../../../storage/observation/PersonObservationRepo";
+import { resetDependencyInjectionsForTesting } from "../../../config/TestingDI";
+import { setupAllDatabases } from "../../../config/setupAllDatabases";
+import { accessionFromFixtureName } from "../../../util/accession";
+import { parseCikSafely } from "../../../util/parseCik";
+
+const CASES = [
+  { dir: "form-3", form: "3" as const, parser: Form_3 },
+  { dir: "form-3-a", form: "3/A" as const, parser: Form_3 },
+  { dir: "form-4", form: "4" as const, parser: Form_4 },
+  { dir: "form-4-a", form: "4/A" as const, parser: Form_4 },
+  { dir: "form-5", form: "5" as const, parser: Form_5 },
+];
+
+function listFixtures(dir: string): string[] {
+  return readdirSync(join(__dirname, "mock_data", dir)).filter((f) =>
+    f.endsWith("-primary_doc.xml")
+  );
+}
+
+describe("OwnershipDocument storage (Forms 3/4/5)", () => {
+  let repo: Section16Repo;
+
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+    repo = new Section16Repo();
+  });
+
+  it("parses and stores every fixture without error", async () => {
+    const errors: Array<{ file: string; error: string }> = [];
+    let count = 0;
+
+    for (const { dir, form, parser } of CASES) {
+      for (const file of listFixtures(dir)) {
+        count++;
+        const accession = accessionFromFixtureName(file);
+        try {
+          const xml = readFileSync(join(__dirname, "mock_data", dir, file), "utf-8");
+          const doc = await (parser as typeof Form_4).parse(form as "4", xml);
+          await processOwnershipForm({
+            cik: parseCikSafely(doc.issuer?.issuerCik),
+            file_number: "",
+            accession_number: accession,
+            filing_date: "2026-05-27",
+            primary_doc: file,
+            form,
+            doc,
+          });
+          const filing = await repo.getFiling(accession);
+          expect(filing).toBeDefined();
+          expect(filing!.form).toBe(form);
+        } catch (error) {
+          errors.push({ file, error: error instanceof Error ? error.message : String(error) });
+        }
+      }
+    }
+
+    expect(count).toBeGreaterThan(0);
+    expect(errors).toEqual([]);
+  });
+
+  it("stores a Form 4 with non-derivative and derivative transactions", async () => {
+    const accession = "0001493152-26-025476";
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-4", "000149315226025476-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_4.parse("4", xml);
+    await processOwnershipForm({
+      cik: 1828673,
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "4",
+      doc,
+    });
+
+    const filing = await repo.getFiling(accession);
+    expect(filing?.issuer_name).toBe("HCW Biologics Inc.");
+    expect(filing?.not_subject_to_section16).toBe(false);
+
+    const txns = await repo.getTransactions(accession);
+    expect(txns.length).toBe(2);
+
+    const nonDeriv = txns.find((t) => !t.is_derivative)!;
+    expect(nonDeriv.transaction_code).toBe("P");
+    expect(nonDeriv.shares).toBe(177936);
+    expect(nonDeriv.price_per_share).toBe(1.405);
+    expect(nonDeriv.acquired_disposed_code).toBe("A");
+    expect(nonDeriv.shares_owned_following).toBe(203441);
+
+    const deriv = txns.find((t) => t.is_derivative)!;
+    expect(deriv.conversion_or_exercise_price).toBe(1.28);
+    expect(deriv.expiration_date).toBe("2031-11-22");
+    expect(deriv.underlying_security_title).toBe("Common Stock");
+    expect(deriv.underlying_security_shares).toBe(177936);
+  });
+
+  it("classifies directors/officers as persons and entities as companies", async () => {
+    // Multi-owner Form 4: an individual 10% owner plus two fund entities.
+    const accession = "0000902664-26-002604";
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-4", "000090266426002604-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_4.parse("4", xml);
+    await processOwnershipForm({
+      cik: 885508,
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "4",
+      doc,
+    });
+
+    const persons = (await new PersonObservationRepo().listByAccession(accession)).map(
+      (p) => p.last_name
+    );
+    const companies = (await new CompanyObservationRepo().listByAccession(accession)).map(
+      (c) => c.name
+    );
+
+    expect(persons).toContain("Fischer Seth");
+    expect(companies).toContain("STRATUS PROPERTIES INC"); // issuer
+    expect(companies).toContain("Oasis Management Co Ltd.");
+    expect(companies).toContain("Oasis Investments II Master Fund Ltd.");
+  });
+
+  it("stores Form 3/A holdings (non-derivative and derivative)", async () => {
+    const accession = "0000950103-26-007758";
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-3-a", "000095010326007758-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_3.parse("3/A", xml);
+    await processOwnershipForm({
+      cik: 1122411,
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "3/A",
+      doc,
+    });
+
+    const holdings = await repo.getHoldings(accession);
+    expect(holdings.length).toBe(3);
+
+    const nonDeriv = holdings.filter((h) => !h.is_derivative);
+    expect(nonDeriv.length).toBe(1);
+    expect(nonDeriv[0].security_title).toBe("Ordinary Shares");
+    expect(nonDeriv[0].shares_owned_following).toBe(30000);
+
+    const deriv = holdings.filter((h) => h.is_derivative);
+    expect(deriv.length).toBe(2);
+    expect(deriv[0].conversion_or_exercise_price).toBe(41.1);
+    expect(deriv[0].underlying_security_shares).toBe(365000);
+    // exerciseDate carried only a footnote id -> null, no transaction rows.
+    expect(deriv[0].exercise_date).toBeNull();
+
+    // A Form 3 reports holdings only, never transactions.
+    expect((await repo.getTransactions(accession)).length).toBe(0);
+
+    // The officer is observed as a person with the officer title.
+    const persons = await new PersonObservationRepo().listByAccession(accession);
+    expect(persons.some((p) => p.last_name === "Chung Chih-Hsiao")).toBe(true);
+  });
+});

--- a/src/sec/forms/insider-trading/OwnershipDocument.storage.test.ts
+++ b/src/sec/forms/insider-trading/OwnershipDocument.storage.test.ts
@@ -144,6 +144,44 @@ describe("OwnershipDocument storage (Forms 3/4/5)", () => {
     expect(companies).toContain("Oasis Investments II Master Fund Ltd.");
   });
 
+  it("clears stale rows when a filing is re-extracted with fewer transactions", async () => {
+    const accession = "0001493152-26-025476";
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-4", "000149315226025476-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_4.parse("4", xml);
+
+    // First pass: one non-derivative + one derivative transaction = 2 rows.
+    await processOwnershipForm({
+      cik: 1828673,
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "4",
+      doc,
+    });
+    expect((await repo.getTransactions(accession)).length).toBe(2);
+
+    // Re-extract the same accession but with the derivative table removed, as a
+    // parser change reducing the row count would produce.
+    const fewer = { ...doc, derivativeTable: undefined };
+    await processOwnershipForm({
+      cik: 1828673,
+      file_number: "",
+      accession_number: accession,
+      filing_date: "2026-05-27",
+      primary_doc: "x.xml",
+      form: "4",
+      doc: fewer,
+    });
+
+    const txns = await repo.getTransactions(accession);
+    expect(txns.length).toBe(1); // no orphaned derivative row left behind
+    expect(txns[0].is_derivative).toBe(false);
+  });
+
   it("stores Form 3/A holdings (non-derivative and derivative)", async () => {
     const accession = "0000950103-26-007758";
     const xml = readFileSync(

--- a/src/sec/forms/insider-trading/OwnershipDocument.storage.ts
+++ b/src/sec/forms/insider-trading/OwnershipDocument.storage.ts
@@ -28,6 +28,7 @@ import { CanonicalCompanyPhoneRepo } from "../../../storage/canonical/CanonicalC
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../../storage/versioning/ComponentVersionSchema";
 import { VersionRegistry } from "../../../storage/versioning/VersionRegistry";
 import { getActiveSlot } from "../../../storage/versioning/getActiveSlot";
+import { formToExtractorId } from "../../../storage/versioning/extractorIds";
 import { Section16Repo } from "../../../storage/section16/Section16Repo";
 import type {
   Section16Holding,
@@ -225,9 +226,12 @@ export async function processOwnershipForm({
   const activeResolverCompanyVersion = companySlot?.semver ?? "1.0.0";
   const extractor_version = "1.0.0";
 
-  // The canonical extractor id is the bare document type (3/4/5); amendments
-  // share the same extractor.
-  const extractor_id = (str(doc.documentType) ?? form).replace("/A", "");
+  // Use the same canonical extractor id the dispatch task records against
+  // (amendments share the base extractor), so observation rows and
+  // extractor_runs/version slots never disagree. Fall back to the bare
+  // document type only for forms not in the mapping.
+  const extractor_id =
+    formToExtractorId(form) ?? (str(doc.documentType) ?? form).replace("/A", "");
   const issuer_cik = parseCikSafely(doc.issuer?.issuerCik) || cik;
 
   const personResolver = new PersonResolver({
@@ -282,6 +286,11 @@ export async function processOwnershipForm({
 
   await processIssuer(doc, ctx);
   await processReportingOwners(doc, ctx);
+
+  // Re-extraction reuses the same positional indices, so clear any prior rows
+  // first to avoid leaving stale orphans when a filing now yields fewer.
+  await section16Repo.clearTransactions(accession_number);
+  await section16Repo.clearHoldings(accession_number);
 
   // Transactions: non-derivative first, then derivative, in a single index space.
   let txnIndex = 0;

--- a/src/sec/forms/insider-trading/OwnershipDocument.storage.ts
+++ b/src/sec/forms/insider-trading/OwnershipDocument.storage.ts
@@ -199,7 +199,6 @@ async function processIssuer(doc: OwnershipDocument, ctx: OwnershipStorageContex
 }
 
 export async function processOwnershipForm({
-  cik,
   accession_number,
   filing_date,
   form,
@@ -232,7 +231,11 @@ export async function processOwnershipForm({
   // document type only for forms not in the mapping.
   const extractor_id =
     formToExtractorId(form) ?? (str(doc.documentType) ?? form).replace("/A", "");
-  const issuer_cik = parseCikSafely(doc.issuer?.issuerCik) || cik;
+  // The XML issuerCik is authoritative. We must NOT fall back to the filing's
+  // own CIK: ownership filings are ingested from a submission feed that may be
+  // the reporting owner's, not the issuer's, so that fallback could stamp the
+  // owner's CIK as the issuer. 0 is the honest "unknown" sentinel.
+  const issuer_cik = parseCikSafely(doc.issuer?.issuerCik);
 
   const personResolver = new PersonResolver({
     canonicalPersonRepo: new CanonicalPersonRepo(),
@@ -277,7 +280,7 @@ export async function processOwnershipForm({
     issuer_cik,
     issuer_name: str(doc.issuer?.issuerName) ?? "",
     issuer_trading_symbol: str(doc.issuer?.issuerTradingSymbol),
-    period_of_report: str(doc.periodOfReport) ?? (filing_date || null),
+    period_of_report: str(doc.periodOfReport),
     filing_date: filing_date || null,
     not_subject_to_section16: toBool(doc.notSubjectToSection16),
     no_securities_owned: toBool(doc.noSecuritiesOwned),

--- a/src/sec/forms/insider-trading/OwnershipDocument.storage.ts
+++ b/src/sec/forms/insider-trading/OwnershipDocument.storage.ts
@@ -1,0 +1,446 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { AddressRepo } from "../../../storage/address/AddressRepo";
+import type { AddressImport } from "../../../storage/address/AddressNormalization";
+import { hasCompanyEnding } from "../../../storage/company/CompanyNormalization";
+import { isBadPersonField } from "../../../types/edgar/bad-data";
+import { parseCikSafely } from "../../../util/parseCik";
+import { EntityObserver } from "../../../resolver/EntityObserver";
+import { PersonResolver } from "../../../resolver/PersonResolver";
+import { CompanyResolver } from "../../../resolver/CompanyResolver";
+import { PersonObservationRepo } from "../../../storage/observation/PersonObservationRepo";
+import { CompanyObservationRepo } from "../../../storage/observation/CompanyObservationRepo";
+import { PersonIdentityLinkRepo } from "../../../storage/canonical/PersonIdentityLinkRepo";
+import { CompanyIdentityLinkRepo } from "../../../storage/canonical/CompanyIdentityLinkRepo";
+import { CanonicalPersonRepo } from "../../../storage/canonical/CanonicalPersonRepo";
+import { CanonicalCompanyRepo } from "../../../storage/canonical/CanonicalCompanyRepo";
+import { CanonicalPersonAliasRepo } from "../../../storage/canonical/CanonicalPersonAliasRepo";
+import { CanonicalCompanyAliasRepo } from "../../../storage/canonical/CanonicalCompanyAliasRepo";
+import { CanonicalPersonAddressRepo } from "../../../storage/canonical/CanonicalPersonAddressRepo";
+import { CanonicalPersonPhoneRepo } from "../../../storage/canonical/CanonicalPersonPhoneRepo";
+import { CanonicalCompanyAddressRepo } from "../../../storage/canonical/CanonicalCompanyAddressRepo";
+import { CanonicalCompanyPhoneRepo } from "../../../storage/canonical/CanonicalCompanyPhoneRepo";
+import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../../storage/versioning/ComponentVersionSchema";
+import { VersionRegistry } from "../../../storage/versioning/VersionRegistry";
+import { getActiveSlot } from "../../../storage/versioning/getActiveSlot";
+import { Section16Repo } from "../../../storage/section16/Section16Repo";
+import type {
+  Section16Holding,
+  Section16Transaction,
+} from "../../../storage/section16/Section16Schema";
+import type { OwnershipDocument } from "./OwnershipDocument.schema";
+
+// EDGAR ownership flags appear as "1"/"0" (X0609) or "true"/"false" (X0607).
+function toBool(raw: string | undefined): boolean {
+  if (raw === undefined) return false;
+  const v = raw.trim().toLowerCase();
+  return v === "1" || v === "true";
+}
+
+// Unwrap a `{ value }` leaf to its string, treating empty as null.
+function str(field: { value?: string } | string | undefined): string | null {
+  if (field === undefined || field === null) return null;
+  if (typeof field === "string") return field.trim() || null;
+  const v = field.value;
+  return v === undefined || v === null || String(v).trim() === "" ? null : String(v).trim();
+}
+
+// Unwrap a `{ value }` leaf to a finite number, or null.
+function num(field: { value?: number | string } | string | undefined): number | null {
+  if (field === undefined || field === null || typeof field === "string") return null;
+  const v = field.value;
+  if (v === undefined || v === null || String(v).trim() === "") return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+interface OwnershipStorageContext {
+  readonly accession_number: string;
+  readonly extractor_id: string;
+  readonly extractor_version: string;
+  readonly issuer_cik: number;
+  readonly observer: EntityObserver;
+}
+
+/**
+ * Builds a human-readable relationship label and officer title from the
+ * reportingOwnerRelationship flags.
+ */
+function describeRelationship(rel: NonNullable<
+  OwnershipDocument["reportingOwner"]
+>[number]["reportingOwnerRelationship"]): { relationship: string; title: string | null } {
+  if (!rel) return { relationship: "reporting-owner", title: null };
+  const roles: string[] = [];
+  if (toBool(rel.isDirector)) roles.push("director");
+  if (toBool(rel.isOfficer)) roles.push("officer");
+  if (toBool(rel.isTenPercentOwner)) roles.push("10% owner");
+  if (toBool(rel.isOther)) roles.push(str(rel.otherText) ?? "other");
+  const title = toBool(rel.isOfficer) ? str(rel.officerTitle) : null;
+  return {
+    relationship: roles.length ? roles.join(", ") : "reporting-owner",
+    title,
+  };
+}
+
+// EDGAR ownership filings carry no explicit person/entity flag. Directors and
+// officers are always individuals, so those flags decide outright. Otherwise we
+// fall back to a company-ending test on a cleaned name — stripping trailing
+// punctuation and a lone trailing initial ("SMITH JOHN A") that would otherwise
+// trip the ending regex.
+function ownerIsCompany(
+  name: string,
+  rel: NonNullable<OwnershipDocument["reportingOwner"]>[number]["reportingOwnerRelationship"]
+): boolean {
+  if (rel && (toBool(rel.isDirector) || toBool(rel.isOfficer))) return false;
+  const cleaned = name
+    .trim()
+    .replace(/[.,]+$/, "")
+    .replace(/\s+[A-Z]$/, "")
+    .trim();
+  return hasCompanyEnding(cleaned);
+}
+
+function buildOwnerAddress(
+  addr: NonNullable<OwnershipDocument["reportingOwner"]>[number]["reportingOwnerAddress"]
+): AddressImport | null {
+  if (!addr) return null;
+  const street1 = str(addr.rptOwnerStreet1);
+  const city = str(addr.rptOwnerCity);
+  const stateOrCountry = str(addr.rptOwnerState) ?? str(addr.rptOwnerNonUSStateTerritory);
+  if (!street1 && !city) return null;
+  return {
+    street1,
+    street2: str(addr.rptOwnerStreet2),
+    city,
+    stateOrCountry,
+    countryCode: str(addr.rptOwnerCountry),
+    stateOrCountryDescription: str(addr.rptOwnerStateDescription),
+    zipCode: str(addr.rptOwnerZipCode),
+    isForeignLocation: toBool(addr.rptOwnerNonUSAddressFlag),
+  };
+}
+
+async function processReportingOwners(
+  doc: OwnershipDocument,
+  ctx: OwnershipStorageContext
+): Promise<void> {
+  const owners = doc.reportingOwner ?? [];
+  const addressRepo = new AddressRepo();
+
+  for (let i = 0; i < owners.length; i++) {
+    const owner = owners[i];
+    const name = str(owner.reportingOwnerId?.rptOwnerName);
+    if (!name) continue;
+
+    const cik = parseCikSafely(owner.reportingOwnerId?.rptOwnerCik) || null;
+    const { relationship, title } = describeRelationship(owner.reportingOwnerRelationship);
+
+    let address_id: string | null = null;
+    const addrImport = buildOwnerAddress(owner.reportingOwnerAddress);
+    if (addrImport) {
+      try {
+        const saved = await addressRepo.saveAddress(addrImport);
+        address_id = saved.address_hash_id;
+      } catch (error) {
+        console.warn(`Failed to save address for reporting owner ${name}:`, error);
+      }
+    }
+
+    const observation_index = i + 1; // 0 reserved for the issuer
+    const source_context = JSON.stringify({ relation: "section16:reporting-owner", relationship });
+
+    if (ownerIsCompany(name, owner.reportingOwnerRelationship)) {
+      await ctx.observer.observeCompany({
+        accession_number: ctx.accession_number,
+        extractor_id: ctx.extractor_id,
+        extractor_version: ctx.extractor_version,
+        observation_index,
+        cik,
+        name,
+        address_id,
+        source_context,
+      });
+    } else if (!isBadPersonField(name)) {
+      await ctx.observer.observePerson({
+        accession_number: ctx.accession_number,
+        extractor_id: ctx.extractor_id,
+        extractor_version: ctx.extractor_version,
+        observation_index,
+        source_filing_issuer_cik: ctx.issuer_cik,
+        cik,
+        last_name: name,
+        title,
+        relationship,
+        address_id,
+        source_context,
+      });
+    }
+  }
+}
+
+async function processIssuer(doc: OwnershipDocument, ctx: OwnershipStorageContext): Promise<void> {
+  const issuerName = str(doc.issuer?.issuerName);
+  if (!issuerName) return;
+  await ctx.observer.observeCompany({
+    accession_number: ctx.accession_number,
+    extractor_id: ctx.extractor_id,
+    extractor_version: ctx.extractor_version,
+    observation_index: 0,
+    cik: ctx.issuer_cik || null,
+    name: issuerName,
+    source_context: JSON.stringify({ relation: "section16:issuer" }),
+  });
+}
+
+export async function processOwnershipForm({
+  cik,
+  accession_number,
+  filing_date,
+  form,
+  doc,
+}: {
+  cik: number;
+  file_number: string;
+  accession_number: string;
+  filing_date: string;
+  primary_doc: string;
+  form: string;
+  doc: OwnershipDocument;
+}): Promise<void> {
+  const versionRegistry = new VersionRegistry(
+    globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
+  );
+
+  const [personSlot, companySlot] = await Promise.all([
+    getActiveSlot(versionRegistry, "resolver", "person"),
+    getActiveSlot(versionRegistry, "resolver", "company"),
+  ]);
+
+  const activeResolverPersonVersion = personSlot?.semver ?? "1.0.0";
+  const activeResolverCompanyVersion = companySlot?.semver ?? "1.0.0";
+  const extractor_version = "1.0.0";
+
+  // The canonical extractor id is the bare document type (3/4/5); amendments
+  // share the same extractor.
+  const extractor_id = (str(doc.documentType) ?? form).replace("/A", "");
+  const issuer_cik = parseCikSafely(doc.issuer?.issuerCik) || cik;
+
+  const personResolver = new PersonResolver({
+    canonicalPersonRepo: new CanonicalPersonRepo(),
+    canonicalPersonAliasRepo: new CanonicalPersonAliasRepo(),
+    activeResolverVersion: activeResolverPersonVersion,
+  });
+  const companyResolver = new CompanyResolver({
+    canonicalCompanyRepo: new CanonicalCompanyRepo(),
+    canonicalCompanyAliasRepo: new CanonicalCompanyAliasRepo(),
+    activeResolverVersion: activeResolverCompanyVersion,
+  });
+
+  const observer = new EntityObserver({
+    personObservationRepo: new PersonObservationRepo(),
+    companyObservationRepo: new CompanyObservationRepo(),
+    personIdentityLinkRepo: new PersonIdentityLinkRepo(),
+    companyIdentityLinkRepo: new CompanyIdentityLinkRepo(),
+    personResolver,
+    companyResolver,
+    canonicalPersonAddressRepo: new CanonicalPersonAddressRepo(),
+    canonicalPersonPhoneRepo: new CanonicalPersonPhoneRepo(),
+    canonicalCompanyAddressRepo: new CanonicalCompanyAddressRepo(),
+    canonicalCompanyPhoneRepo: new CanonicalCompanyPhoneRepo(),
+    activeResolverPersonVersion,
+    activeResolverCompanyVersion,
+  });
+
+  const ctx: OwnershipStorageContext = {
+    accession_number,
+    extractor_id,
+    extractor_version,
+    issuer_cik,
+    observer,
+  };
+
+  const section16Repo = new Section16Repo();
+
+  await section16Repo.saveFiling({
+    accession_number,
+    form,
+    document_type: str(doc.documentType) ?? form,
+    issuer_cik,
+    issuer_name: str(doc.issuer?.issuerName) ?? "",
+    issuer_trading_symbol: str(doc.issuer?.issuerTradingSymbol),
+    period_of_report: str(doc.periodOfReport) ?? (filing_date || null),
+    filing_date: filing_date || null,
+    not_subject_to_section16: toBool(doc.notSubjectToSection16),
+    no_securities_owned: toBool(doc.noSecuritiesOwned),
+    remarks: str(doc.remarks),
+  });
+
+  await processIssuer(doc, ctx);
+  await processReportingOwners(doc, ctx);
+
+  // Transactions: non-derivative first, then derivative, in a single index space.
+  let txnIndex = 0;
+  for (const t of doc.nonDerivativeTable?.nonDerivativeTransaction ?? []) {
+    await section16Repo.saveTransaction(nonDerivativeTransactionRow(t, accession_number, issuer_cik, txnIndex++));
+  }
+  for (const t of doc.derivativeTable?.derivativeTransaction ?? []) {
+    await section16Repo.saveTransaction(derivativeTransactionRow(t, accession_number, issuer_cik, txnIndex++));
+  }
+
+  // Holdings: non-derivative first, then derivative.
+  let holdIndex = 0;
+  for (const h of doc.nonDerivativeTable?.nonDerivativeHolding ?? []) {
+    await section16Repo.saveHolding(nonDerivativeHoldingRow(h, accession_number, issuer_cik, holdIndex++));
+  }
+  for (const h of doc.derivativeTable?.derivativeHolding ?? []) {
+    await section16Repo.saveHolding(derivativeHoldingRow(h, accession_number, issuer_cik, holdIndex++));
+  }
+}
+
+type NonDerivTxn = NonNullable<
+  NonNullable<OwnershipDocument["nonDerivativeTable"]>["nonDerivativeTransaction"]
+>[number];
+type DerivTxn = NonNullable<
+  NonNullable<OwnershipDocument["derivativeTable"]>["derivativeTransaction"]
+>[number];
+type NonDerivHold = NonNullable<
+  NonNullable<OwnershipDocument["nonDerivativeTable"]>["nonDerivativeHolding"]
+>[number];
+type DerivHold = NonNullable<
+  NonNullable<OwnershipDocument["derivativeTable"]>["derivativeHolding"]
+>[number];
+
+function nonDerivativeTransactionRow(
+  t: NonDerivTxn,
+  accession_number: string,
+  issuer_cik: number,
+  transaction_index: number
+): Section16Transaction {
+  const code = t.transactionCoding;
+  const amt = t.transactionAmounts;
+  const post = t.postTransactionAmounts;
+  const own = t.ownershipNature;
+  return {
+    accession_number,
+    transaction_index,
+    issuer_cik,
+    is_derivative: false,
+    security_title: str(t.securityTitle),
+    transaction_date: str(t.transactionDate),
+    deemed_execution_date: str(t.deemedExecutionDate),
+    transaction_code: code ? str(code.transactionCode) : null,
+    transaction_form_type: code ? str(code.transactionFormType) : null,
+    equity_swap_involved: code?.equitySwapInvolved ? toBool(code.equitySwapInvolved) : null,
+    acquired_disposed_code: amt ? str(amt.transactionAcquiredDisposedCode) : null,
+    shares: amt ? num(amt.transactionShares) : null,
+    price_per_share: amt ? num(amt.transactionPricePerShare) : null,
+    shares_owned_following: post ? num(post.sharesOwnedFollowingTransaction) : null,
+    value_owned_following: post ? num(post.valueOwnedFollowingTransaction) : null,
+    direct_or_indirect_ownership: own ? str(own.directOrIndirectOwnership) : null,
+    nature_of_ownership: own ? str(own.natureOfOwnership) : null,
+    conversion_or_exercise_price: null,
+    exercise_date: null,
+    expiration_date: null,
+    underlying_security_title: null,
+    underlying_security_shares: null,
+    underlying_security_value: null,
+  };
+}
+
+function derivativeTransactionRow(
+  t: DerivTxn,
+  accession_number: string,
+  issuer_cik: number,
+  transaction_index: number
+): Section16Transaction {
+  const code = t.transactionCoding;
+  const amt = t.transactionAmounts;
+  const post = t.postTransactionAmounts;
+  const own = t.ownershipNature;
+  const under = t.underlyingSecurity;
+  return {
+    accession_number,
+    transaction_index,
+    issuer_cik,
+    is_derivative: true,
+    security_title: str(t.securityTitle),
+    transaction_date: str(t.transactionDate),
+    deemed_execution_date: str(t.deemedExecutionDate),
+    transaction_code: code ? str(code.transactionCode) : null,
+    transaction_form_type: code ? str(code.transactionFormType) : null,
+    equity_swap_involved: code?.equitySwapInvolved ? toBool(code.equitySwapInvolved) : null,
+    acquired_disposed_code: amt ? str(amt.transactionAcquiredDisposedCode) : null,
+    shares: amt ? num(amt.transactionShares) : null,
+    price_per_share: amt ? num(amt.transactionPricePerShare) : null,
+    shares_owned_following: post ? num(post.sharesOwnedFollowingTransaction) : null,
+    value_owned_following: post ? num(post.valueOwnedFollowingTransaction) : null,
+    direct_or_indirect_ownership: own ? str(own.directOrIndirectOwnership) : null,
+    nature_of_ownership: own ? str(own.natureOfOwnership) : null,
+    conversion_or_exercise_price: num(t.conversionOrExercisePrice),
+    exercise_date: str(t.exerciseDate),
+    expiration_date: str(t.expirationDate),
+    underlying_security_title: under ? str(under.underlyingSecurityTitle) : null,
+    underlying_security_shares: under ? num(under.underlyingSecurityShares) : null,
+    underlying_security_value: under ? num(under.underlyingSecurityValue) : null,
+  };
+}
+
+function nonDerivativeHoldingRow(
+  h: NonDerivHold,
+  accession_number: string,
+  issuer_cik: number,
+  holding_index: number
+): Section16Holding {
+  const post = h.postTransactionAmounts;
+  const own = h.ownershipNature;
+  return {
+    accession_number,
+    holding_index,
+    issuer_cik,
+    is_derivative: false,
+    security_title: str(h.securityTitle),
+    shares_owned_following: post ? num(post.sharesOwnedFollowingTransaction) : null,
+    value_owned_following: post ? num(post.valueOwnedFollowingTransaction) : null,
+    direct_or_indirect_ownership: own ? str(own.directOrIndirectOwnership) : null,
+    nature_of_ownership: own ? str(own.natureOfOwnership) : null,
+    conversion_or_exercise_price: null,
+    exercise_date: null,
+    expiration_date: null,
+    underlying_security_title: null,
+    underlying_security_shares: null,
+    underlying_security_value: null,
+  };
+}
+
+function derivativeHoldingRow(
+  h: DerivHold,
+  accession_number: string,
+  issuer_cik: number,
+  holding_index: number
+): Section16Holding {
+  const post = h.postTransactionAmounts;
+  const own = h.ownershipNature;
+  const under = h.underlyingSecurity;
+  return {
+    accession_number,
+    holding_index,
+    issuer_cik,
+    is_derivative: true,
+    security_title: str(h.securityTitle),
+    shares_owned_following: post ? num(post.sharesOwnedFollowingTransaction) : null,
+    value_owned_following: post ? num(post.valueOwnedFollowingTransaction) : null,
+    direct_or_indirect_ownership: own ? str(own.directOrIndirectOwnership) : null,
+    nature_of_ownership: own ? str(own.natureOfOwnership) : null,
+    conversion_or_exercise_price: num(h.conversionOrExercisePrice),
+    exercise_date: str(h.exerciseDate),
+    expiration_date: str(h.expirationDate),
+    underlying_security_title: under ? str(under.underlyingSecurityTitle) : null,
+    underlying_security_shares: under ? num(under.underlyingSecurityShares) : null,
+    underlying_security_value: under ? num(under.underlyingSecurityValue) : null,
+  };
+}

--- a/src/sec/forms/insider-trading/OwnershipDocument.test.ts
+++ b/src/sec/forms/insider-trading/OwnershipDocument.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { Form_3 } from "./Form_3";
+import { Form_4 } from "./Form_4";
+import { Form_5 } from "./Form_5";
+
+const CASES = [
+  { dir: "form-3", form: "3" as const, parser: Form_3, expectType: "3" },
+  { dir: "form-3-a", form: "3/A" as const, parser: Form_3, expectType: "3/A" },
+  { dir: "form-4", form: "4" as const, parser: Form_4, expectType: "4" },
+  { dir: "form-4-a", form: "4/A" as const, parser: Form_4, expectType: "4/A" },
+  { dir: "form-5", form: "5" as const, parser: Form_5, expectType: "5" },
+];
+
+function listFixtures(dir: string): string[] {
+  return readdirSync(join(__dirname, "mock_data", dir)).filter((f) =>
+    f.endsWith("-primary_doc.xml")
+  );
+}
+
+describe("OwnershipDocument parsing (Forms 3/4/5)", () => {
+  for (const { dir, form, parser, expectType } of CASES) {
+    it(`parses every ${form} fixture in mock_data/${dir}`, async () => {
+      const files = listFixtures(dir);
+      expect(files.length).toBeGreaterThan(0);
+
+      for (const file of files) {
+        const xml = readFileSync(join(__dirname, "mock_data", dir, file), "utf-8");
+        const doc = await (parser as typeof Form_4).parse(form as "4", xml);
+
+        expect(doc).toBeDefined();
+        expect(doc.documentType).toBe(expectType);
+        expect(doc.issuer?.issuerCik).toMatch(/^\d+$/);
+        expect(doc.issuer?.issuerName).toBeTruthy();
+        // reportingOwner is always forced to an array by the parser.
+        expect(Array.isArray(doc.reportingOwner)).toBe(true);
+        expect(doc.reportingOwner!.length).toBeGreaterThan(0);
+      }
+    });
+  }
+
+  it("forces single-element tables into arrays", async () => {
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-4", "000149315226025476-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_4.parse("4", xml);
+    expect(Array.isArray(doc.nonDerivativeTable?.nonDerivativeTransaction)).toBe(true);
+    expect(doc.nonDerivativeTable?.nonDerivativeTransaction?.length).toBe(1);
+    expect(Array.isArray(doc.derivativeTable?.derivativeTransaction)).toBe(true);
+    expect(doc.derivativeTable?.derivativeTransaction?.length).toBe(1);
+  });
+
+  it("unwraps and coerces value-wrapped leaves", async () => {
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-4", "000149315226025476-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_4.parse("4", xml);
+    const txn = doc.nonDerivativeTable!.nonDerivativeTransaction![0];
+    expect(txn.transactionAmounts?.transactionShares?.value).toBe(177936);
+    expect(txn.transactionAmounts?.transactionPricePerShare?.value).toBe(1.405);
+    expect(txn.securityTitle?.value).toBe("Common Stock");
+  });
+
+  it("parses derivative and non-derivative holdings on a Form 3/A", async () => {
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-3-a", "000095010326007758-primary_doc.xml"),
+      "utf-8"
+    );
+    const doc = await Form_3.parse("3/A", xml);
+    expect(doc.nonDerivativeTable?.nonDerivativeHolding?.length).toBe(1);
+    expect(doc.derivativeTable?.derivativeHolding?.length).toBe(2);
+    // exerciseDate carries only a footnoteId (no value) — must not crash.
+    expect(doc.derivativeTable?.derivativeHolding?.[0]?.exerciseDate?.value).toBeUndefined();
+  });
+
+  it("rejects a mismatched form symbol", async () => {
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-4", "000090266426002604-primary_doc.xml"),
+      "utf-8"
+    );
+    // @ts-expect-error intentionally passing a symbol Form_4 does not handle
+    await expect(Form_4.parse("3", xml)).rejects.toThrow();
+  });
+});

--- a/src/sec/forms/insider-trading/mock_data/form-144-a/000166326626000004-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-144-a/000166326626000004-primary_doc.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?><edgarSubmission xmlns="http://www.sec.gov/edgar/ownership" xmlns:com="http://www.sec.gov/edgar/common">
+  <headerData>
+    <submissionType>144/A</submissionType>
+    <previousAccessionNumber>0001663266-26-000001</previousAccessionNumber>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>0001663266</cik>
+          <ccc>XXXXXXXX</ccc>
+        </filerCredentials>
+      </filer>
+      <liveTestFlag>LIVE</liveTestFlag>
+
+
+
+    </filerInfo>
+  </headerData>
+  <formData>
+    <issuerInfo>
+      <issuerCik>0001915657</issuerCik>
+      <issuerName>HF Sinclair </issuerName>
+      <secFileNumber>001-41325</secFileNumber>
+      <issuerAddress>
+        <com:street1>2323 VICTORY AVENUE</com:street1>
+        <com:street2>SUITE 1400</com:street2>
+        <com:city>DALLAS</com:city>
+        <com:stateOrCountry>TX</com:stateOrCountry>
+        <com:zipCode>75219</com:zipCode>
+      </issuerAddress>
+      <issuerContactPhone>214-954-6696</issuerContactPhone>
+      <nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>Go Timothy</nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>
+      <relationshipsToIssuer>
+        <relationshipToIssuer>Former Employee</relationshipToIssuer>
+      </relationshipsToIssuer>
+    </issuerInfo>
+    <securitiesInformation>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <brokerOrMarketmakerDetails>
+        <name>Pershing Advisor Solutions</name>
+        <address>
+          <com:street1>One Pershing Plaza</com:street1>
+          <com:city>Jersey City</com:city>
+          <com:stateOrCountry>NJ</com:stateOrCountry>
+          <com:zipCode>07399</com:zipCode>
+        </address>
+      </brokerOrMarketmakerDetails>
+      <noOfUnitsSold>16184</noOfUnitsSold>
+      <aggregateMarketValue>1123856.61</aggregateMarketValue>
+      <noOfUnitsOutstanding>180275437</noOfUnitsOutstanding>
+      <approxSaleDate>05/15/2026</approxSaleDate>
+      <securitiesExchangeName>NYSE</securitiesExchangeName>
+    </securitiesInformation>
+    <securitiesToBeSold>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <acquiredDate>12/01/2022</acquiredDate>
+      <natureOfAcquisitionTransaction>Vested Stock</natureOfAcquisitionTransaction>
+      <nameOfPersonfromWhomAcquired>HF SInclair</nameOfPersonfromWhomAcquired>
+      <isGiftTransaction>N</isGiftTransaction>
+      <amountOfSecuritiesAcquired>16184</amountOfSecuritiesAcquired>
+      <paymentDate>12/01/2022</paymentDate>
+      <natureOfPayment>Vested Stock</natureOfPayment>
+    </securitiesToBeSold>
+    <nothingToReportFlagOnSecuritiesSoldInPast3Months>Y</nothingToReportFlagOnSecuritiesSoldInPast3Months>
+    <noticeSignature>
+      <noticeDate>05/27/2026</noticeDate>
+      <signature>TimothyGo</signature>
+    </noticeSignature>
+  </formData>
+</edgarSubmission>

--- a/src/sec/forms/insider-trading/mock_data/form-144/000166326626000003-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-144/000166326626000003-primary_doc.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?><edgarSubmission xmlns="http://www.sec.gov/edgar/ownership" xmlns:com="http://www.sec.gov/edgar/common">
+  <headerData>
+    <submissionType>144</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>0001663266</cik>
+          <ccc>XXXXXXXX</ccc>
+        </filerCredentials>
+      </filer>
+      <liveTestFlag>LIVE</liveTestFlag>
+
+
+
+    </filerInfo>
+  </headerData>
+  <formData>
+    <issuerInfo>
+      <issuerCik>0001534263</issuerCik>
+      <issuerName>HF Sinclair</issuerName>
+      <secFileNumber>000-56092</secFileNumber>
+      <issuerAddress>
+        <com:street1>2323 Victory Avenue Suite 1400</com:street1>
+        <com:street2>SUITE D582</com:street2>
+        <com:city>Dallas</com:city>
+        <com:stateOrCountry>TX</com:stateOrCountry>
+        <com:zipCode>75219</com:zipCode>
+      </issuerAddress>
+      <issuerContactPhone>2148713555</issuerContactPhone>
+      <nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>Go Timothy</nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>
+      <relationshipsToIssuer>
+        <relationshipToIssuer>Former Employee</relationshipToIssuer>
+      </relationshipsToIssuer>
+    </issuerInfo>
+    <securitiesInformation>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <brokerOrMarketmakerDetails>
+        <name>Pershing Advisor Solutions</name>
+        <address>
+          <com:street1>One Pershing Plaza</com:street1>
+          <com:city>Jersey City</com:city>
+          <com:stateOrCountry>NJ</com:stateOrCountry>
+          <com:zipCode>07399</com:zipCode>
+        </address>
+      </brokerOrMarketmakerDetails>
+      <noOfUnitsSold>129915</noOfUnitsSold>
+      <aggregateMarketValue>9019409.69</aggregateMarketValue>
+      <noOfUnitsOutstanding>180275437</noOfUnitsOutstanding>
+      <approxSaleDate>05/26/2026</approxSaleDate>
+      <securitiesExchangeName>NYSE</securitiesExchangeName>
+    </securitiesInformation>
+    <securitiesToBeSold>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <acquiredDate>12/01/2023</acquiredDate>
+      <natureOfAcquisitionTransaction>Vested Stock</natureOfAcquisitionTransaction>
+      <nameOfPersonfromWhomAcquired>HF Sinclair</nameOfPersonfromWhomAcquired>
+      <isGiftTransaction>N</isGiftTransaction>
+      <amountOfSecuritiesAcquired>66505</amountOfSecuritiesAcquired>
+      <paymentDate>12/01/2023</paymentDate>
+      <natureOfPayment>Vesting</natureOfPayment>
+    </securitiesToBeSold>
+    <securitiesToBeSold>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <acquiredDate>12/01/2025</acquiredDate>
+      <natureOfAcquisitionTransaction>Vested Stock</natureOfAcquisitionTransaction>
+      <nameOfPersonfromWhomAcquired>HF Sinclair</nameOfPersonfromWhomAcquired>
+      <isGiftTransaction>N</isGiftTransaction>
+      <amountOfSecuritiesAcquired>63410</amountOfSecuritiesAcquired>
+      <paymentDate>12/01/2025</paymentDate>
+      <natureOfPayment>Vesting</natureOfPayment>
+    </securitiesToBeSold>
+    <nothingToReportFlagOnSecuritiesSoldInPast3Months>N</nothingToReportFlagOnSecuritiesSoldInPast3Months>
+    <securitiesSoldInPast3Months>
+      <sellerDetails>
+        <name>Timothy Go</name>
+        <address>
+          <com:street1>4325 Fairfax Ave</com:street1>
+          <com:city>Dallas</com:city>
+          <com:stateOrCountry>TX</com:stateOrCountry>
+          <com:zipCode>75206</com:zipCode>
+        </address>
+      </sellerDetails>
+      <securitiesClassTitle>HF Sinclair Corp</securitiesClassTitle>
+      <saleDate>05/15/2026</saleDate>
+      <amountOfSecuritiesSold>16814</amountOfSecuritiesSold>
+      <grossProceeds>1123856.61</grossProceeds>
+    </securitiesSoldInPast3Months>
+    <securitiesSoldInPast3Months>
+      <sellerDetails>
+        <name>Timothy Go</name>
+        <address>
+          <com:street1>4325 Fairfax Ave</com:street1>
+          <com:city>Dallas</com:city>
+          <com:stateOrCountry>TX</com:stateOrCountry>
+          <com:zipCode>75206</com:zipCode>
+        </address>
+      </sellerDetails>
+      <securitiesClassTitle>HF Sinclair Corp</securitiesClassTitle>
+      <saleDate>05/18/2026</saleDate>
+      <amountOfSecuritiesSold>4768</amountOfSecuritiesSold>
+      <grossProceeds>339958.40</grossProceeds>
+    </securitiesSoldInPast3Months>
+    <noticeSignature>
+      <noticeDate>05/27/2026</noticeDate>
+      <signature>Timothy Go</signature>
+    </noticeSignature>
+  </formData>
+</edgarSubmission>

--- a/src/sec/forms/insider-trading/mock_data/form-144/000195917326004030-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-144/000195917326004030-primary_doc.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?><edgarSubmission xmlns="http://www.sec.gov/edgar/ownership" xmlns:com="http://www.sec.gov/edgar/common">
+  <headerData>
+    <submissionType>144</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>0001346064</cik>
+          <ccc>XXXXXXXX</ccc>
+        </filerCredentials>
+      </filer>
+      <liveTestFlag>LIVE</liveTestFlag>
+
+
+
+    </filerInfo>
+  </headerData>
+  <formData>
+    <issuerInfo>
+      <issuerCik>0000943819</issuerCik>
+      <issuerName>RESMED INC</issuerName>
+      <secFileNumber>001-15317</secFileNumber>
+      <issuerAddress>
+        <com:street1>9001 SPECTRUM CENTER BLVD.</com:street1>
+        <com:city>SAN DIEGO</com:city>
+        <com:stateOrCountry>CA</com:stateOrCountry>
+        <com:zipCode>92123</com:zipCode>
+      </issuerAddress>
+      <issuerContactPhone>8587462400</issuerContactPhone>
+      <nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>Sandercock Brett</nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>
+      <relationshipsToIssuer>
+        <relationshipToIssuer>Former Officer</relationshipToIssuer>
+      </relationshipsToIssuer>
+    </issuerInfo>
+    <securitiesInformation>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <brokerOrMarketmakerDetails>
+        <name>Fidelity Brokerage Services LLC</name>
+        <address>
+          <com:street1>900 Salem Street</com:street1>
+          <com:city>Smithfield</com:city>
+          <com:stateOrCountry>RI</com:stateOrCountry>
+          <com:zipCode>02917</com:zipCode>
+        </address>
+      </brokerOrMarketmakerDetails>
+      <noOfUnitsSold>8000</noOfUnitsSold>
+      <aggregateMarketValue>1672560.00</aggregateMarketValue>
+      <noOfUnitsOutstanding>145056384</noOfUnitsOutstanding>
+      <approxSaleDate>05/27/2026</approxSaleDate>
+      <securitiesExchangeName>NYSE</securitiesExchangeName>
+    </securitiesInformation>
+    <securitiesToBeSold>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <acquiredDate>11/21/2019</acquiredDate>
+      <natureOfAcquisitionTransaction>Restricted Stock Vesting</natureOfAcquisitionTransaction>
+      <nameOfPersonfromWhomAcquired>Issuer</nameOfPersonfromWhomAcquired>
+      <isGiftTransaction>N</isGiftTransaction>
+      <amountOfSecuritiesAcquired>8000</amountOfSecuritiesAcquired>
+      <paymentDate>11/21/2019</paymentDate>
+      <natureOfPayment>Compensation</natureOfPayment>
+    </securitiesToBeSold>
+    <nothingToReportFlagOnSecuritiesSoldInPast3Months>N</nothingToReportFlagOnSecuritiesSoldInPast3Months>
+    <securitiesSoldInPast3Months>
+      <sellerDetails>
+        <name>Brett Sandercock</name>
+        <address>
+          <com:street1>9001 Spectrum Center Blvd.</com:street1>
+          <com:city>San Diego</com:city>
+          <com:stateOrCountry>CA</com:stateOrCountry>
+          <com:zipCode>92123</com:zipCode>
+        </address>
+      </sellerDetails>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <saleDate>03/02/2026</saleDate>
+      <amountOfSecuritiesSold>1000</amountOfSecuritiesSold>
+      <grossProceeds>254300.00</grossProceeds>
+    </securitiesSoldInPast3Months>
+    <securitiesSoldInPast3Months>
+      <sellerDetails>
+        <name>Brett Sandercock</name>
+        <address>
+          <com:street1>9001 Spectrum Center Blvd.</com:street1>
+          <com:city>San Diego</com:city>
+          <com:stateOrCountry>CA</com:stateOrCountry>
+          <com:zipCode>92123</com:zipCode>
+        </address>
+      </sellerDetails>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <saleDate>04/01/2026</saleDate>
+      <amountOfSecuritiesSold>1000</amountOfSecuritiesSold>
+      <grossProceeds>224310.00</grossProceeds>
+    </securitiesSoldInPast3Months>
+    <noticeSignature>
+      <noticeDate>05/27/2026</noticeDate>
+      <signature>/s/ Jared Cook, as a duly authorized representative of Fidelity Brokerage Services LLC, as attorney-in-fact for Brett Sandercock</signature>
+    </noticeSignature>
+  </formData>
+</edgarSubmission>

--- a/src/sec/forms/insider-trading/mock_data/form-144/000195917326004038-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-144/000195917326004038-primary_doc.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?><edgarSubmission xmlns="http://www.sec.gov/edgar/ownership" xmlns:com="http://www.sec.gov/edgar/common">
+  <headerData>
+    <submissionType>144</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>0001310306</cik>
+          <ccc>XXXXXXXX</ccc>
+        </filerCredentials>
+      </filer>
+      <liveTestFlag>LIVE</liveTestFlag>
+
+
+
+    </filerInfo>
+  </headerData>
+  <formData>
+    <issuerInfo>
+      <issuerCik>0001560258</issuerCik>
+      <issuerName>electroCore, Inc.</issuerName>
+      <secFileNumber>001-38538</secFileNumber>
+      <issuerAddress>
+        <com:street1>200 FORGE WAY</com:street1>
+        <com:street2>SUITE 205</com:street2>
+        <com:city>ROCKAWAY</com:city>
+        <com:stateOrCountry>NJ</com:stateOrCountry>
+        <com:zipCode>07866</com:zipCode>
+      </issuerAddress>
+      <issuerContactPhone>973-290-0097</issuerContactPhone>
+      <nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>PATTON THOMAS M</nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>
+      <relationshipsToIssuer>
+        <relationshipToIssuer>Director</relationshipToIssuer>
+      </relationshipsToIssuer>
+    </issuerInfo>
+    <securitiesInformation>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <brokerOrMarketmakerDetails>
+        <name>Fidelity Brokerage Services LLC</name>
+        <address>
+          <com:street1>245 Summer Street</com:street1>
+          <com:city>Boston</com:city>
+          <com:stateOrCountry>MA</com:stateOrCountry>
+          <com:zipCode>02110</com:zipCode>
+        </address>
+      </brokerOrMarketmakerDetails>
+      <noOfUnitsSold>85000</noOfUnitsSold>
+      <aggregateMarketValue>615658.00</aggregateMarketValue>
+      <noOfUnitsOutstanding>8295707</noOfUnitsOutstanding>
+      <approxSaleDate>05/22/2026</approxSaleDate>
+      <securitiesExchangeName>NASDAQ</securitiesExchangeName>
+    </securitiesInformation>
+    <securitiesToBeSold>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <acquiredDate>04/02/2021</acquiredDate>
+      <natureOfAcquisitionTransaction>Payment for services rendered</natureOfAcquisitionTransaction>
+      <nameOfPersonfromWhomAcquired>ISSUER</nameOfPersonfromWhomAcquired>
+      <isGiftTransaction>N</isGiftTransaction>
+      <amountOfSecuritiesAcquired>3333</amountOfSecuritiesAcquired>
+      <paymentDate>04/02/2021</paymentDate>
+      <natureOfPayment>Compensation</natureOfPayment>
+    </securitiesToBeSold>
+    <securitiesToBeSold>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <acquiredDate>04/02/2022</acquiredDate>
+      <natureOfAcquisitionTransaction>Payment for services rendered</natureOfAcquisitionTransaction>
+      <nameOfPersonfromWhomAcquired>ISSUER</nameOfPersonfromWhomAcquired>
+      <isGiftTransaction>N</isGiftTransaction>
+      <amountOfSecuritiesAcquired>3333</amountOfSecuritiesAcquired>
+      <paymentDate>04/02/2022</paymentDate>
+      <natureOfPayment>Compensation</natureOfPayment>
+    </securitiesToBeSold>
+    <securitiesToBeSold>
+      <securitiesClassTitle>common</securitiesClassTitle>
+      <acquiredDate>04/03/2023</acquiredDate>
+      <natureOfAcquisitionTransaction>Payment for services rendered</natureOfAcquisitionTransaction>
+      <nameOfPersonfromWhomAcquired>ISSUER</nameOfPersonfromWhomAcquired>
+      <isGiftTransaction>N</isGiftTransaction>
+      <amountOfSecuritiesAcquired>3333</amountOfSecuritiesAcquired>
+      <paymentDate>04/03/2023</paymentDate>
+      <natureOfPayment>Compensation</natureOfPayment>
+    </securitiesToBeSold>
+    <securitiesToBeSold>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <acquiredDate>06/11/2022</acquiredDate>
+      <natureOfAcquisitionTransaction>Payment for services rendered</natureOfAcquisitionTransaction>
+      <nameOfPersonfromWhomAcquired>ISSUER</nameOfPersonfromWhomAcquired>
+      <isGiftTransaction>N</isGiftTransaction>
+      <amountOfSecuritiesAcquired>2967</amountOfSecuritiesAcquired>
+      <paymentDate>06/11/2022</paymentDate>
+      <natureOfPayment>Compensation</natureOfPayment>
+    </securitiesToBeSold>
+    <securitiesToBeSold>
+      <securitiesClassTitle>Common</securitiesClassTitle>
+      <acquiredDate>05/16/2026</acquiredDate>
+      <natureOfAcquisitionTransaction>Payment for services rendered</natureOfAcquisitionTransaction>
+      <nameOfPersonfromWhomAcquired>ISSUER</nameOfPersonfromWhomAcquired>
+      <isGiftTransaction>N</isGiftTransaction>
+      <amountOfSecuritiesAcquired>72034</amountOfSecuritiesAcquired>
+      <paymentDate>05/16/2026</paymentDate>
+      <natureOfPayment>Compensation</natureOfPayment>
+    </securitiesToBeSold>
+    <nothingToReportFlagOnSecuritiesSoldInPast3Months>Y</nothingToReportFlagOnSecuritiesSoldInPast3Months>
+    <noticeSignature>
+      <noticeDate>05/27/2026</noticeDate>
+      <signature>/s/ Ariadna Gonzalez as a duly authorized representative of Fidelity Brokerage Services LLC, as attorney-in-fact for PATTON THOMAS M</signature>
+    </noticeSignature>
+  </formData>
+</edgarSubmission>

--- a/src/sec/forms/insider-trading/mock_data/form-3-a/000095010326007758-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-3-a/000095010326007758-primary_doc.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0"?>
+<ownershipDocument>
+
+    <schemaVersion>X0607</schemaVersion>
+
+    <documentType>3/A</documentType>
+
+    <periodOfReport>2026-03-18</periodOfReport>
+
+    <dateOfOriginalSubmission>2026-03-18</dateOfOriginalSubmission>
+
+    <noSecuritiesOwned>0</noSecuritiesOwned>
+
+    <issuer>
+        <issuerCik>0001122411</issuerCik>
+        <issuerName>ASE Technology Holding Co., Ltd.</issuerName>
+        <issuerTradingSymbol>ASX</issuerTradingSymbol>
+        <issuerForeignTradingSymbol></issuerForeignTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0002116851</rptOwnerCik>
+            <rptOwnerName>Chung Chih-Hsiao</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerNonUSAddressFlag>true</rptOwnerNonUSAddressFlag>
+            <rptOwnerStreet1>1863, OOAZAIRYUDA</rptOwnerStreet1>
+            <rptOwnerStreet2>TAKAHATA-MACHI</rptOwnerStreet2>
+            <rptOwnerCity>HIGASHIOKITAMA-GUN, YAMAGATA</rptOwnerCity>
+            <rptOwnerNonUSStateTerritory></rptOwnerNonUSStateTerritory>
+            <rptOwnerCountry>M0</rptOwnerCountry>
+            <rptOwnerZipCode>992-0324</rptOwnerZipCode>
+            <rptOwnerStateDescription>JAPAN</rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>0</isDirector>
+            <isOfficer>1</isOfficer>
+            <isTenPercentOwner>0</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle>GM, ASE Japan &amp; Wuxi Tongzhi</officerTitle>
+            <otherText></otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <nonDerivativeTable>
+        <nonDerivativeHolding>
+            <securityTitle>
+                <value>Ordinary Shares</value>
+            </securityTitle>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>30000</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeHolding>
+    </nonDerivativeTable>
+
+    <derivativeTable>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Stock Option (Right to Buy)</value>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>41.10</value>
+                <footnoteId id="F2"/>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <footnoteId id="F1"/>
+            </exerciseDate>
+            <expirationDate>
+                <value>2028-11-22</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Ordinary Shares</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>365000</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Stock Option (Right to Buy)</value>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>99.70</value>
+                <footnoteId id="F2"/>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <footnoteId id="F3"/>
+            </exerciseDate>
+            <expirationDate>
+                <value>2033-08-17</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Ordinary Shares</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>500000</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+    </derivativeTable>
+
+    <footnotes>
+        <footnote id="F1">Reflects stock options to purchase Ordinary Shares. These stock options were granted on November 23, 2018 and are fully vested and exercisable.</footnote>
+        <footnote id="F2">The option exercise price reflects New Taiwan dollars.</footnote>
+        <footnote id="F3">Reflects stock options to purchase Ordinary Shares. These stock options were granted on August 18, 2023 and vest in seven semi-annual installments. 40% of the options vested on August 18, 2025, 10% of the options vested on February 18, 2026, and the remaining installments will vest at 10% each on August 18 2026, February 18, 2027, August 18, 2027, February 18, 2028 and August 18, 2028.</footnote>
+    </footnotes>
+
+    <remarks>Exhibit 24.1 - Power of Attorney</remarks>
+
+    <ownerSignature>
+        <signatureName>/s/ Georgette Yeh, attorney-in-fact for Chih-Hsiao Chung</signatureName>
+        <signatureDate>2026-05-27</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/src/sec/forms/insider-trading/mock_data/form-3/000212961626000003-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-3/000212961626000003-primary_doc.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<ownershipDocument>
+
+    <schemaVersion>X0607</schemaVersion>
+
+    <documentType>3</documentType>
+
+    <periodOfReport>2026-05-22</periodOfReport>
+
+    <noSecuritiesOwned>1</noSecuritiesOwned>
+
+    <issuer>
+        <issuerCik>0002075109</issuerCik>
+        <issuerName>Matternet, Inc.</issuerName>
+        <issuerTradingSymbol>NONE</issuerTradingSymbol>
+        <issuerForeignTradingSymbol></issuerForeignTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0002129616</rptOwnerCik>
+            <rptOwnerName>Secore Jason Benjamin</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerNonUSAddressFlag>false</rptOwnerNonUSAddressFlag>
+            <rptOwnerStreet1>C/O MATTERNET, INC.</rptOwnerStreet1>
+            <rptOwnerStreet2>355 RAVENDALE DRIVE</rptOwnerStreet2>
+            <rptOwnerCity>MOUNTAIN VIEW</rptOwnerCity>
+            <rptOwnerState>CA</rptOwnerState>
+            <rptOwnerZipCode>Mountain V</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>false</isDirector>
+            <isOfficer>true</isOfficer>
+            <isTenPercentOwner>false</isTenPercentOwner>
+            <isOther>false</isOther>
+            <officerTitle>Chief Financial Officer</officerTitle>
+            <otherText></otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <nonDerivativeTable></nonDerivativeTable>
+
+    <derivativeTable></derivativeTable>
+
+    <footnotes></footnotes>
+
+    <ownerSignature>
+        <signatureName>/s/ Jason Benjamin Secore</signatureName>
+        <signatureDate>2026-05-27</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/src/sec/forms/insider-trading/mock_data/form-4-a/000089706926001273-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-4-a/000089706926001273-primary_doc.xml
@@ -1,0 +1,326 @@
+<?xml version="1.0"?>
+<ownershipDocument>
+
+    <schemaVersion>X0609</schemaVersion>
+
+    <documentType>4/A</documentType>
+
+    <periodOfReport>2026-05-21</periodOfReport>
+
+    <dateOfOriginalSubmission>2026-05-26</dateOfOriginalSubmission>
+
+    <issuer>
+        <issuerCik>0000062234</issuerCik>
+        <issuerName>MARCUS CORP</issuerName>
+        <issuerTradingSymbol>MCS</issuerTradingSymbol>
+        <issuerForeignTradingSymbol></issuerForeignTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001010208</rptOwnerCik>
+            <rptOwnerName>STARK BRIAN JAY</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerNonUSAddressFlag>false</rptOwnerNonUSAddressFlag>
+            <rptOwnerStreet1>THE MARCUS CORPORATION</rptOwnerStreet1>
+            <rptOwnerStreet2>111 EAST KILBOURN AVENUE, SUITE 1200</rptOwnerStreet2>
+            <rptOwnerCity>MILWAUKEE</rptOwnerCity>
+            <rptOwnerState>WI</rptOwnerState>
+            <rptOwnerZipCode>53202</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>true</isDirector>
+            <isOfficer>false</isOfficer>
+            <isTenPercentOwner>false</isTenPercentOwner>
+            <isOther>false</isOther>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>false</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2026-05-21</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>A</transactionCode>
+                <equitySwapInvolved>false</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>1391</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>17.97</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>48206</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+    </nonDerivativeTable>
+
+    <derivativeTable>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Stock Option (Right to Buy)</value>
+                <footnoteId id="F2"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>31.55</value>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <value>2016-12-29</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2026-12-29</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>1000</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>1000</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Stock Option (Right to Buy)</value>
+                <footnoteId id="F2"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>27.2</value>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <value>2017-12-28</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2027-12-28</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>1000</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>1000</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Stock Option (Right to Buy)</value>
+                <footnoteId id="F2"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>38.51</value>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <value>2018-12-27</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2027-12-27</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>1000</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>1000</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Stock Option (Right to Buy)</value>
+                <footnoteId id="F2"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>32.6</value>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <value>2019-12-26</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2029-12-26</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>1000</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>1000</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Stock Option (Right to Buy)</value>
+                <footnoteId id="F2"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>17.95</value>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <value>2021-12-30</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2031-12-30</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>750</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>750</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Stock Option (Right to Buy)</value>
+                <footnoteId id="F2"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>14.25</value>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <value>2022-12-28</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2032-12-29</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>1438</value>
+                    <footnoteId id="F3"/>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>1438</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Stock Option (Right to Buy)</value>
+                <footnoteId id="F2"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>14.69</value>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <value>2023-12-28</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2033-12-28</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>1455</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>1455</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+    </derivativeTable>
+
+    <footnotes>
+        <footnote id="F1">Granted by Issuer in consideration of service as a director.</footnote>
+        <footnote id="F2">Granted pursuant to The Marcus Corporation 2004 Equity and Incentive Awards Plan.</footnote>
+        <footnote id="F3">Amending solely to correct previously reported Underlying Securities reported in dollars to be reported in shares.</footnote>
+    </footnotes>
+
+    <ownerSignature>
+        <signatureName>/s/ Steven R. Barth, Attorney-in-Fact for Brian Jay Stark</signatureName>
+        <signatureDate>2026-05-27</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/src/sec/forms/insider-trading/mock_data/form-4/000090266426002604-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-4/000090266426002604-primary_doc.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<ownershipDocument>
+
+    <schemaVersion>X0609</schemaVersion>
+
+    <documentType>4</documentType>
+
+    <periodOfReport>2026-05-26</periodOfReport>
+
+    <notSubjectToSection16>0</notSubjectToSection16>
+
+    <issuer>
+        <issuerCik>0000885508</issuerCik>
+        <issuerName>STRATUS PROPERTIES INC</issuerName>
+        <issuerTradingSymbol>STRS</issuerTradingSymbol>
+        <issuerForeignTradingSymbol></issuerForeignTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001317904</rptOwnerCik>
+            <rptOwnerName>Oasis Management Co Ltd.</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerNonUSAddressFlag>true</rptOwnerNonUSAddressFlag>
+            <rptOwnerStreet1>4TH FLOOR ANDERSON SQUARE,</rptOwnerStreet1>
+            <rptOwnerStreet2>64 SHEDDEN ROAD, P.O. BOX 10324</rptOwnerStreet2>
+            <rptOwnerCity>GRAND CAYMAN</rptOwnerCity>
+            <rptOwnerNonUSStateTerritory>E9</rptOwnerNonUSStateTerritory>
+            <rptOwnerCountry>E9</rptOwnerCountry>
+            <rptOwnerZipCode>KY-1103</rptOwnerZipCode>
+            <rptOwnerStateDescription>CAYMAN ISLANDS</rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>0</isDirector>
+            <isOfficer>0</isOfficer>
+            <isTenPercentOwner>1</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle></officerTitle>
+            <otherText></otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001530803</rptOwnerCik>
+            <rptOwnerName>Oasis Investments II Master Fund Ltd.</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerNonUSAddressFlag>true</rptOwnerNonUSAddressFlag>
+            <rptOwnerStreet1>UGLAND HOUSE PO BOX 309</rptOwnerStreet1>
+            <rptOwnerStreet2></rptOwnerStreet2>
+            <rptOwnerCity>GRAND CAYMAN</rptOwnerCity>
+            <rptOwnerNonUSStateTerritory>E9</rptOwnerNonUSStateTerritory>
+            <rptOwnerCountry>E9</rptOwnerCountry>
+            <rptOwnerZipCode>KY1-1104</rptOwnerZipCode>
+            <rptOwnerStateDescription>CAYMAN ISLANDS</rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>0</isDirector>
+            <isOfficer>0</isOfficer>
+            <isTenPercentOwner>1</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle></officerTitle>
+            <otherText></otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001456474</rptOwnerCik>
+            <rptOwnerName>Fischer Seth</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerNonUSAddressFlag>true</rptOwnerNonUSAddressFlag>
+            <rptOwnerStreet1>C/O OASIS MANAGEMENT (HONG KONG) LLC</rptOwnerStreet1>
+            <rptOwnerStreet2>21/F MAN YEE BUILDING, 68 DES VOEUX ROAD</rptOwnerStreet2>
+            <rptOwnerCity>CENTRAL</rptOwnerCity>
+            <rptOwnerNonUSStateTerritory>K3</rptOwnerNonUSStateTerritory>
+            <rptOwnerCountry>K3</rptOwnerCountry>
+            <rptOwnerZipCode>0</rptOwnerZipCode>
+            <rptOwnerStateDescription>HONG KONG</rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>0</isDirector>
+            <isOfficer>0</isOfficer>
+            <isTenPercentOwner>1</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle></officerTitle>
+            <otherText></otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>0</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock, par value $0.01 per share</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2026-05-26</value>
+            </transactionDate>
+            <deemedExecutionDate></deemedExecutionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionTimeliness></transactionTimeliness>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>10000</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>29.0502</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>971129</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>See footnotes</value>
+                    <footnoteId id="F1"/>
+                    <footnoteId id="F2"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+    </nonDerivativeTable>
+
+    <footnotes>
+        <footnote id="F1">The securities to which this filing relates are held directly by Oasis Investments II Master Fund Ltd., a Cayman Islands exempted company (the &quot;Oasis II Fund&quot;). Oasis Management Company Ltd., a Cayman Islands exempted company (the &quot;Investment Manager&quot;), is the investment manager of Oasis II Fund. Seth Fischer, is responsible for the supervision and conduct of all investment activities of the Investment Manager, including all investment decisions with respect to the assets of the Oasis II Fund.</footnote>
+        <footnote id="F2">The filing of this statement shall not be deemed an admission that any of the Reporting Persons is the beneficial owner of the securities reported herein for purposes of Section 16 of the Securities Act of 1934, as amended, or otherwise. Each of the Reporting Persons expressly disclaims beneficial ownership of the securities reported herein except to the extent of its or his pecuniary interest therein, if any.</footnote>
+    </footnotes>
+
+    <ownerSignature>
+        <signatureName>/s/ Oasis Management Company Ltd., By: Phillip Meyer, its General Counsel</signatureName>
+        <signatureDate>2026-05-27</signatureDate>
+    </ownerSignature>
+
+    <ownerSignature>
+        <signatureName>/s/ Oasis Investments II Master Fund Ltd., By: Phillip Meyer, its Director</signatureName>
+        <signatureDate>2026-05-27</signatureDate>
+    </ownerSignature>
+
+    <ownerSignature>
+        <signatureName>/s/ Seth Fischer</signatureName>
+        <signatureDate>2026-05-27</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/src/sec/forms/insider-trading/mock_data/form-4/000149315226025476-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-4/000149315226025476-primary_doc.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0"?>
+<ownershipDocument>
+
+    <schemaVersion>X0609</schemaVersion>
+
+    <documentType>4</documentType>
+
+    <periodOfReport>2026-05-22</periodOfReport>
+
+    <notSubjectToSection16>0</notSubjectToSection16>
+
+    <issuer>
+        <issuerCik>0001828673</issuerCik>
+        <issuerName>HCW Biologics Inc.</issuerName>
+        <issuerTradingSymbol>HCWB</issuerTradingSymbol>
+        <issuerForeignTradingSymbol></issuerForeignTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001231174</rptOwnerCik>
+            <rptOwnerName>GARRETT SCOTT T</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerNonUSAddressFlag>false</rptOwnerNonUSAddressFlag>
+            <rptOwnerStreet1>C/O HCW BIOLOGICS INC.</rptOwnerStreet1>
+            <rptOwnerStreet2>2929 N. COMMERCE PARKWAY</rptOwnerStreet2>
+            <rptOwnerCity>MIRAMAR,</rptOwnerCity>
+            <rptOwnerState>FL</rptOwnerState>
+            <rptOwnerZipCode>33025</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>1</isDirector>
+            <isOfficer>0</isOfficer>
+            <isTenPercentOwner>0</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle></officerTitle>
+            <otherText></otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>0</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2026-05-22</value>
+            </transactionDate>
+            <deemedExecutionDate></deemedExecutionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>P</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionTimeliness></transactionTimeliness>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>177936</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>1.405</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>203441</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By LLC</value>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+    </nonDerivativeTable>
+
+    <derivativeTable>
+        <derivativeTransaction>
+            <securityTitle>
+                <value>Common Stock Purchase Warrant</value>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>1.28</value>
+            </conversionOrExercisePrice>
+            <transactionDate>
+                <value>2026-05-22</value>
+            </transactionDate>
+            <deemedExecutionDate></deemedExecutionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>P</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionTimeliness></transactionTimeliness>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>177936</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>0</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <exerciseDate>
+                <value>2026-05-22</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2031-11-22</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>177936</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>180628</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By LLC</value>
+                </natureOfOwnership>
+            </ownershipNature>
+        </derivativeTransaction>
+    </derivativeTable>
+
+    <footnotes>
+        <footnote id="F1">The reporting person purchased these shares directly from the issuer in a private placement, which purchase is exempt from Section 16(b) in accordance with Rule 16b-3(d) promulgated under the Securities Exchange Act of 1934, as amended.</footnote>
+    </footnotes>
+
+    <ownerSignature>
+        <signatureName>/s/ Nicole Valdivieso, as Attorney-in-Fact for Scott T. Garrett</signatureName>
+        <signatureDate>2026-05-27</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/src/sec/forms/insider-trading/mock_data/form-5/000119312526225124-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-5/000119312526225124-primary_doc.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<ownershipDocument>
+
+    <schemaVersion>X0609</schemaVersion>
+
+    <documentType>5</documentType>
+
+    <periodOfReport>2026-03-19</periodOfReport>
+
+    <notSubjectToSection16>false</notSubjectToSection16>
+
+    <form3HoldingsReported>0</form3HoldingsReported>
+
+    <form4TransactionsReported>0</form4TransactionsReported>
+
+    <issuer>
+        <issuerCik>0001070304</issuerCik>
+        <issuerName>ORIX CORP</issuerName>
+        <issuerTradingSymbol>IX</issuerTradingSymbol>
+        <issuerForeignTradingSymbol>TSE: 8591</issuerForeignTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0002118674</rptOwnerCik>
+            <rptOwnerName>Matsuzaki Satoru</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerNonUSAddressFlag>true</rptOwnerNonUSAddressFlag>
+            <rptOwnerStreet1>WORLD TRADE CENTER BUILDING, SOUTH TOWER</rptOwnerStreet1>
+            <rptOwnerStreet2>2-4-1 HAMAMATSU-CHO, MINATO-KU</rptOwnerStreet2>
+            <rptOwnerCity>TOKYO</rptOwnerCity>
+            <rptOwnerNonUSStateTerritory>JAPAN</rptOwnerNonUSStateTerritory>
+            <rptOwnerCountry>M0</rptOwnerCountry>
+            <rptOwnerZipCode>105-5135</rptOwnerZipCode>
+            <rptOwnerStateDescription>JAPAN</rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>true</isDirector>
+            <isOfficer>true</isOfficer>
+            <isTenPercentOwner>false</isTenPercentOwner>
+            <isOther>false</isOther>
+            <officerTitle>See remarks</officerTitle>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>false</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2026-03-19</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>5</transactionFormType>
+                <transactionCode>P</transactionCode>
+                <equitySwapInvolved>false</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>6.586</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>30.16</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>10699.312</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2026-04-20</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>5</transactionFormType>
+                <transactionCode>P</transactionCode>
+                <equitySwapInvolved>false</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>13.162</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>31.94</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>10712.474</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+    </nonDerivativeTable>
+
+    <remarks>Deputy President Executive Officer, Chief Operating Officer, Japan &amp; APAC Business Unit</remarks>
+
+    <ownerSignature>
+        <signatureName>/s/ Tomohiko Ishihara as Attorney-in-Fact for Satoru Matsuzaki</signatureName>
+        <signatureDate>2026-05-15</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/src/sec/forms/insider-trading/mock_data/form-5/000158064226003205-primary_doc.xml
+++ b/src/sec/forms/insider-trading/mock_data/form-5/000158064226003205-primary_doc.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<ownershipDocument>
+
+    <schemaVersion>X0609</schemaVersion>
+
+    <documentType>5</documentType>
+
+    <periodOfReport>2026-03-31</periodOfReport>
+
+    <notSubjectToSection16>0</notSubjectToSection16>
+
+    <form3HoldingsReported>0</form3HoldingsReported>
+
+    <form4TransactionsReported>0</form4TransactionsReported>
+
+    <issuer>
+        <issuerCik>0002042256</issuerCik>
+        <issuerName>iDirect Private Credit Fund</issuerName>
+        <issuerTradingSymbol>NA</issuerTradingSymbol>
+        <issuerForeignTradingSymbol></issuerForeignTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001068868</rptOwnerCik>
+            <rptOwnerName>VERONIS NICHOLAS</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerNonUSAddressFlag>false</rptOwnerNonUSAddressFlag>
+            <rptOwnerStreet1>2 GREENWICH PLAZA, 3RD FLOOR</rptOwnerStreet1>
+            <rptOwnerStreet2></rptOwnerStreet2>
+            <rptOwnerCity>GREENWICH</rptOwnerCity>
+            <rptOwnerState>CT</rptOwnerState>
+            <rptOwnerZipCode>06830</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>1</isDirector>
+            <isOfficer>1</isOfficer>
+            <isTenPercentOwner>0</isTenPercentOwner>
+            <isOther>1</isOther>
+            <officerTitle>Trustee, Pres of Issuer</officerTitle>
+            <otherText>IA CEO</otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>0</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Shares of beneficial interest</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-07-11</value>
+            </transactionDate>
+            <deemedExecutionDate></deemedExecutionDate>
+            <transactionCoding>
+                <transactionFormType>5</transactionFormType>
+                <transactionCode>P</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionTimeliness></transactionTimeliness>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>70449.14</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>10</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>73988.331</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+    </nonDerivativeTable>
+
+    <ownerSignature>
+        <signatureName>/s/ Nicholas Veronis</signatureName>
+        <signatureDate>2026-05-15</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/src/storage/form144/Form144Repo.ts
+++ b/src/storage/form144/Form144Repo.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  Form144Acquisition,
+  Form144AcquisitionRepositoryStorage,
+  Form144Filing,
+  Form144FilingRepositoryStorage,
+  Form144RecentSale,
+  Form144RecentSaleRepositoryStorage,
+  FORM144_ACQUISITION_REPOSITORY_TOKEN,
+  FORM144_FILING_REPOSITORY_TOKEN,
+  FORM144_RECENT_SALE_REPOSITORY_TOKEN,
+} from "./Form144Schema";
+
+interface Form144RepoOptions {
+  filingRepository?: Form144FilingRepositoryStorage;
+  acquisitionRepository?: Form144AcquisitionRepositoryStorage;
+  recentSaleRepository?: Form144RecentSaleRepositoryStorage;
+}
+
+/**
+ * Repository for Form 144 notices: the filing header (including the proposed
+ * sale), the acquisition lots, and the trailing-3-month sales.
+ */
+export class Form144Repo implements Form144RepoOptions {
+  filingRepository: Form144FilingRepositoryStorage;
+  acquisitionRepository: Form144AcquisitionRepositoryStorage;
+  recentSaleRepository: Form144RecentSaleRepositoryStorage;
+
+  constructor(options: Form144RepoOptions = {}) {
+    this.filingRepository =
+      options.filingRepository ?? globalServiceRegistry.get(FORM144_FILING_REPOSITORY_TOKEN);
+    this.acquisitionRepository =
+      options.acquisitionRepository ??
+      globalServiceRegistry.get(FORM144_ACQUISITION_REPOSITORY_TOKEN);
+    this.recentSaleRepository =
+      options.recentSaleRepository ??
+      globalServiceRegistry.get(FORM144_RECENT_SALE_REPOSITORY_TOKEN);
+  }
+
+  async saveFiling(filing: Form144Filing): Promise<void> {
+    await this.filingRepository.put(filing);
+  }
+
+  async getFiling(accession_number: string): Promise<Form144Filing | undefined> {
+    return this.filingRepository.get({ accession_number });
+  }
+
+  async saveAcquisition(acquisition: Form144Acquisition): Promise<void> {
+    await this.acquisitionRepository.put(acquisition);
+  }
+
+  async getAcquisitions(accession_number: string): Promise<Form144Acquisition[]> {
+    return (await this.acquisitionRepository.query({ accession_number })) || [];
+  }
+
+  /**
+   * Removes every acquisition row for a filing. Rows are keyed by a positional
+   * `(accession_number, acquisition_index)`, so re-extracting a filing that now
+   * yields fewer rows would otherwise leave stale orphans at the higher
+   * indices. Callers clear before re-inserting to stay idempotent.
+   */
+  async clearAcquisitions(accession_number: string): Promise<void> {
+    const rows = (await this.acquisitionRepository.query({ accession_number })) || [];
+    for (const row of rows) {
+      await this.acquisitionRepository.delete({
+        accession_number,
+        acquisition_index: row.acquisition_index,
+      });
+    }
+  }
+
+  async saveRecentSale(sale: Form144RecentSale): Promise<void> {
+    await this.recentSaleRepository.put(sale);
+  }
+
+  async getRecentSales(accession_number: string): Promise<Form144RecentSale[]> {
+    return (await this.recentSaleRepository.query({ accession_number })) || [];
+  }
+
+  /** Removes every trailing-3-month sale row for a filing; see {@link clearAcquisitions}. */
+  async clearRecentSales(accession_number: string): Promise<void> {
+    const rows = (await this.recentSaleRepository.query({ accession_number })) || [];
+    for (const row of rows) {
+      await this.recentSaleRepository.delete({ accession_number, sale_index: row.sale_index });
+    }
+  }
+}

--- a/src/storage/form144/Form144Schema.ts
+++ b/src/storage/form144/Form144Schema.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+import { TypeNullable } from "../../util/TypeBoxUtil";
+
+/**
+ * One row per Form 144 / 144/A filing. The single `securitiesInformation`
+ * block (proposed sale + broker) is folded in here, since it is 1:1 with the
+ * notice. Dates are stored verbatim as the US-format (MM/DD/YYYY) strings
+ * EDGAR emits.
+ */
+export const Form144FilingSchema = Type.Object({
+  accession_number: Type.String({ maxLength: 25 }),
+  form: Type.String({ maxLength: 10 }),
+  submission_type: TypeNullable(Type.String({ maxLength: 10 })),
+  issuer_cik: Type.Integer({ minimum: 0 }),
+  issuer_name: Type.String({ maxLength: 150 }),
+  sec_file_number: TypeNullable(Type.String({ maxLength: 30 })),
+  person_for_whose_account: TypeNullable(Type.String({ maxLength: 150 })),
+  relationships_to_issuer: TypeNullable(Type.String({ maxLength: 255 })),
+  securities_class_title: TypeNullable(Type.String({ maxLength: 255 })),
+  broker_name: TypeNullable(Type.String({ maxLength: 255 })),
+  no_of_units_sold: TypeNullable(Type.Number()),
+  aggregate_market_value: TypeNullable(Type.Number()),
+  no_of_units_outstanding: TypeNullable(Type.Number()),
+  approx_sale_date: TypeNullable(Type.String({ maxLength: 12 })),
+  securities_exchange_name: TypeNullable(Type.String({ maxLength: 100 })),
+  nothing_to_report_past_3_months: Type.Boolean(),
+  notice_date: TypeNullable(Type.String({ maxLength: 12 })),
+  filing_date: TypeNullable(Type.String()),
+});
+
+export type Form144Filing = Static<typeof Form144FilingSchema>;
+
+export const Form144FilingPrimaryKeyNames = ["accession_number"] as const;
+export type Form144FilingRepositoryStorage = ITabularStorage<
+  typeof Form144FilingSchema,
+  typeof Form144FilingPrimaryKeyNames,
+  Form144Filing
+>;
+
+export const FORM144_FILING_REPOSITORY_TOKEN = createServiceToken<Form144FilingRepositoryStorage>(
+  "sec.storage.form144FilingRepository"
+);
+
+/**
+ * One row per `securitiesToBeSold` entry: a lot of securities being sold and
+ * how/when it was acquired.
+ */
+export const Form144AcquisitionSchema = Type.Object({
+  accession_number: Type.String({ maxLength: 25 }),
+  acquisition_index: Type.Integer({ minimum: 0 }),
+  issuer_cik: Type.Integer({ minimum: 0 }),
+  securities_class_title: TypeNullable(Type.String({ maxLength: 255 })),
+  acquired_date: TypeNullable(Type.String({ maxLength: 12 })),
+  nature_of_acquisition: TypeNullable(Type.String({ maxLength: 255 })),
+  name_of_person_from_whom_acquired: TypeNullable(Type.String({ maxLength: 150 })),
+  is_gift: TypeNullable(Type.Boolean()),
+  amount_acquired: TypeNullable(Type.Number()),
+  payment_date: TypeNullable(Type.String({ maxLength: 12 })),
+  nature_of_payment: TypeNullable(Type.String({ maxLength: 255 })),
+});
+
+export type Form144Acquisition = Static<typeof Form144AcquisitionSchema>;
+
+export const Form144AcquisitionPrimaryKeyNames = ["accession_number", "acquisition_index"] as const;
+export type Form144AcquisitionRepositoryStorage = ITabularStorage<
+  typeof Form144AcquisitionSchema,
+  typeof Form144AcquisitionPrimaryKeyNames,
+  Form144Acquisition
+>;
+
+export const FORM144_ACQUISITION_REPOSITORY_TOKEN =
+  createServiceToken<Form144AcquisitionRepositoryStorage>(
+    "sec.storage.form144AcquisitionRepository"
+  );
+
+/**
+ * One row per `securitiesSoldInPast3Months` entry: a sale already made in the
+ * trailing three months that the notice must disclose.
+ */
+export const Form144RecentSaleSchema = Type.Object({
+  accession_number: Type.String({ maxLength: 25 }),
+  sale_index: Type.Integer({ minimum: 0 }),
+  issuer_cik: Type.Integer({ minimum: 0 }),
+  seller_name: TypeNullable(Type.String({ maxLength: 150 })),
+  securities_class_title: TypeNullable(Type.String({ maxLength: 255 })),
+  sale_date: TypeNullable(Type.String({ maxLength: 12 })),
+  amount_sold: TypeNullable(Type.Number()),
+  gross_proceeds: TypeNullable(Type.Number()),
+});
+
+export type Form144RecentSale = Static<typeof Form144RecentSaleSchema>;
+
+export const Form144RecentSalePrimaryKeyNames = ["accession_number", "sale_index"] as const;
+export type Form144RecentSaleRepositoryStorage = ITabularStorage<
+  typeof Form144RecentSaleSchema,
+  typeof Form144RecentSalePrimaryKeyNames,
+  Form144RecentSale
+>;
+
+export const FORM144_RECENT_SALE_REPOSITORY_TOKEN =
+  createServiceToken<Form144RecentSaleRepositoryStorage>(
+    "sec.storage.form144RecentSaleRepository"
+  );

--- a/src/storage/form144/Form144Schema.ts
+++ b/src/storage/form144/Form144Schema.ts
@@ -8,6 +8,7 @@ import { Static, Type } from "typebox";
 import type { ITabularStorage } from "workglow";
 import { createServiceToken } from "workglow";
 import { TypeNullable } from "../../util/TypeBoxUtil";
+import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 
 /**
  * One row per Form 144 / 144/A filing. The single `securitiesInformation`
@@ -19,7 +20,7 @@ export const Form144FilingSchema = Type.Object({
   accession_number: Type.String({ maxLength: 25 }),
   form: Type.String({ maxLength: 10 }),
   submission_type: TypeNullable(Type.String({ maxLength: 10 })),
-  issuer_cik: Type.Integer({ minimum: 0 }),
+  issuer_cik: TypeSecCik(),
   issuer_name: Type.String({ maxLength: 150 }),
   sec_file_number: TypeNullable(Type.String({ maxLength: 30 })),
   person_for_whose_account: TypeNullable(Type.String({ maxLength: 150 })),
@@ -56,7 +57,7 @@ export const FORM144_FILING_REPOSITORY_TOKEN = createServiceToken<Form144FilingR
 export const Form144AcquisitionSchema = Type.Object({
   accession_number: Type.String({ maxLength: 25 }),
   acquisition_index: Type.Integer({ minimum: 0 }),
-  issuer_cik: Type.Integer({ minimum: 0 }),
+  issuer_cik: TypeSecCik(),
   securities_class_title: TypeNullable(Type.String({ maxLength: 255 })),
   acquired_date: TypeNullable(Type.String({ maxLength: 12 })),
   nature_of_acquisition: TypeNullable(Type.String({ maxLength: 255 })),
@@ -88,7 +89,7 @@ export const FORM144_ACQUISITION_REPOSITORY_TOKEN =
 export const Form144RecentSaleSchema = Type.Object({
   accession_number: Type.String({ maxLength: 25 }),
   sale_index: Type.Integer({ minimum: 0 }),
-  issuer_cik: Type.Integer({ minimum: 0 }),
+  issuer_cik: TypeSecCik(),
   seller_name: TypeNullable(Type.String({ maxLength: 150 })),
   securities_class_title: TypeNullable(Type.String({ maxLength: 255 })),
   sale_date: TypeNullable(Type.String({ maxLength: 12 })),

--- a/src/storage/section16/Section16Repo.ts
+++ b/src/storage/section16/Section16Repo.ts
@@ -58,11 +58,35 @@ export class Section16Repo implements Section16RepoOptions {
     return (await this.transactionRepository.query({ accession_number })) || [];
   }
 
+  /**
+   * Removes every transaction row for a filing. Transactions are keyed by a
+   * positional `(accession_number, transaction_index)`, so re-extracting a
+   * filing that now yields fewer rows would otherwise leave stale orphans at
+   * the higher indices. Callers clear before re-inserting to stay idempotent.
+   */
+  async clearTransactions(accession_number: string): Promise<void> {
+    const rows = (await this.transactionRepository.query({ accession_number })) || [];
+    for (const row of rows) {
+      await this.transactionRepository.delete({
+        accession_number,
+        transaction_index: row.transaction_index,
+      });
+    }
+  }
+
   async saveHolding(holding: Section16Holding): Promise<void> {
     await this.holdingRepository.put(holding);
   }
 
   async getHoldings(accession_number: string): Promise<Section16Holding[]> {
     return (await this.holdingRepository.query({ accession_number })) || [];
+  }
+
+  /** Removes every holding row for a filing; see {@link clearTransactions}. */
+  async clearHoldings(accession_number: string): Promise<void> {
+    const rows = (await this.holdingRepository.query({ accession_number })) || [];
+    for (const row of rows) {
+      await this.holdingRepository.delete({ accession_number, holding_index: row.holding_index });
+    }
   }
 }

--- a/src/storage/section16/Section16Repo.ts
+++ b/src/storage/section16/Section16Repo.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  Section16Filing,
+  Section16FilingRepositoryStorage,
+  Section16Holding,
+  Section16HoldingRepositoryStorage,
+  Section16Transaction,
+  Section16TransactionRepositoryStorage,
+  SECTION16_FILING_REPOSITORY_TOKEN,
+  SECTION16_HOLDING_REPOSITORY_TOKEN,
+  SECTION16_TRANSACTION_REPOSITORY_TOKEN,
+} from "./Section16Schema";
+
+interface Section16RepoOptions {
+  filingRepository?: Section16FilingRepositoryStorage;
+  transactionRepository?: Section16TransactionRepositoryStorage;
+  holdingRepository?: Section16HoldingRepositoryStorage;
+}
+
+/**
+ * Repository for Section 16 ownership filings (Forms 3/4/5): the filing
+ * header, its transactions, and its holdings.
+ */
+export class Section16Repo implements Section16RepoOptions {
+  filingRepository: Section16FilingRepositoryStorage;
+  transactionRepository: Section16TransactionRepositoryStorage;
+  holdingRepository: Section16HoldingRepositoryStorage;
+
+  constructor(options: Section16RepoOptions = {}) {
+    this.filingRepository =
+      options.filingRepository ?? globalServiceRegistry.get(SECTION16_FILING_REPOSITORY_TOKEN);
+    this.transactionRepository =
+      options.transactionRepository ??
+      globalServiceRegistry.get(SECTION16_TRANSACTION_REPOSITORY_TOKEN);
+    this.holdingRepository =
+      options.holdingRepository ?? globalServiceRegistry.get(SECTION16_HOLDING_REPOSITORY_TOKEN);
+  }
+
+  async saveFiling(filing: Section16Filing): Promise<void> {
+    await this.filingRepository.put(filing);
+  }
+
+  async getFiling(accession_number: string): Promise<Section16Filing | undefined> {
+    return this.filingRepository.get({ accession_number });
+  }
+
+  async saveTransaction(transaction: Section16Transaction): Promise<void> {
+    await this.transactionRepository.put(transaction);
+  }
+
+  async getTransactions(accession_number: string): Promise<Section16Transaction[]> {
+    return (await this.transactionRepository.query({ accession_number })) || [];
+  }
+
+  async saveHolding(holding: Section16Holding): Promise<void> {
+    await this.holdingRepository.put(holding);
+  }
+
+  async getHoldings(accession_number: string): Promise<Section16Holding[]> {
+    return (await this.holdingRepository.query({ accession_number })) || [];
+  }
+}

--- a/src/storage/section16/Section16Schema.ts
+++ b/src/storage/section16/Section16Schema.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+import { TypeNullable } from "../../util/TypeBoxUtil";
+
+/**
+ * One row per Section 16 ownership filing (Form 3 / 4 / 5 and amendments),
+ * keyed by accession number.
+ */
+export const Section16FilingSchema = Type.Object({
+  accession_number: Type.String({ maxLength: 25, description: "EDGAR accession number" }),
+  form: Type.String({ maxLength: 10, description: "Form symbol (3, 4, 5, 3/A, ...)" }),
+  document_type: Type.String({ maxLength: 10, description: "ownershipDocument documentType" }),
+  issuer_cik: Type.Integer({ minimum: 0, description: "Issuer CIK" }),
+  issuer_name: Type.String({ maxLength: 150, description: "Issuer name" }),
+  issuer_trading_symbol: TypeNullable(Type.String({ maxLength: 20 })),
+  period_of_report: TypeNullable(Type.String({ description: "Period of report (date)" })),
+  filing_date: TypeNullable(Type.String({ description: "Filing date" })),
+  not_subject_to_section16: Type.Boolean({ description: "notSubjectToSection16 flag" }),
+  no_securities_owned: Type.Boolean({ description: "Form 3 noSecuritiesOwned flag" }),
+  remarks: TypeNullable(Type.String()),
+});
+
+export type Section16Filing = Static<typeof Section16FilingSchema>;
+
+export const Section16FilingPrimaryKeyNames = ["accession_number"] as const;
+export type Section16FilingRepositoryStorage = ITabularStorage<
+  typeof Section16FilingSchema,
+  typeof Section16FilingPrimaryKeyNames,
+  Section16Filing
+>;
+
+export const SECTION16_FILING_REPOSITORY_TOKEN =
+  createServiceToken<Section16FilingRepositoryStorage>("sec.storage.section16FilingRepository");
+
+/**
+ * One row per transaction (derivative or non-derivative) within a Section 16
+ * filing. `is_derivative` distinguishes the two tables.
+ */
+export const Section16TransactionSchema = Type.Object({
+  accession_number: Type.String({ maxLength: 25 }),
+  transaction_index: Type.Integer({ minimum: 0 }),
+  issuer_cik: Type.Integer({ minimum: 0 }),
+  is_derivative: Type.Boolean(),
+  security_title: TypeNullable(Type.String({ maxLength: 255 })),
+  transaction_date: TypeNullable(Type.String()),
+  deemed_execution_date: TypeNullable(Type.String()),
+  transaction_code: TypeNullable(Type.String({ maxLength: 4 })),
+  transaction_form_type: TypeNullable(Type.String({ maxLength: 4 })),
+  equity_swap_involved: TypeNullable(Type.Boolean()),
+  acquired_disposed_code: TypeNullable(Type.String({ maxLength: 1 })),
+  shares: TypeNullable(Type.Number()),
+  price_per_share: TypeNullable(Type.Number()),
+  shares_owned_following: TypeNullable(Type.Number()),
+  value_owned_following: TypeNullable(Type.Number()),
+  direct_or_indirect_ownership: TypeNullable(Type.String({ maxLength: 1 })),
+  nature_of_ownership: TypeNullable(Type.String({ maxLength: 255 })),
+  conversion_or_exercise_price: TypeNullable(Type.Number()),
+  exercise_date: TypeNullable(Type.String()),
+  expiration_date: TypeNullable(Type.String()),
+  underlying_security_title: TypeNullable(Type.String({ maxLength: 255 })),
+  underlying_security_shares: TypeNullable(Type.Number()),
+  underlying_security_value: TypeNullable(Type.Number()),
+});
+
+export type Section16Transaction = Static<typeof Section16TransactionSchema>;
+
+export const Section16TransactionPrimaryKeyNames = [
+  "accession_number",
+  "transaction_index",
+] as const;
+export type Section16TransactionRepositoryStorage = ITabularStorage<
+  typeof Section16TransactionSchema,
+  typeof Section16TransactionPrimaryKeyNames,
+  Section16Transaction
+>;
+
+export const SECTION16_TRANSACTION_REPOSITORY_TOKEN =
+  createServiceToken<Section16TransactionRepositoryStorage>(
+    "sec.storage.section16TransactionRepository"
+  );
+
+/**
+ * One row per holding (derivative or non-derivative) within a Section 16
+ * filing. Holdings carry post-transaction ownership but no transaction.
+ */
+export const Section16HoldingSchema = Type.Object({
+  accession_number: Type.String({ maxLength: 25 }),
+  holding_index: Type.Integer({ minimum: 0 }),
+  issuer_cik: Type.Integer({ minimum: 0 }),
+  is_derivative: Type.Boolean(),
+  security_title: TypeNullable(Type.String({ maxLength: 255 })),
+  shares_owned_following: TypeNullable(Type.Number()),
+  value_owned_following: TypeNullable(Type.Number()),
+  direct_or_indirect_ownership: TypeNullable(Type.String({ maxLength: 1 })),
+  nature_of_ownership: TypeNullable(Type.String({ maxLength: 255 })),
+  conversion_or_exercise_price: TypeNullable(Type.Number()),
+  exercise_date: TypeNullable(Type.String()),
+  expiration_date: TypeNullable(Type.String()),
+  underlying_security_title: TypeNullable(Type.String({ maxLength: 255 })),
+  underlying_security_shares: TypeNullable(Type.Number()),
+  underlying_security_value: TypeNullable(Type.Number()),
+});
+
+export type Section16Holding = Static<typeof Section16HoldingSchema>;
+
+export const Section16HoldingPrimaryKeyNames = ["accession_number", "holding_index"] as const;
+export type Section16HoldingRepositoryStorage = ITabularStorage<
+  typeof Section16HoldingSchema,
+  typeof Section16HoldingPrimaryKeyNames,
+  Section16Holding
+>;
+
+export const SECTION16_HOLDING_REPOSITORY_TOKEN =
+  createServiceToken<Section16HoldingRepositoryStorage>("sec.storage.section16HoldingRepository");

--- a/src/storage/section16/Section16Schema.ts
+++ b/src/storage/section16/Section16Schema.ts
@@ -8,6 +8,7 @@ import { Static, Type } from "typebox";
 import type { ITabularStorage } from "workglow";
 import { createServiceToken } from "workglow";
 import { TypeNullable } from "../../util/TypeBoxUtil";
+import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 
 /**
  * One row per Section 16 ownership filing (Form 3 / 4 / 5 and amendments),
@@ -17,7 +18,7 @@ export const Section16FilingSchema = Type.Object({
   accession_number: Type.String({ maxLength: 25, description: "EDGAR accession number" }),
   form: Type.String({ maxLength: 10, description: "Form symbol (3, 4, 5, 3/A, ...)" }),
   document_type: Type.String({ maxLength: 10, description: "ownershipDocument documentType" }),
-  issuer_cik: Type.Integer({ minimum: 0, description: "Issuer CIK" }),
+  issuer_cik: TypeSecCik({ description: "Issuer CIK" }),
   issuer_name: Type.String({ maxLength: 150, description: "Issuer name" }),
   issuer_trading_symbol: TypeNullable(Type.String({ maxLength: 20 })),
   period_of_report: TypeNullable(Type.String({ description: "Period of report (date)" })),
@@ -46,7 +47,7 @@ export const SECTION16_FILING_REPOSITORY_TOKEN =
 export const Section16TransactionSchema = Type.Object({
   accession_number: Type.String({ maxLength: 25 }),
   transaction_index: Type.Integer({ minimum: 0 }),
-  issuer_cik: Type.Integer({ minimum: 0 }),
+  issuer_cik: TypeSecCik(),
   is_derivative: Type.Boolean(),
   security_title: TypeNullable(Type.String({ maxLength: 255 })),
   transaction_date: TypeNullable(Type.String()),
@@ -93,7 +94,7 @@ export const SECTION16_TRANSACTION_REPOSITORY_TOKEN =
 export const Section16HoldingSchema = Type.Object({
   accession_number: Type.String({ maxLength: 25 }),
   holding_index: Type.Integer({ minimum: 0 }),
-  issuer_cik: Type.Integer({ minimum: 0 }),
+  issuer_cik: TypeSecCik(),
   is_derivative: Type.Boolean(),
   security_title: TypeNullable(Type.String({ maxLength: 255 })),
   shares_owned_following: TypeNullable(Type.Number()),

--- a/src/storage/versioning/componentRegistry.test.ts
+++ b/src/storage/versioning/componentRegistry.test.ts
@@ -8,8 +8,8 @@ import { describe, expect, it } from "bun:test";
 import { isRegisteredComponent, listRegisteredComponents } from "./componentRegistry";
 
 describe("componentRegistry", () => {
-  it("registers all five extractors", () => {
-    for (const id of ["D", "C", "1-A", "1-K", "1-Z"]) {
+  it("registers all extractors", () => {
+    for (const id of ["D", "C", "1-A", "1-K", "1-Z", "3", "4", "5"]) {
       expect(isRegisteredComponent("extractor", id)).toBe(true);
     }
   });
@@ -24,7 +24,7 @@ describe("componentRegistry", () => {
     expect(isRegisteredComponent("resolver", "sponsor")).toBe(false);
   });
 
-  it("listRegisteredComponents returns 7 entries", () => {
-    expect(listRegisteredComponents()).toHaveLength(7);
+  it("listRegisteredComponents returns one entry per extractor and resolver", () => {
+    expect(listRegisteredComponents()).toHaveLength(10);
   });
 });

--- a/src/storage/versioning/componentRegistry.test.ts
+++ b/src/storage/versioning/componentRegistry.test.ts
@@ -9,7 +9,7 @@ import { isRegisteredComponent, listRegisteredComponents } from "./componentRegi
 
 describe("componentRegistry", () => {
   it("registers all extractors", () => {
-    for (const id of ["D", "C", "1-A", "1-K", "1-Z", "3", "4", "5"]) {
+    for (const id of ["D", "C", "1-A", "1-K", "1-Z", "3", "4", "5", "144"]) {
       expect(isRegisteredComponent("extractor", id)).toBe(true);
     }
   });
@@ -25,6 +25,6 @@ describe("componentRegistry", () => {
   });
 
   it("listRegisteredComponents returns one entry per extractor and resolver", () => {
-    expect(listRegisteredComponents()).toHaveLength(10);
+    expect(listRegisteredComponents()).toHaveLength(11);
   });
 });

--- a/src/storage/versioning/extractorIds.test.ts
+++ b/src/storage/versioning/extractorIds.test.ts
@@ -13,8 +13,15 @@ import {
 } from "./extractorIds";
 
 describe("extractorIds", () => {
-  it("exposes exactly five canonical extractor ids", () => {
-    expect([...EXTRACTOR_IDS].sort()).toEqual(["1-A", "1-K", "1-Z", "C", "D"]);
+  it("exposes the canonical extractor ids", () => {
+    expect([...EXTRACTOR_IDS].sort()).toEqual(["1-A", "1-K", "1-Z", "3", "4", "5", "C", "D"]);
+  });
+
+  it("maps Form 3/4/5 and amendments to their document-type extractor ids", () => {
+    for (const form of ["3", "4", "5"]) {
+      expect(formToExtractorId(form)).toBe(form);
+      expect(formToExtractorId(`${form}/A`)).toBe(form);
+    }
   });
 
   it("maps Form D and amendments to extractor id 'D'", () => {

--- a/src/storage/versioning/extractorIds.test.ts
+++ b/src/storage/versioning/extractorIds.test.ts
@@ -14,7 +14,17 @@ import {
 
 describe("extractorIds", () => {
   it("exposes the canonical extractor ids", () => {
-    expect([...EXTRACTOR_IDS].sort()).toEqual(["1-A", "1-K", "1-Z", "3", "4", "5", "C", "D"]);
+    expect([...EXTRACTOR_IDS].sort()).toEqual([
+      "1-A",
+      "1-K",
+      "1-Z",
+      "144",
+      "3",
+      "4",
+      "5",
+      "C",
+      "D",
+    ]);
   });
 
   it("maps Form 3/4/5 and amendments to their document-type extractor ids", () => {
@@ -22,6 +32,11 @@ describe("extractorIds", () => {
       expect(formToExtractorId(form)).toBe(form);
       expect(formToExtractorId(`${form}/A`)).toBe(form);
     }
+  });
+
+  it("maps Form 144 and its amendment to extractor id '144'", () => {
+    expect(formToExtractorId("144")).toBe("144");
+    expect(formToExtractorId("144/A")).toBe("144");
   });
 
   it("maps Form D and amendments to extractor id 'D'", () => {

--- a/src/storage/versioning/extractorIds.ts
+++ b/src/storage/versioning/extractorIds.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const EXTRACTOR_IDS = ["D", "C", "1-A", "1-K", "1-Z"] as const;
+export const EXTRACTOR_IDS = ["D", "C", "1-A", "1-K", "1-Z", "3", "4", "5"] as const;
 export type ExtractorId = (typeof EXTRACTOR_IDS)[number];
 
 /**
@@ -34,6 +34,12 @@ export const FORM_TO_EXTRACTOR_ID: Readonly<Record<string, ExtractorId>> = {
   "1-K/A": "1-K",
   "1-Z": "1-Z",
   "1-Z/A": "1-Z",
+  "3": "3",
+  "3/A": "3",
+  "4": "4",
+  "4/A": "4",
+  "5": "5",
+  "5/A": "5",
 };
 
 export function formToExtractorId(form: string): ExtractorId | undefined {

--- a/src/storage/versioning/extractorIds.ts
+++ b/src/storage/versioning/extractorIds.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const EXTRACTOR_IDS = ["D", "C", "1-A", "1-K", "1-Z", "3", "4", "5"] as const;
+export const EXTRACTOR_IDS = ["D", "C", "1-A", "1-K", "1-Z", "3", "4", "5", "144"] as const;
 export type ExtractorId = (typeof EXTRACTOR_IDS)[number];
 
 /**
@@ -40,6 +40,8 @@ export const FORM_TO_EXTRACTOR_ID: Readonly<Record<string, ExtractorId>> = {
   "4/A": "4",
   "5": "5",
   "5/A": "5",
+  "144": "144",
+  "144/A": "144",
 };
 
 export function formToExtractorId(form: string): ExtractorId | undefined {

--- a/src/task/forms/ProcessAccessionDocFormTask.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.ts
@@ -19,6 +19,7 @@ import { processForm1K } from "../../sec/forms/exempt-offerings/Form_1_K.storage
 import { processForm1Z } from "../../sec/forms/exempt-offerings/Form_1_Z.storage";
 import { processFormC } from "../../sec/forms/exempt-offerings/Form_C.storage";
 import { processFormD } from "../../sec/forms/exempt-offerings/Form_D.storage";
+import { processOwnershipForm } from "../../sec/forms/insider-trading/OwnershipDocument.storage";
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../storage/versioning/ComponentVersionSchema";
@@ -182,6 +183,14 @@ export class ProcessAccessionDocFormTask extends Task<
             case "1-Z":
             case "1-Z/A":
               await processForm1Z({ ...storageArgs, form1Z: parsed });
+              break;
+            case "3":
+            case "3/A":
+            case "4":
+            case "4/A":
+            case "5":
+            case "5/A":
+              await processOwnershipForm({ ...storageArgs, form: form!, doc: parsed });
               break;
             default:
               throw new TaskError(`Form '${form}' has no storage handler`);

--- a/src/task/forms/ProcessAccessionDocFormTask.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.ts
@@ -20,6 +20,7 @@ import { processForm1Z } from "../../sec/forms/exempt-offerings/Form_1_Z.storage
 import { processFormC } from "../../sec/forms/exempt-offerings/Form_C.storage";
 import { processFormD } from "../../sec/forms/exempt-offerings/Form_D.storage";
 import { processOwnershipForm } from "../../sec/forms/insider-trading/OwnershipDocument.storage";
+import { processForm144 } from "../../sec/forms/insider-trading/Form_144.storage";
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../storage/versioning/ComponentVersionSchema";
@@ -191,6 +192,10 @@ export class ProcessAccessionDocFormTask extends Task<
             case "5":
             case "5/A":
               await processOwnershipForm({ ...storageArgs, form: form!, doc: parsed });
+              break;
+            case "144":
+            case "144/A":
+              await processForm144({ ...storageArgs, form: form!, doc: parsed });
               break;
             default:
               throw new TaskError(`Form '${form}' has no storage handler`);


### PR DESCRIPTION
## Summary

Implements parsing and storage for SEC insider-ownership filings, covering the EDGAR `ownershipDocument` schema shared by **Forms 3 / 4 / 5 (+ `/A` amendments)** and the separate **Form 144 / 144-A** "Notice of Proposed Sale" schema.

### Section 16 (Forms 3 / 4 / 5)
- Shared `OwnershipDocument.schema.ts` (TypeBox); `Form_3/4/5.parse()` delegate to it. Array paths are declared so single-element tables still parse as arrays, and `{ value }`-wrapped leaves coerce automatically.
- New `src/storage/section16/` tier:
  - `section16_filings` — one row per filing
  - `section16_transactions` — Form 4 / 5 transactions, `is_derivative` flag, full transaction + underlying-security detail
  - `section16_holdings` — Form 3 / 5 holdings
- Orphan-safe `clearTransactions` / `clearHoldings` on the positional-key detail tables for idempotent re-extraction.
- Reporting owners + issuer flow through `EntityObserver`. Owners are classified on the relationship flags (directors/officers are always individuals) with a cleaned-name fallback for the 10%-owner / other cases.

### Form 144 / 144-A
- `Form_144.schema.ts` models the `edgarSubmission` shape: issuer info + relationships, the (1:1) `securitiesInformation` / broker block, repeating `securitiesToBeSold` (acquisition lots), and `securitiesSoldInPast3Months` (recent sales). Dates are kept as the US-format strings EDGAR emits; numeric leaves are kept as strings and coerced in storage so an empty element doesn't become a fabricated 0.
- New `src/storage/form144/` tier: `form144_filings` (with the proposed-sale block folded in), `form144_acquisitions`, `form144_recent_sales`, plus `clear*` for idempotent re-extraction.
- Issuer + broker observed as companies; account holder observed as a person via `EntityObserver`.

### Wiring
- Extractors `3`, `4`, `5`, `144` added to `extractorIds`, dispatched in `ProcessAccessionDocFormTask`, registered in both DI containers, set up in `setupAllDatabases`, listed in `db stats`.
- Updated the extractor-count assertions in the versioning tests.

## Notable decisions
- **Person/entity classification** (no explicit flag in EDGAR ownership): directors/officers ⇒ person; otherwise a cleaned-name company-ending test (strips trailing punctuation + lone trailing initial). Verified on real multi-owner filings.
- **`issuer_cik`** comes solely from the XML `<issuerCik>`; no fallback to the filing's own CIK — the ingestion path may carry the reporting owner's CIK, which would otherwise contaminate the issuer column.
- **Form 144 numeric leaves are typed as strings** in the parse schema (storage `num()` coerces), avoiding `Value.Convert("")` → 0 which would fabricate $0 market values for empty elements.

## Test plan
- [x] Real EDGAR fixtures: Forms 3 / 3-A (with holdings) / 4 (incl. derivative) / 4-A / 5 / 144 / 144-A (incl. nothing-to-report)
- [x] Parse + storage tests, owner classification, orphan-clear regression, empty-numeric regression
- [x] Full suite: **753 pass / 0 fail**, `tsc --noEmit` clean, `bun run build` clean
- [x] Verified real `sec db setup` creates all 6 new tables (`section16_*`, `form144_*`)

https://claude.ai/code/session_017BajKRHwBkxAyPYDyDhgLz