### PR TITLE
fix(forms,storage,cli): person-collision issuer guard + alias chain block + CLI input validation + coverage perf

### DIFF
--- a/src/cli/groups/canonical.test.ts
+++ b/src/cli/groups/canonical.test.ts
@@ -251,6 +251,30 @@ describe("resolveCanonicalPersonRef", () => {
   it("throws when no canonical person matches a bare name", async () => {
     await expect(resolveCanonicalPersonRef("Nobody Here", repo)).rejects.toThrow(/no canonical/);
   });
+
+  it("trims leading/trailing whitespace before UUID and name matching", async () => {
+    const id = "aaaaaaaa-0000-0000-0000-000000000001";
+    await repo.create({
+      canonical_person_id: id,
+      resolver_version: "1.0.0",
+      display_first: "Jane",
+      display_middle: null,
+      display_last: "Doe",
+      display_suffix: null,
+      cik: null,
+      normalized_first: "jane",
+      normalized_middle: null,
+      normalized_last: "doe",
+      normalized_suffix: null,
+      source_filing_issuer_cik: null,
+      created_at: "2026-05-22T00:00:00.000Z",
+    });
+    // UUID with surrounding whitespace still detected as UUID.
+    expect(await resolveCanonicalPersonRef(` ${id}\n`, repo)).toBe(id);
+    // Bare name with trailing whitespace still resolves to its UUID.
+    expect(await resolveCanonicalPersonRef("Jane Doe ", repo)).toBe(id);
+    expect(await resolveCanonicalPersonRef(" doe\t", repo)).toBe(id);
+  });
 });
 
 describe("resolveCanonicalCompanyRef", () => {
@@ -316,5 +340,21 @@ describe("resolveCanonicalCompanyRef", () => {
     await expect(resolveCanonicalCompanyRef("Nonexistent Co", repo)).rejects.toThrow(
       /no canonical/
     );
+  });
+
+  it("trims leading/trailing whitespace before UUID and name matching", async () => {
+    const id = "bbbbbbbb-0000-0000-0000-000000000001";
+    await repo.create({
+      canonical_company_id: id,
+      resolver_version: "1.0.0",
+      display_name: "Acme Holdings LLC",
+      cik: null,
+      crd_number: null,
+      normalized_name: "acme holdings llc",
+      created_at: "2026-05-22T00:00:00.000Z",
+    });
+    expect(await resolveCanonicalCompanyRef(` ${id}\n`, repo)).toBe(id);
+    expect(await resolveCanonicalCompanyRef("Acme Holdings LLC ", repo)).toBe(id);
+    expect(await resolveCanonicalCompanyRef(" acme holdings llc\t", repo)).toBe(id);
   });
 });

