### PR TITLE
fix(cli): harden CSV formula-injection escape (sec)

### DIFF
--- a/src/cli/output/TableRenderer.test.ts
+++ b/src/cli/output/TableRenderer.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { renderTable } from "./TableRenderer";
+import { renderTable, __testing } from "./TableRenderer";
 import type { ColumnDef, RenderOptions } from "./TableRenderer";
+
+const { escapeCsvValue } = __testing;
 
 const columns: ReadonlyArray<ColumnDef> = [
   { key: "id", header: "ID", width: 6 },
@@ -152,5 +154,81 @@ describe("renderTable", () => {
       expect(result).toContain("Showing 0-0 of 10 results");
       expect(result).not.toContain("--offset");
     });
+  });
+});
+
+describe("escapeCsvValue", () => {
+  // Per OWASP CSV Injection (https://owasp.org/www-community/attacks/CSV_Injection),
+  // cells beginning with =/+/-/@ (or TAB/CR after whitespace stripping) must be
+  // neutralized with a leading single-quote before being handed to a spreadsheet.
+
+  it("prefixes a single-quote when value starts with '='", () => {
+    expect(escapeCsvValue("=cmd")).toBe("'=cmd");
+  });
+
+  it("prefixes a single-quote when value starts with '+'", () => {
+    expect(escapeCsvValue("+cmd")).toBe("'+cmd");
+  });
+
+  it("prefixes a single-quote when value starts with '-'", () => {
+    expect(escapeCsvValue("-cmd")).toBe("'-cmd");
+  });
+
+  it("prefixes a single-quote when value starts with '@'", () => {
+    expect(escapeCsvValue("@cmd")).toBe("'@cmd");
+  });
+
+  it("prefixes a single-quote when value starts with TAB", () => {
+    expect(escapeCsvValue("\tcmd")).toBe("'\tcmd");
+  });
+
+  it("prefixes a single-quote when value starts with CR", () => {
+    // CR alone forces RFC 4180 quoting too because the cell contains a CR.
+    expect(escapeCsvValue("\rcmd")).toBe('"\'\rcmd"');
+  });
+
+  it("defuses leading ASCII space before '=' (spreadsheets strip leading WS)", () => {
+    expect(escapeCsvValue(" =cmd")).toBe("' =cmd");
+  });
+
+  it("defuses leading U+00A0 NBSP before '=' (spreadsheets strip NBSP too)", () => {
+    expect(escapeCsvValue(" =cmd")).toBe("' =cmd");
+  });
+
+  it("leaves plain alphabetic values unchanged", () => {
+    expect(escapeCsvValue("abc")).toBe("abc");
+  });
+
+  it("leaves plain numeric values unchanged", () => {
+    expect(escapeCsvValue("123")).toBe("123");
+  });
+
+  it("defuses a dangerous line after LF inside a multi-line cell", () => {
+    // Excel/Sheets re-parse every physical line of a quoted multi-line cell,
+    // so the second line must also be defused.
+    expect(escapeCsvValue("safe\n=cmd")).toBe('"safe\n\'=cmd"');
+  });
+
+  it("defuses a dangerous line after CRLF inside a multi-line cell", () => {
+    expect(escapeCsvValue("safe\r\n=cmd")).toBe('"safe\r\n\'=cmd"');
+  });
+
+  it("defuses every dangerous follow-up line, leaving safe interleaved lines alone", () => {
+    const input = "safe\n=danger1\nstillsafe\n+danger2\n@danger3";
+    const expected =
+      '"safe\n\'=danger1\nstillsafe\n\'+danger2\n\'@danger3"';
+    expect(escapeCsvValue(input)).toBe(expected);
+  });
+
+  it("wraps cells that contain a comma in double quotes", () => {
+    expect(escapeCsvValue("a,b")).toBe('"a,b"');
+  });
+
+  it("doubles embedded double-quotes inside a wrapped cell", () => {
+    expect(escapeCsvValue('he said "hi"')).toBe('"he said ""hi"""');
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(escapeCsvValue("")).toBe("");
   });
 });

--- a/src/cli/output/TableRenderer.ts
+++ b/src/cli/output/TableRenderer.ts
@@ -34,21 +34,60 @@ function pad(value: string, width: number): string {
   return truncate(value, width).padEnd(width);
 }
 
+// Characters that trigger formula interpretation when found at the start of a
+// spreadsheet cell. See OWASP CSV Injection
+// (https://owasp.org/www-community/attacks/CSV_Injection).
+const DANGEROUS_LEAD = /^[=+\-@\t\r]/;
+// ASCII whitespace plus U+00A0 NBSP — Excel/Sheets/Numbers strip leading
+// whitespace (including NBSP) before parsing a cell as a formula, so we must
+// strip it too before checking for the dangerous leading char.
+const LEADING_WS = /^[\s ]+/;
+
+function needsFormulaPrefix(line: string): boolean {
+  return DANGEROUS_LEAD.test(line.replace(LEADING_WS, ""));
+}
+
+function defuseLine(line: string): string {
+  return needsFormulaPrefix(line) ? "'" + line : line;
+}
+
+/**
+ * Defuse CSV/spreadsheet formula injection per OWASP CSV Injection guidance.
+ *
+ * When Excel/Sheets/Numbers open a CSV, a cell starting with =/+/-/@ (or TAB/CR
+ * which some loaders strip) is interpreted as a formula and can exfiltrate data
+ * via WEBSERVICE/HYPERLINK or run external commands. Prefixing a single quote
+ * neutralizes the formula — spreadsheets render the apostrophe as a literal and
+ * hide the prefix; plain CSV consumers see one extra leading apostrophe.
+ *
+ * The naive `^[=+\-@\t\r]` check has three bypasses we handle here:
+ *   1. Leading ASCII whitespace (" =cmd...") — spreadsheets strip it.
+ *   2. Leading U+00A0 NBSP (" =cmd...") — also stripped.
+ *   3. Dangerous char after an embedded newline in a quoted multi-line cell
+ *      ("safe\n=cmd") — each physical line is re-parsed.
+ *
+ * Each line of the value is defused independently; the result is then RFC 4180
+ * quoted if it contains a comma, quote, CR, or LF.
+ */
 function escapeCsvValue(value: string): string {
-  // Defuse CSV/spreadsheet formula injection. When Excel/Sheets/Numbers
-  // open a CSV, a cell starting with =/+/-/@ (or with leading TAB/CR
-  // that some loaders strip) is interpreted as a formula, which can
-  // exfiltrate data via WEBSERVICE/HYPERLINK or run external commands.
-  // Prefix a single quote — spreadsheets render it as a literal and hide
-  // the prefix; plain CSV consumers see the original text with one
-  // leading apostrophe, which is a small price for not shipping a known
-  // attack vector.
-  const dangerous = value.length > 0 && /^[=+\-@\t\r]/.test(value);
-  let escaped = dangerous ? "'" + value : value;
-  if (escaped.includes(",") || escaped.includes('"') || escaped.includes("\n")) {
-    return '"' + escaped.replace(/"/g, '""') + '"';
+  if (value.length === 0) {
+    return value;
   }
-  return escaped;
+  // Capturing-group split preserves the separators at odd indices so we can
+  // round-trip the exact line endings (LF vs CRLF) the caller used.
+  const parts = value.split(/(\r?\n)/);
+  const defused = parts
+    .map((part, i) => (i % 2 === 0 ? defuseLine(part) : part))
+    .join("");
+  if (
+    defused.includes(",") ||
+    defused.includes('"') ||
+    defused.includes("\n") ||
+    defused.includes("\r")
+  ) {
+    return '"' + defused.replace(/"/g, '""') + '"';
+  }
+  return defused;
 }
 
 function cellValue(row: Record<string, unknown>, key: string): string {
@@ -128,3 +167,6 @@ export function renderTable(
       return renderTextTable(rows, columns, options);
   }
 }
+
+// Exported for unit tests; not part of the module's public API.
+export const __testing = { escapeCsvValue };


### PR DESCRIPTION
## Summary

Hardens `escapeCsvValue` in `src/cli/output/TableRenderer.ts` against three classes of CSV formula-injection bypass that the previous `^[=+\-@\t\r]/` check missed. Follows [OWASP CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection) guidance for neutralizing untrusted cell content emitted by `sec query --format csv` before a spreadsheet opens it.

### Bypasses now closed

1. **Leading ASCII whitespace** — Excel/Sheets/Numbers strip leading whitespace before parsing a cell as a formula, so ` =cmd|'/c calc'!A0` (note the leading space) was reaching the spreadsheet unprefixed and executing.
2. **Leading U+00A0 NBSP** — Same as above; NBSP is stripped by the parsers and was not in the previous whitespace check.
3. **Dangerous chars after embedded newlines in a multi-line cell** — Quoted multi-line cells are re-parsed per physical line, so `"safe\n=cmd"` exposed the second line as a formula even when the first line was benign.

### Fix

- New `DANGEROUS_LEAD` (`/^[=+\-@\t\r]/`) + `LEADING_WS` (`/^[\s ]+/`) constants.
- `needsFormulaPrefix(line)` strips leading WS/NBSP before the dangerous-lead test.
- `defuseLine(line)` returns `"'" + line` when dangerous.
- `escapeCsvValue` now splits the value on `/(\r?\n)/`, defuses each data line independently, preserves the original separators, and only then applies RFC 4180 quoting (now also triggered by `\r`, not just `\n`).
- Public API is unchanged; `escapeCsvValue` is re-exported via `__testing` purely for unit tests.

## Test plan

New `describe("escapeCsvValue")` block in `src/cli/output/TableRenderer.test.ts`:

- [ ] All six dangerous leads prefixed: `=cmd`, `+cmd`, `-cmd`, `@cmd`, `\tcmd`, `\rcmd`.
- [ ] Leading ASCII space + `=cmd` → `' =cmd`.
- [ ] Leading NBSP + `=cmd` → `' =cmd`.
- [ ] Plain `abc` and `123` left unchanged.
- [ ] Multi-line LF `safe\n=cmd` → `"safe\n'=cmd"`.
- [ ] Multi-line CRLF `safe\r\n=cmd` → `"safe\r\n'=cmd"`.
- [ ] Multi-line with multiple dangerous lines interleaved with safe ones — every dangerous line defused, safe ones untouched.
- [ ] Cell with `,` wrapped in quotes.
- [ ] Embedded `"` doubled inside wrapped cell.
- [ ] `escapeCsvValue("")` returns `""`.
- [ ] All existing `renderTable` tests (json/csv/table format) still pass — header/data rows, comma/quote/null handling, original 5-row formula-prefix test, benign leads, table padding/truncation/pagination.

## Out of scope

Plans I and J (PR #118's branch) are intentionally not touched here; the PR author for that branch will apply them.

---
_Generated by [Claude Code](https://claude.ai/code/session_014tiKE9KxsLy9rdhJk8qjmh)_