--- a/src/cli/groups/canonical.test.ts
+++ b/src/cli/groups/canonical.test.ts
@@ -4,10 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { InMemoryTabularStorage } from "workglow";
+import { CanonicalPersonRepo } from "../../storage/canonical/CanonicalPersonRepo";
+import { CanonicalCompanyRepo } from "../../storage/canonical/CanonicalCompanyRepo";
+import {
+  CanonicalPersonSchema,
+  CanonicalPersonPrimaryKeyNames,
+  type CanonicalPerson,
+} from "../../storage/canonical/CanonicalPersonSchema";
+import {
+  CanonicalCompanySchema,
+  CanonicalCompanyPrimaryKeyNames,
+  type CanonicalCompany,
+} from "../../storage/canonical/CanonicalCompanySchema";
+import {
+  resolveCanonicalCompanyRef,
+  resolveCanonicalPersonRef,
+} from "./canonical";
 
 interface RunResult {
   stdout: string;
@@ -147,5 +164,157 @@ describe("sec canonical CLI", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// Direct unit tests for the canonical-reference resolver helpers. The CLI docs
+// invite operators to pass display names; we must not let those flow straight
+// into UUID-typed columns. See S-MAIN-03.
+describe("resolveCanonicalPersonRef", () => {
+  let storage: InMemoryTabularStorage<
+    typeof CanonicalPersonSchema,
+    typeof CanonicalPersonPrimaryKeyNames,
+    CanonicalPerson
+  >;
+  let repo: CanonicalPersonRepo;
+
+  beforeEach(() => {
+    storage = new InMemoryTabularStorage<
+      typeof CanonicalPersonSchema,
+      typeof CanonicalPersonPrimaryKeyNames,
+      CanonicalPerson
+    >(CanonicalPersonSchema, CanonicalPersonPrimaryKeyNames, []);
+    repo = new CanonicalPersonRepo({ canonicalPersonRepository: storage });
+  });
+
+  it("returns a UUID input unchanged (round-trip)", async () => {
+    const id = "11111111-2222-3333-4444-555555555555";
+    expect(await resolveCanonicalPersonRef(id, repo)).toBe(id);
+  });
+
+  it("resolves a bare name to its UUID", async () => {
+    const id = "aaaaaaaa-0000-0000-0000-000000000001";
+    await repo.create({
+      canonical_person_id: id,
+      resolver_version: "1.0.0",
+      display_first: "Jane",
+      display_middle: null,
+      display_last: "Doe",
+      display_suffix: null,
+      cik: null,
+      normalized_first: "jane",
+      normalized_middle: null,
+      normalized_last: "doe",
+      normalized_suffix: null,
+      source_filing_issuer_cik: null,
+      created_at: "2026-05-22T00:00:00.000Z",
+    });
+    expect(await resolveCanonicalPersonRef("Jane Doe", repo)).toBe(id);
+    // last-only and case-insensitive matches also work
+    expect(await resolveCanonicalPersonRef("doe", repo)).toBe(id);
+  });
+
+  it("throws on ambiguous bare name (multiple matches)", async () => {
+    await repo.create({
+      canonical_person_id: "aaaaaaaa-0000-0000-0000-000000000001",
+      resolver_version: "1.0.0",
+      display_first: null,
+      display_middle: null,
+      display_last: "Smith",
+      display_suffix: null,
+      cik: null,
+      normalized_first: null,
+      normalized_middle: null,
+      normalized_last: "smith",
+      normalized_suffix: null,
+      source_filing_issuer_cik: 100,
+      created_at: "2026-05-22T00:00:00.000Z",
+    });
+    await repo.create({
+      canonical_person_id: "aaaaaaaa-0000-0000-0000-000000000002",
+      resolver_version: "1.0.0",
+      display_first: null,
+      display_middle: null,
+      display_last: "Smith",
+      display_suffix: null,
+      cik: null,
+      normalized_first: null,
+      normalized_middle: null,
+      normalized_last: "smith",
+      normalized_suffix: null,
+      source_filing_issuer_cik: 200,
+      created_at: "2026-05-22T00:00:00.000Z",
+    });
+    await expect(resolveCanonicalPersonRef("Smith", repo)).rejects.toThrow(/multiple/);
+  });
+
+  it("throws when no canonical person matches a bare name", async () => {
+    await expect(resolveCanonicalPersonRef("Nobody Here", repo)).rejects.toThrow(/no canonical/);
+  });
+});
+
+describe("resolveCanonicalCompanyRef", () => {
+  let storage: InMemoryTabularStorage<
+    typeof CanonicalCompanySchema,
+    typeof CanonicalCompanyPrimaryKeyNames,
+    CanonicalCompany
+  >;
+  let repo: CanonicalCompanyRepo;
+
+  beforeEach(() => {
+    storage = new InMemoryTabularStorage<
+      typeof CanonicalCompanySchema,
+      typeof CanonicalCompanyPrimaryKeyNames,
+      CanonicalCompany
+    >(CanonicalCompanySchema, CanonicalCompanyPrimaryKeyNames, []);
+    repo = new CanonicalCompanyRepo({ canonicalCompanyRepository: storage });
+  });
+
+  it("returns a UUID input unchanged (round-trip)", async () => {
+    const id = "11111111-2222-3333-4444-555555555555";
+    expect(await resolveCanonicalCompanyRef(id, repo)).toBe(id);
+  });
+
+  it("resolves a bare name to its UUID", async () => {
+    const id = "bbbbbbbb-0000-0000-0000-000000000001";
+    await repo.create({
+      canonical_company_id: id,
+      resolver_version: "1.0.0",
+      display_name: "Acme Holdings LLC",
+      cik: null,
+      crd_number: null,
+      normalized_name: "acme holdings llc",
+      created_at: "2026-05-22T00:00:00.000Z",
+    });
+    expect(await resolveCanonicalCompanyRef("acme holdings llc", repo)).toBe(id);
+    expect(await resolveCanonicalCompanyRef("Acme Holdings LLC", repo)).toBe(id);
+  });
+
+  it("throws on ambiguous bare name (multiple matches)", async () => {
+    await repo.create({
+      canonical_company_id: "bbbbbbbb-0000-0000-0000-000000000001",
+      resolver_version: "1.0.0",
+      display_name: "Globex",
+      cik: null,
+      crd_number: null,
+      normalized_name: "globex",
+      created_at: "2026-05-22T00:00:00.000Z",
+    });
+    await repo.create({
+      canonical_company_id: "bbbbbbbb-0000-0000-0000-000000000002",
+      resolver_version: "2.0.0",
+      display_name: "Globex",
+      cik: null,
+      crd_number: null,
+      normalized_name: "globex",
+      created_at: "2026-05-22T00:00:00.000Z",
+    });
+    await expect(resolveCanonicalCompanyRef("Globex", repo)).rejects.toThrow(/multiple/);
+  });
+
+  it("throws when no canonical company matches a bare name", async () => {
+    await expect(resolveCanonicalCompanyRef("Nonexistent Co", repo)).rejects.toThrow(
+      /no canonical/
+    );
   });
 });

--- a/src/cli/groups/canonical.ts
+++ b/src/cli/groups/canonical.ts
@@ -10,6 +10,70 @@ import { CanonicalCompanyAliasRepo } from "../../storage/canonical/CanonicalComp
 import { CanonicalPersonRepo } from "../../storage/canonical/CanonicalPersonRepo";
 import { CanonicalCompanyRepo } from "../../storage/canonical/CanonicalCompanyRepo";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve a CLI-supplied canonical reference (UUID or display name) to a
+ * canonical UUID. Bare strings are matched case-insensitively against the
+ * canonical's display name (`display_first display_last` composite or
+ * `display_last` alone for persons; `display_name` for companies). The CLI
+ * docs invite operators to pass names, so we must not let raw strings flow
+ * straight into UUID-typed columns.
+ *
+ * Throws when the input does not look like a UUID and no canonical row
+ * matches (or more than one does).
+ */
+/** @internal exported for unit tests */
+export async function resolveCanonicalPersonRef(
+  input: string,
+  repo: CanonicalPersonRepo
+): Promise<string> {
+  if (UUID_RE.test(input)) return input;
+  const all = await repo.listAll();
+  const lower = input.toLowerCase();
+  const matches = all.filter((r) => {
+    const composite = [r.display_first, r.display_last]
+      .filter((s): s is string => Boolean(s))
+      .join(" ")
+      .toLowerCase();
+    const lastOnly = (r.display_last ?? "").toLowerCase();
+    return composite === lower || lastOnly === lower;
+  });
+  if (matches.length === 0) {
+    throw new Error(`no canonical person matches '${input}'`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `multiple canonical persons match '${input}': ${matches
+        .map((m) => m.canonical_person_id)
+        .join(", ")}`
+    );
+  }
+  return matches[0].canonical_person_id;
+}
+
+/** @internal exported for unit tests */
+export async function resolveCanonicalCompanyRef(
+  input: string,
+  repo: CanonicalCompanyRepo
+): Promise<string> {
+  if (UUID_RE.test(input)) return input;
+  const all = await repo.listAll();
+  const lower = input.toLowerCase();
+  const matches = all.filter((r) => (r.display_name ?? "").toLowerCase() === lower);
+  if (matches.length === 0) {
+    throw new Error(`no canonical company matches '${input}'`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `multiple canonical companies match '${input}': ${matches
+        .map((m) => m.canonical_company_id)
+        .join(", ")}`
+    );
+  }
+  return matches[0].canonical_company_id;
+}
+
 export function addCanonicalCommands(program: Command): void {
   const cmd = program.command("canonical");
   cmd.description("Manage canonical-identity aliases.");
@@ -21,13 +85,28 @@ export function addCanonicalCommands(program: Command): void {
     .command("alias <from> <into>")
     .option("--reason <text>", "free-text annotation")
     .action(async (from: string, into: string, opts: { reason?: string }) => {
-      if (from === into) {
+      const canonRepo = new CanonicalPersonRepo();
+      let fromId: string;
+      let intoId: string;
+      try {
+        fromId = await resolveCanonicalPersonRef(from, canonRepo);
+        intoId = await resolveCanonicalPersonRef(into, canonRepo);
+      } catch (e) {
+        console.error(`error: ${(e as Error).message}`);
+        process.exit(1);
+      }
+      if (fromId === intoId) {
         console.error("error: cannot alias an id to itself");
         process.exit(1);
       }
       const aliasRepo = new CanonicalPersonAliasRepo();
       try {
-        const row = await aliasRepo.add(from, into, opts.reason ?? null, process.env.USER ?? null);
+        const row = await aliasRepo.add(
+          fromId,
+          intoId,
+          opts.reason ?? null,
+          process.env.USER ?? null
+        );
         console.log(`aliased ${row.alias_canonical_id} → ${row.target_canonical_id}`);
       } catch (e) {
         console.error(`error: ${(e as Error).message}`);
@@ -38,9 +117,17 @@ export function addCanonicalCommands(program: Command): void {
   person
     .command("alias-remove <from>")
     .action(async (from: string) => {
+      const canonRepo = new CanonicalPersonRepo();
+      let fromId: string;
+      try {
+        fromId = await resolveCanonicalPersonRef(from, canonRepo);
+      } catch (e) {
+        console.error(`error: ${(e as Error).message}`);
+        process.exit(1);
+      }
       const aliasRepo = new CanonicalPersonAliasRepo();
-      await aliasRepo.remove(from);
-      console.log(`removed alias for ${from}`);
+      await aliasRepo.remove(fromId);
+      console.log(`removed alias for ${fromId}`);
     });
 
   person
@@ -70,13 +157,28 @@ export function addCanonicalCommands(program: Command): void {
     .command("alias <from> <into>")
     .option("--reason <text>", "free-text annotation")
     .action(async (from: string, into: string, opts: { reason?: string }) => {
-      if (from === into) {
+      const canonRepo = new CanonicalCompanyRepo();
+      let fromId: string;
+      let intoId: string;
+      try {
+        fromId = await resolveCanonicalCompanyRef(from, canonRepo);
+        intoId = await resolveCanonicalCompanyRef(into, canonRepo);
+      } catch (e) {
+        console.error(`error: ${(e as Error).message}`);
+        process.exit(1);
+      }
+      if (fromId === intoId) {
         console.error("error: cannot alias an id to itself");
         process.exit(1);
       }
       const aliasRepo = new CanonicalCompanyAliasRepo();
       try {
-        const row = await aliasRepo.add(from, into, opts.reason ?? null, process.env.USER ?? null);
+        const row = await aliasRepo.add(
+          fromId,
+          intoId,
+          opts.reason ?? null,
+          process.env.USER ?? null
+        );
         console.log(`aliased ${row.alias_canonical_id} → ${row.target_canonical_id}`);
       } catch (e) {
         console.error(`error: ${(e as Error).message}`);
@@ -87,9 +189,17 @@ export function addCanonicalCommands(program: Command): void {
   company
     .command("alias-remove <from>")
     .action(async (from: string) => {
+      const canonRepo = new CanonicalCompanyRepo();
+      let fromId: string;
+      try {
+        fromId = await resolveCanonicalCompanyRef(from, canonRepo);
+      } catch (e) {
+        console.error(`error: ${(e as Error).message}`);
+        process.exit(1);
+      }
       const aliasRepo = new CanonicalCompanyAliasRepo();
-      await aliasRepo.remove(from);
-      console.log(`removed alias for ${from}`);
+      await aliasRepo.remove(fromId);
+      console.log(`removed alias for ${fromId}`);
     });
 
   company

--- a/src/cli/groups/canonical.ts
+++ b/src/cli/groups/canonical.ts
@@ -28,9 +28,10 @@ export async function resolveCanonicalPersonRef(
   input: string,
   repo: CanonicalPersonRepo
 ): Promise<string> {
-  if (UUID_RE.test(input)) return input;
+  const trimmed = input.trim();
+  if (UUID_RE.test(trimmed)) return trimmed;
   const all = await repo.listAll();
-  const lower = input.toLowerCase();
+  const lower = trimmed.toLowerCase();
   const matches = all.filter((r) => {
     const composite = [r.display_first, r.display_last]
       .filter((s): s is string => Boolean(s))
@@ -40,11 +41,11 @@ export async function resolveCanonicalPersonRef(
     return composite === lower || lastOnly === lower;
   });
   if (matches.length === 0) {
-    throw new Error(`no canonical person matches '${input}'`);
+    throw new Error(`no canonical person matches '${trimmed}'`);
   }
   if (matches.length > 1) {
     throw new Error(
-      `multiple canonical persons match '${input}': ${matches
+      `multiple canonical persons match '${trimmed}': ${matches
         .map((m) => m.canonical_person_id)
         .join(", ")}`
     );
@@ -57,16 +58,17 @@ export async function resolveCanonicalCompanyRef(
   input: string,
   repo: CanonicalCompanyRepo
 ): Promise<string> {
-  if (UUID_RE.test(input)) return input;
+  const trimmed = input.trim();
+  if (UUID_RE.test(trimmed)) return trimmed;
   const all = await repo.listAll();
-  const lower = input.toLowerCase();
+  const lower = trimmed.toLowerCase();
   const matches = all.filter((r) => (r.display_name ?? "").toLowerCase() === lower);
   if (matches.length === 0) {
-    throw new Error(`no canonical company matches '${input}'`);
+    throw new Error(`no canonical company matches '${trimmed}'`);
   }
   if (matches.length > 1) {
     throw new Error(
-      `multiple canonical companies match '${input}': ${matches
+      `multiple canonical companies match '${trimmed}': ${matches
         .map((m) => m.canonical_company_id)
         .join(", ")}`
     );

--- a/src/cli/groups/resolve.test.ts
+++ b/src/cli/groups/resolve.test.ts
@@ -168,4 +168,55 @@ describe("sec resolve CLI", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("resolve rejects partial semver --resolver-version '1.0'", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-resolve-test-"));
+    try {
+      const setup = await runCli(["db", "setup"], dir);
+      expect(setup.exitCode).toBe(0);
+
+      const result = await runCli(
+        ["resolve", "--kind", "person", "--resolver-version", "1.0", "--all"],
+        dir
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("--resolver-version");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolve rejects v-prefixed --resolver-version 'v1.0.0'", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-resolve-test-"));
+    try {
+      const setup = await runCli(["db", "setup"], dir);
+      expect(setup.exitCode).toBe(0);
+
+      const result = await runCli(
+        ["resolve", "--kind", "person", "--resolver-version", "v1.0.0", "--all"],
+        dir
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("--resolver-version");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolve rejects nonsense --resolver-version 'not-a-version'", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sec-resolve-test-"));
+    try {
+      const setup = await runCli(["db", "setup"], dir);
+      expect(setup.exitCode).toBe(0);
+
+      const result = await runCli(
+        ["resolve", "--kind", "person", "--resolver-version", "not-a-version", "--all"],
+        dir
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("--resolver-version");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/groups/resolve.ts
+++ b/src/cli/groups/resolve.ts
@@ -16,6 +16,7 @@ import { CanonicalCompanyAliasRepo } from "../../storage/canonical/CanonicalComp
 import { PersonResolver } from "../../resolver/PersonResolver";
 import { CompanyResolver } from "../../resolver/CompanyResolver";
 import { RESOLVER_IDS, type ResolverId } from "../../resolver/resolverIds";
+import { isValidSemver } from "../../storage/versioning/VersionRegistry";
 
 export function addResolveCommands(program: Command): void {
   const cmd = program.command("resolve");
@@ -31,6 +32,12 @@ export function addResolveCommands(program: Command): void {
       }
       if (!opts.all) {
         console.error("error: --all is required (no other mode supported in v1)");
+        process.exit(1);
+      }
+      if (!isValidSemver(opts.resolverVersion)) {
+        console.error(
+          `error: --resolver-version must be a valid semver (got '${opts.resolverVersion}')`
+        );
         process.exit(1);
       }
 

--- a/src/cli/groups/version.ts
+++ b/src/cli/groups/version.ts
@@ -68,13 +68,6 @@ function assertFormat(s: string): asserts s is "table" | "json" {
  * dev-cycle, they will need their own kind-aware snapshot strategy
  * (count of observations? count of canonical identities? TBD). Add a
  * dispatch table keyed on ComponentKind here when PR4 lands.
- *
- * TODO(perf): currently loads all filings into memory via filingRepo.query()
- * just to count them. For Form D at projected scale (hundreds of thousands
- * of filings) this is ~100MB transient. A filtered-count helper on the
- * tabular storage or a paged-iteration counter would be cheaper. Acceptable
- * for v1 because start-dev is a rare manual ceremony; revisit if it becomes
- * a routine operation.
  */
 async function snapshotTargetCount(
   kind: ComponentKind,
@@ -91,8 +84,9 @@ async function snapshotTargetCount(
     .map(([form]) => form);
   let total = 0;
   for (const form of forms) {
-    const rows = (await filingRepo.query({ form })) ?? [];
-    total += rows.length;
+    // COUNT() path — at Form D scale (hundreds of thousands of filings)
+    // materializing every row was ~100MB transient.
+    total += await filingRepo.count({ form });
   }
   return total;
 }

--- a/src/cli/queries/ResolverCoverage.test.ts
+++ b/src/cli/queries/ResolverCoverage.test.ts
@@ -5,10 +5,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
 import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
 import { setupAllDatabases } from "../../config/setupAllDatabases";
 import { PersonObservationRepo } from "../../storage/observation/PersonObservationRepo";
 import { PersonIdentityLinkRepo } from "../../storage/canonical/PersonIdentityLinkRepo";
+import { PERSON_OBSERVATION_REPOSITORY_TOKEN } from "../../storage/observation/PersonObservationSchema";
+import { PERSON_IDENTITY_LINK_REPOSITORY_TOKEN } from "../../storage/canonical/PersonIdentityLinkSchema";
 import { computeResolverCoverage } from "./ResolverCoverage";
 
 describe("computeResolverCoverage", () => {
@@ -70,5 +73,45 @@ describe("computeResolverCoverage", () => {
     expect(result.numerator).toBe(0);
     expect(result.denominator).toBe(0);
     expect(result.fraction).toBe(0);
+  });
+
+  it("uses count() (not listAll/getAll) to compute coverage (S-MAIN-05)", async () => {
+    // Stub the underlying ITabularStorage instances so that every row-materializing
+    // path (getAll / query / records / pages) throws if called, while count()
+    // returns deterministic values. If computeResolverCoverage still materializes
+    // the full table this test will fail loudly with the planted error.
+    const obsStorage = globalServiceRegistry.get(PERSON_OBSERVATION_REPOSITORY_TOKEN);
+    const linkStorage = globalServiceRegistry.get(PERSON_IDENTITY_LINK_REPOSITORY_TOKEN);
+
+    let countCalls = 0;
+    let lastLinkCriteria: Record<string, unknown> | undefined;
+
+    const refuse = (name: string) => {
+      throw new Error(`forbidden materialization path '${name}' was called`);
+    };
+
+    // We only need to intercept the methods ResolverCoverage might call.
+    (obsStorage as { getAll: () => Promise<unknown> }).getAll = async () =>
+      refuse("PersonObservation.getAll");
+    (obsStorage as { count: (c?: unknown) => Promise<number> }).count = async () => {
+      countCalls++;
+      return 17;
+    };
+    (linkStorage as { getAll: () => Promise<unknown> }).getAll = async () =>
+      refuse("PersonIdentityLink.getAll");
+    (linkStorage as { count: (c?: Record<string, unknown>) => Promise<number> }).count = async (
+      criteria
+    ) => {
+      countCalls++;
+      lastLinkCriteria = criteria;
+      return 11;
+    };
+
+    const result = await computeResolverCoverage("person", "1.0.0");
+    expect(result.numerator).toBe(11);
+    expect(result.denominator).toBe(17);
+    expect(result.fraction).toBeCloseTo(11 / 17);
+    expect(countCalls).toBe(2);
+    expect(lastLinkCriteria).toEqual({ resolver_version: "1.0.0" });
   });
 });

--- a/src/cli/queries/ResolverCoverage.ts
+++ b/src/cli/queries/ResolverCoverage.ts
@@ -22,12 +22,13 @@ export async function computeResolverCoverage(
   kind: ResolverId,
   resolver_version: string
 ): Promise<ResolverCoverageResult> {
+  // Use the storage layer's COUNT path instead of materializing every row.
+  // At Form D + Section 16 scale `listAll()` OOMs.
   if (kind === "person") {
     const obsRepo = new PersonObservationRepo();
     const linkRepo = new PersonIdentityLinkRepo();
-    const denom = (await obsRepo.listAll()).length;
-    const allLinks = await linkRepo.listAll();
-    const num = allLinks.filter((l) => l.resolver_version === resolver_version).length;
+    const denom = await obsRepo.count();
+    const num = await linkRepo.count({ resolver_version });
     return {
       kind,
       resolver_version,
@@ -38,9 +39,8 @@ export async function computeResolverCoverage(
   }
   const obsRepo = new CompanyObservationRepo();
   const linkRepo = new CompanyIdentityLinkRepo();
-  const denom = (await obsRepo.listAll()).length;
-  const allLinks = await linkRepo.listAll();
-  const num = allLinks.filter((l) => l.resolver_version === resolver_version).length;
+  const denom = await obsRepo.count();
+  const num = await linkRepo.count({ resolver_version });
   return {
     kind,
     resolver_version,

--- a/src/sec/forms/insider-trading/OwnershipDocument.storage.test.ts
+++ b/src/sec/forms/insider-trading/OwnershipDocument.storage.test.ts
@@ -324,6 +324,66 @@ describe("OwnershipDocument storage (Forms 3/4/5)", () => {
     expect(deriv[1].conversion_or_exercise_price).not.toBeNull();
   });
 
+  it("preserves null issuer CIK on reporting-owner observations (S-MAIN-01)", async () => {
+    // Two unrelated Form 4 filings whose XML omits issuer.issuerCik (or carries
+    // an unparseable value) must NOT collapse two reporting owners that happen
+    // to share a name into one canonical person. The observation must carry
+    // source_filing_issuer_cik=null instead of the raw 0 sentinel that
+    // PersonResolver's name-fallback key would conflate across filers.
+    const xml = readFileSync(
+      join(__dirname, "mock_data", "form-4", "000149315226025476-primary_doc.xml"),
+      "utf-8"
+    );
+    const docA = await Form_4.parse("4", xml);
+    const docB = await Form_4.parse("4", xml);
+
+    // Strip the issuer CIK on both filings (different accessions). Use a
+    // distinct reporting-owner name so we can find it back later.
+    const SHARED_NAME = "Smith John A";
+    docA.issuer!.issuerCik = undefined;
+    docB.issuer!.issuerCik = undefined;
+    // Rewrite each filing's first reporting owner to the same name with no CIK
+    // so the resolver hits the name-fallback path (not the CIK fast-path).
+    docA.reportingOwner![0].reportingOwnerId!.rptOwnerName = { value: SHARED_NAME };
+    docA.reportingOwner![0].reportingOwnerId!.rptOwnerCik = undefined;
+    docB.reportingOwner![0].reportingOwnerId!.rptOwnerName = { value: SHARED_NAME };
+    docB.reportingOwner![0].reportingOwnerId!.rptOwnerCik = undefined;
+
+    const accessionA = "0001493152-26-025476";
+    const accessionB = "0001493152-26-099999";
+
+    await processOwnershipForm({
+      cik: 1828673,
+      file_number: "",
+      accession_number: accessionA,
+      filing_date: "2026-05-27",
+      primary_doc: "a.xml",
+      form: "4",
+      doc: docA,
+    });
+    await processOwnershipForm({
+      cik: 9999999,
+      file_number: "",
+      accession_number: accessionB,
+      filing_date: "2026-05-27",
+      primary_doc: "b.xml",
+      form: "4",
+      doc: docB,
+    });
+
+    const obsA = (await new PersonObservationRepo().listByAccession(accessionA)).find(
+      (p) => p.last_name === SHARED_NAME
+    );
+    const obsB = (await new PersonObservationRepo().listByAccession(accessionB)).find(
+      (p) => p.last_name === SHARED_NAME
+    );
+    expect(obsA).toBeDefined();
+    expect(obsB).toBeDefined();
+    // The fix: source_filing_issuer_cik is null, not 0.
+    expect(obsA!.source_filing_issuer_cik).toBeNull();
+    expect(obsB!.source_filing_issuer_cik).toBeNull();
+  });
+
   it("stores null (not 0) for an empty underlyingSecurityShares on a derivative transaction", async () => {
     const accession = "0001493152-26-025476";
     const xml = readFileSync(

--- a/src/sec/forms/insider-trading/OwnershipDocument.storage.ts
+++ b/src/sec/forms/insider-trading/OwnershipDocument.storage.ts
@@ -67,7 +67,13 @@ interface OwnershipStorageContext {
   readonly accession_number: string;
   readonly extractor_id: string;
   readonly extractor_version: string;
-  readonly issuer_cik: number;
+  // Null when the XML `issuer.issuerCik` is missing or unparseable. Must NOT
+  // be coerced to 0 on the observation path: PersonResolver's `personKey`
+  // includes `source_filing_issuer_cik` in the name-fallback key, so a 0
+  // sentinel collapses reporting-owner observations with the same name
+  // across unrelated filers into one canonical person. Form_144 already
+  // guards this at `Form_144.storage.ts` with `issuer_cik || null`.
+  readonly issuer_cik: number | null;
   readonly observer: EntityObserver;
 }
 
@@ -195,7 +201,7 @@ async function processIssuer(doc: OwnershipDocument, ctx: OwnershipStorageContex
     extractor_id: ctx.extractor_id,
     extractor_version: ctx.extractor_version,
     observation_index: 0,
-    cik: ctx.issuer_cik || null,
+    cik: ctx.issuer_cik,
     name: issuerName,
     source_context: JSON.stringify({ relation: "section16:issuer" }),
   });
@@ -226,7 +232,10 @@ export async function processOwnershipForm({
 
   const activeResolverPersonVersion = personSlot?.semver ?? "1.0.0";
   const activeResolverCompanyVersion = companySlot?.semver ?? "1.0.0";
-  const extractor_version = "1.0.0";
+  // 1.0.1 (S-MAIN-01): preserve null issuer_cik on observation path so
+  // PersonResolver does not collapse same-named reporting owners across
+  // unrelated filers via the 0 sentinel. Patch bump — same dev cycle.
+  const extractor_version = "1.0.1";
 
   // Use the same canonical extractor id the dispatch task records against
   // (amendments share the base extractor), so observation rows and
@@ -236,8 +245,11 @@ export async function processOwnershipForm({
   // The XML issuerCik is authoritative. We must NOT fall back to the filing's
   // own CIK: ownership filings are ingested from a submission feed that may be
   // the reporting owner's, not the issuer's, so that fallback could stamp the
-  // owner's CIK as the issuer. 0 is the honest "unknown" sentinel.
-  const issuer_cik = parseCikSafely(doc.issuer?.issuerCik);
+  // owner's CIK as the issuer. Use `|| null` (not `parseCikSafely` alone): the
+  // raw 0 sentinel poisons PersonResolver's name-fallback key — see Form_144
+  // for the parallel guard. Section16 row sites coerce back with `?? 0` since
+  // the SQL column is non-null (TypeSecCik is `Type.Number`).
+  const issuer_cik = parseCikSafely(doc.issuer?.issuerCik) || null;
 
   const personResolver = new PersonResolver({
     canonicalPersonRepo: new CanonicalPersonRepo(),
@@ -275,11 +287,16 @@ export async function processOwnershipForm({
 
   const section16Repo = new Section16Repo();
 
+  // Section16 SQL columns require a non-null CIK (TypeSecCik is `Type.Number`).
+  // 0 is acceptable here as a "missing" sentinel for the raw section16 row;
+  // it is NOT acceptable on the observation/resolver path above.
+  const section16IssuerCik = issuer_cik ?? 0;
+
   await section16Repo.saveFiling({
     accession_number,
     form,
     document_type: str(doc.documentType) ?? form,
-    issuer_cik,
+    issuer_cik: section16IssuerCik,
     issuer_name: str(doc.issuer?.issuerName) ?? "",
     issuer_trading_symbol: str(doc.issuer?.issuerTradingSymbol),
     period_of_report: str(doc.periodOfReport),
@@ -301,12 +318,12 @@ export async function processOwnershipForm({
   let txnIndex = 0;
   for (const t of doc.nonDerivativeTable?.nonDerivativeTransaction ?? []) {
     await section16Repo.saveTransaction(
-      nonDerivativeTransactionRow(t, accession_number, issuer_cik, txnIndex++)
+      nonDerivativeTransactionRow(t, accession_number, section16IssuerCik, txnIndex++)
     );
   }
   for (const t of doc.derivativeTable?.derivativeTransaction ?? []) {
     await section16Repo.saveTransaction(
-      derivativeTransactionRow(t, accession_number, issuer_cik, txnIndex++)
+      derivativeTransactionRow(t, accession_number, section16IssuerCik, txnIndex++)
     );
   }
 
@@ -314,12 +331,12 @@ export async function processOwnershipForm({
   let holdIndex = 0;
   for (const h of doc.nonDerivativeTable?.nonDerivativeHolding ?? []) {
     await section16Repo.saveHolding(
-      nonDerivativeHoldingRow(h, accession_number, issuer_cik, holdIndex++)
+      nonDerivativeHoldingRow(h, accession_number, section16IssuerCik, holdIndex++)
     );
   }
   for (const h of doc.derivativeTable?.derivativeHolding ?? []) {
     await section16Repo.saveHolding(
-      derivativeHoldingRow(h, accession_number, issuer_cik, holdIndex++)
+      derivativeHoldingRow(h, accession_number, section16IssuerCik, holdIndex++)
     );
   }
 }

--- a/src/storage/canonical/CanonicalCompanyAliasRepo.test.ts
+++ b/src/storage/canonical/CanonicalCompanyAliasRepo.test.ts
@@ -48,6 +48,14 @@ describe("CanonicalCompanyAliasRepo", () => {
     await expect(repo.add("uuid-x", "uuid-x", null, "op")).rejects.toThrow(/self/);
   });
 
+  it("add rejects when from-id is already a target (no 2-hop chains)", async () => {
+    // Establish A → B. Now B is a target.
+    await repo.add("uuid-a", "uuid-b", null, "op");
+    // Attempting B → C must fail; otherwise resolve("uuid-a") would yield
+    // the stale "uuid-b" since resolve() is single-hop by design.
+    await expect(repo.add("uuid-b", "uuid-c", null, "op")).rejects.toThrow(/single-hop/);
+  });
+
   it("remove deletes the row; resolve falls back to identity afterwards", async () => {
     await repo.add("uuid-a", "uuid-b", null, "op");
     await repo.remove("uuid-a");

--- a/src/storage/canonical/CanonicalCompanyAliasRepo.ts
+++ b/src/storage/canonical/CanonicalCompanyAliasRepo.ts
@@ -41,6 +41,15 @@ export class CanonicalCompanyAliasRepo {
         `single-hop invariant violated: target ${target_canonical_id} is itself an alias`
       );
     }
+    // Also reject when the new FROM is already the TARGET of some other alias.
+    // Without this, `add X Y` then `add Y Z` would create a 2-hop chain that
+    // `resolve()` (single-hop) silently mis-resolves to the stale Y.
+    const fromIsTarget = (await this.repo.query({ target_canonical_id: alias_canonical_id })) ?? [];
+    if (fromIsTarget.length > 0) {
+      throw new Error(
+        `single-hop invariant violated: ${alias_canonical_id} is already a target of an existing alias`
+      );
+    }
     const row: CanonicalCompanyAlias = {
       alias_canonical_id,
       target_canonical_id,

--- a/src/storage/canonical/CanonicalPersonAliasRepo.test.ts
+++ b/src/storage/canonical/CanonicalPersonAliasRepo.test.ts
@@ -48,6 +48,14 @@ describe("CanonicalPersonAliasRepo", () => {
     await expect(repo.add("uuid-x", "uuid-x", null, "op")).rejects.toThrow(/self/);
   });
 
+  it("add rejects when from-id is already a target (no 2-hop chains)", async () => {
+    // Establish A → B. Now B is a target.
+    await repo.add("uuid-a", "uuid-b", null, "op");
+    // Attempting B → C must fail; otherwise resolve("uuid-a") would yield
+    // the stale "uuid-b" since resolve() is single-hop by design.
+    await expect(repo.add("uuid-b", "uuid-c", null, "op")).rejects.toThrow(/single-hop/);
+  });
+
   it("remove deletes the row; resolve falls back to identity afterwards", async () => {
     await repo.add("uuid-a", "uuid-b", null, "op");
     await repo.remove("uuid-a");

--- a/src/storage/canonical/CanonicalPersonAliasRepo.ts
+++ b/src/storage/canonical/CanonicalPersonAliasRepo.ts
@@ -41,6 +41,15 @@ export class CanonicalPersonAliasRepo {
         `single-hop invariant violated: target ${target_canonical_id} is itself an alias`
       );
     }
+    // Also reject when the new FROM is already the TARGET of some other alias.
+    // Without this, `add X Y` then `add Y Z` would create a 2-hop chain that
+    // `resolve()` (single-hop) silently mis-resolves to the stale Y.
+    const fromIsTarget = (await this.repo.query({ target_canonical_id: alias_canonical_id })) ?? [];
+    if (fromIsTarget.length > 0) {
+      throw new Error(
+        `single-hop invariant violated: ${alias_canonical_id} is already a target of an existing alias`
+      );
+    }
     const row: CanonicalPersonAlias = {
       alias_canonical_id,
       target_canonical_id,

--- a/src/storage/canonical/CompanyIdentityLinkRepo.ts
+++ b/src/storage/canonical/CompanyIdentityLinkRepo.ts
@@ -5,6 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
 import {
   COMPANY_IDENTITY_LINK_REPOSITORY_TOKEN,
   type CompanyIdentityLink,
@@ -73,5 +74,13 @@ export class CompanyIdentityLinkRepo {
 
   async listAll(): Promise<CompanyIdentityLink[]> {
     return (await this.repo.getAll()) ?? [];
+  }
+
+  /**
+   * Pass-through to the underlying tabular storage's COUNT path. Callers
+   * must prefer this over `(await listAll()).length` at scale.
+   */
+  async count(criteria?: SearchCriteria<CompanyIdentityLink>): Promise<number> {
+    return await this.repo.count(criteria);
   }
 }

--- a/src/storage/canonical/PersonIdentityLinkRepo.ts
+++ b/src/storage/canonical/PersonIdentityLinkRepo.ts
@@ -5,6 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
 import {
   PERSON_IDENTITY_LINK_REPOSITORY_TOKEN,
   type PersonIdentityLink,
@@ -71,5 +72,13 @@ export class PersonIdentityLinkRepo {
 
   async listAll(): Promise<PersonIdentityLink[]> {
     return (await this.repo.getAll()) ?? [];
+  }
+
+  /**
+   * Pass-through to the underlying tabular storage's COUNT path. Callers
+   * must prefer this over `(await listAll()).length` at scale.
+   */
+  async count(criteria?: SearchCriteria<PersonIdentityLink>): Promise<number> {
+    return await this.repo.count(criteria);
   }
 }

--- a/src/storage/observation/CompanyObservationRepo.ts
+++ b/src/storage/observation/CompanyObservationRepo.ts
@@ -5,6 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
 import {
   COMPANY_OBSERVATION_REPOSITORY_TOKEN,
   type CompanyObservation,
@@ -115,6 +116,15 @@ export class CompanyObservationRepo {
 
   async listAll(): Promise<CompanyObservation[]> {
     return (await this.repo.getAll()) ?? [];
+  }
+
+  /**
+   * Pass-through to the underlying tabular storage's COUNT path. Callers
+   * (e.g. `ResolverCoverage`) must prefer this over `(await listAll()).length`
+   * at Form D / Section 16 scale to avoid materializing the full table.
+   */
+  async count(criteria?: SearchCriteria<CompanyObservation>): Promise<number> {
+    return await this.repo.count(criteria);
   }
 
   private applyNullDefaults(

--- a/src/storage/observation/PersonObservationRepo.ts
+++ b/src/storage/observation/PersonObservationRepo.ts
@@ -5,6 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
+import type { SearchCriteria } from "workglow";
 import {
   PERSON_OBSERVATION_REPOSITORY_TOKEN,
   type PersonObservation,
@@ -130,6 +131,15 @@ export class PersonObservationRepo {
 
   async listAll(): Promise<PersonObservation[]> {
     return (await this.repo.getAll()) ?? [];
+  }
+
+  /**
+   * Pass-through to the underlying tabular storage's COUNT path. Callers
+   * (e.g. `ResolverCoverage`) must prefer this over `(await listAll()).length`
+   * at Form D / Section 16 scale to avoid materializing the full table.
+   */
+  async count(criteria?: SearchCriteria<PersonObservation>): Promise<number> {
+    return await this.repo.count(criteria);
   }
 
   private applyNullDefaults(


### PR DESCRIPTION
## Summary

Five correctness / security / performance fixes on `main`.

### S-MAIN-01 (CRITICAL) — OwnershipDocument issuer 0-sentinel poisons person identity
`src/sec/forms/insider-trading/OwnershipDocument.storage.ts` was passing the raw `0` sentinel from `parseCikSafely(doc.issuer?.issuerCik)` as `source_filing_issuer_cik` on every reporting-owner observation when the XML `issuer.issuerCik` was missing. `PersonResolver`'s name-fallback key includes `source_filing_issuer_cik`, so a `0` collapsed reporting-owner observations with the same name from unrelated filers into one canonical person.

- Widened `OwnershipStorageContext.issuer_cik` to `number | null`.
- Compute `const issuer_cik = parseCikSafely(doc.issuer?.issuerCik) || null;` once (mirrors the Form_144 guard).
- Kept `?? 0` coercion only at Section16 row sites where the SQL column is non-null (`TypeSecCik` is `Type.Number`).
- Bumped `extractor_version` from `1.0.0` to `1.0.1` (patch — same dev cycle, no major ceremony).

**Migration note** (operational, not a code change): this fix changes behavior going forward. Existing wrongly-merged `canonical_person` rows from earlier ingest are NOT auto-healed. Operators must re-run `sec resolve --kind person --resolver-version <current> --all` after deploy to rebuild the identity-link rows against fresh canonical persons. Plan a `version drop-previous resolver person` once the rebuild is verified to purge the poisoned canonicals.

### S-MAIN-02 (HIGH) — Alias chains via missing from-as-target check
`CanonicalPersonAliasRepo.add` / `CanonicalCompanyAliasRepo.add` rejected when the new TARGET was already an alias, but not when the new FROM (`alias_canonical_id`) was the TARGET of some other alias. `add X Y` then `add Y Z` produced a 2-hop chain; the single-hop `resolve()` then silently mis-resolved to the stale `Y`.

Added the symmetric precondition. Kept `resolve()` single-hop — the invariant stays a write-time guard.

### S-MAIN-03 (HIGH) — alias CLI takes raw strings into UUID columns
`sec canonical {person,company} alias <from> <into>` and `alias-remove <from>` previously wrote `<from>`/`<into>` straight into UUID-typed columns. The CLAUDE.md docs invite operators to pass display names.

Added `resolveCanonicalPersonRef` / `resolveCanonicalCompanyRef` helpers that:
- pass UUIDs through unchanged,
- look up bare strings case-insensitively against the canonical display name (composite `display_first display_last` or `display_last` alone for persons; `display_name` for companies),
- reject ambiguous / unknown names with a non-zero exit and a clear error.

Applied at all four call sites.

### S-MAIN-04 (HIGH) — `--resolver-version` unvalidated
`sec resolve --resolver-version` accepted arbitrary strings (`"1.0"`, `"v1.0.0"`, `"not-a-version"`), letting bad values flow into `identity-link` rows and canonical_person/canonical_company keys where they would silently miss every subsequent lookup.

Validated with `isValidSemver` from `VersionRegistry` (the same `MAJOR.MINOR.PATCH` check the version registry uses) and exit non-zero on malformed input.

### S-MAIN-05 (HIGH) — ResolverCoverage / version snapshot materialize full set
`ResolverCoverage` used `(await obsRepo.listAll()).length` and `(await linkRepo.listAll())`; `version.ts:snapshotTargetCount` did `(await filingRepo.query({form})).length` per form. At Form D + Section 16 scale these OOM.

- Added `count(criteria?)` pass-through to `PersonObservationRepo`, `CompanyObservationRepo`, `PersonIdentityLinkRepo`, `CompanyIdentityLinkRepo` (the underlying `ITabularStorage` already supports filtered COUNT).
- `ResolverCoverage`: `await obsRepo.count()` + `await linkRepo.count({ resolver_version })`.
- `snapshotTargetCount`: `await filingRepo.count({ form })` per form. Dropped the `TODO(perf)` block.

## Test plan

- [x] `bun test src/sec/forms/insider-trading/OwnershipDocument.storage.test.ts` — added regression: two filings with missing `issuer.issuerCik` and the same reporting-owner name produce observations with `source_filing_issuer_cik=null` (not `0`).
- [x] `bun test src/storage/canonical/CanonicalPersonAliasRepo.test.ts src/storage/canonical/CanonicalCompanyAliasRepo.test.ts` — added "rejects when from-id is already a target".
- [x] `bun test src/cli/groups/canonical.test.ts` — UUID round-trip, bare-name resolves, ambiguous-name and nonexistent-name error paths for both helpers.
- [x] `bun test src/cli/groups/resolve.test.ts` — `--resolver-version 1.0`, `v1.0.0`, `not-a-version` all exit non-zero.
- [x] `bun test src/cli/queries/ResolverCoverage.test.ts` — stub storage so `getAll` throws and `count` returns the expected values; proves `listAll` is not called and the link criterion is `{ resolver_version: "1.0.0" }`.
- [x] `bun test src/sec/forms` — full forms suite still passes (197 tests).
- [x] `npx tsc --noEmit` — clean.

https://claude.ai/code/session_01VF4sE9UoHhdChYmm8zYx6y


---
_Generated by [Claude Code](https://claude.ai/code/session_01VF4sE9UoHhdChYmm8zYx6y)_