### PR TITLE
fix: DRSLTR dispatch, SPAC sponsor span verification, resolver test + RFC-9112 Content-Length

### DIFF
--- a/src/resolver/CompanyResolver.test.ts
+++ b/src/resolver/CompanyResolver.test.ts
@@ -148,7 +148,7 @@ describe("CompanyResolver.resolve", () => {
   });
 
   it("serialises alias lookup inside the per-key mutex (no overlapping alias.resolve calls)", async () => {
-    // H-S2: the previous regression test stubbed `aliasRepo.resolve` to always
+    // The previous regression test stubbed `aliasRepo.resolve` to always
     // return a constant id regardless of input, so both pre-fix (lookup
     // outside the mutex) and post-fix (lookup inside the mutex) code paths
     // produced the same final answer and the test could not discriminate the

--- a/src/resolver/CompanyResolver.test.ts
+++ b/src/resolver/CompanyResolver.test.ts
@@ -145,4 +145,39 @@ describe("CompanyResolver.resolve", () => {
     const result = await resolver.resolve(obs({ cik: 1234, observation_id: 3 }));
     expect(result).toBe("alias-target");
   });
+
+  it("alias resolution is serialised with create", async () => {
+    // Two parallel resolves on the same natural key must converge on the
+    // alias-resolved id even when the alias lookup is slow. With the alias
+    // call inside the mutex, the queued caller waits for the entire
+    // find-or-create + alias step rather than racing it, so concurrent
+    // resolves cannot split between the pre-alias candidate id and the
+    // alias target.
+    //
+    // Stub `aliasRepo.resolve` to always return "B-id" after a 10ms sleep
+    // — the sleep widens the window where, without the fix, the second
+    // caller could overtake the first's alias lookup.
+
+    // Spy on create to confirm exactly one canonical row was minted —
+    // proving the mutex itself still serialised the find-or-create pair.
+    const originalCreate = setup.canonRepo.create.bind(setup.canonRepo);
+    let createCount = 0;
+    setup.canonRepo.create = (async (row: CanonicalCompany) => {
+      createCount += 1;
+      return originalCreate(row);
+    }) as typeof setup.canonRepo.create;
+
+    setup.aliasRepo.resolve = async (_id: string) => {
+      await new Promise((r) => setTimeout(r, 10));
+      return "B-id";
+    };
+
+    const [a, b] = await Promise.all([
+      resolver.resolve(obs({ cik: 4242 })),
+      resolver.resolve(obs({ cik: 4242, observation_id: 2 })),
+    ]);
+    expect(a).toBe("B-id");
+    expect(b).toBe("B-id");
+    expect(createCount).toBe(1);
+  });
 });

--- a/src/resolver/CompanyResolver.test.ts
+++ b/src/resolver/CompanyResolver.test.ts
@@ -40,6 +40,7 @@ function makeRepos() {
     canonRepo: new CanonicalCompanyRepo({ canonicalCompanyRepository: canonStorage }),
     aliasRepo: new CanonicalCompanyAliasRepo({ canonicalCompanyAliasRepository: aliasStorage }),
     canonStorage,
+    aliasStorage,
   };
 }
 
@@ -146,20 +147,19 @@ describe("CompanyResolver.resolve", () => {
     expect(result).toBe("alias-target");
   });
 
-  it("alias resolution is serialised with create", async () => {
-    // Two parallel resolves on the same natural key must converge on the
-    // alias-resolved id even when the alias lookup is slow. With the alias
-    // call inside the mutex, the queued caller waits for the entire
-    // find-or-create + alias step rather than racing it, so concurrent
-    // resolves cannot split between the pre-alias candidate id and the
-    // alias target.
+  it("serialises alias lookup inside the per-key mutex (no overlapping alias.resolve calls)", async () => {
+    // H-S2: the previous regression test stubbed `aliasRepo.resolve` to always
+    // return a constant id regardless of input, so both pre-fix (lookup
+    // outside the mutex) and post-fix (lookup inside the mutex) code paths
+    // produced the same final answer and the test could not discriminate the
+    // bug. The actual difference between the two code paths is whether the
+    // alias lookups overlap in time — pre-fix runs them in parallel after
+    // the mutex releases; post-fix runs them sequentially inside the lock.
     //
-    // Stub `aliasRepo.resolve` to always return "B-id" after a 10ms sleep
-    // — the sleep widens the window where, without the fix, the second
-    // caller could overtake the first's alias lookup.
+    // Track concurrent in-flight alias.resolve calls. Pre-fix code drives the
+    // counter to 2 simultaneously when two resolves run in parallel; post-fix
+    // never sees more than one in flight.
 
-    // Spy on create to confirm exactly one canonical row was minted —
-    // proving the mutex itself still serialised the find-or-create pair.
     const originalCreate = setup.canonRepo.create.bind(setup.canonRepo);
     let createCount = 0;
     setup.canonRepo.create = (async (row: CanonicalCompany) => {
@@ -167,17 +167,30 @@ describe("CompanyResolver.resolve", () => {
       return originalCreate(row);
     }) as typeof setup.canonRepo.create;
 
-    setup.aliasRepo.resolve = async (_id: string) => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let aliasCallCount = 0;
+    setup.aliasRepo.resolve = async (id: string) => {
+      inFlight += 1;
+      if (inFlight > maxInFlight) maxInFlight = inFlight;
+      aliasCallCount += 1;
+      // Sleep long enough that a parallel caller is guaranteed to start
+      // before this one resolves.
       await new Promise((r) => setTimeout(r, 10));
-      return "B-id";
+      inFlight -= 1;
+      return id; // alias not installed — we only care about the in-flight window
     };
 
-    const [a, b] = await Promise.all([
+    await Promise.all([
       resolver.resolve(obs({ cik: 4242 })),
       resolver.resolve(obs({ cik: 4242, observation_id: 2 })),
     ]);
-    expect(a).toBe("B-id");
-    expect(b).toBe("B-id");
+
+    // Post-fix: alias lookup is inside the mutex → at most one in flight.
+    // Pre-fix: alias lookup is after mutex.release → both run in parallel.
+    expect(maxInFlight).toBe(1);
+    expect(aliasCallCount).toBe(2);
+    // Exactly one canonical row was minted — find-or-create remains serialised.
     expect(createCount).toBe(1);
   });
 });

--- a/src/resolver/CompanyResolver.ts
+++ b/src/resolver/CompanyResolver.ts
@@ -41,7 +41,12 @@ function companyKey(
  * Delegates alias indirection to CanonicalCompanyAliasRepo.
  *
  * Concurrency: see PersonResolver — same per-key AsyncMutex with refcount
- * pattern. Multi-process callers still need a backend UNIQUE constraint.
+ * pattern, and the alias-resolution lookup also runs inside the mutex so
+ * the queued caller observes both the canonical row and its alias
+ * resolution, so concurrent resolves converge to the same final
+ * canonical_company_id even when one races an alias rewrite that happens
+ * between the create and the alias lookup. Multi-process callers still
+ * need a backend UNIQUE constraint.
  */
 export class CompanyResolver {
   private static readonly _keyMutexes = new Map<
@@ -65,9 +70,9 @@ export class CompanyResolver {
     }
     entry.refs += 1;
 
-    let candidateId: string;
+    let resolvedId: string;
     try {
-      candidateId = await entry.mutex.lock(async () => {
+      resolvedId = await entry.mutex.lock(async () => {
         // Re-query inside the critical section — a queued caller might
         // have just created the row we're about to mint.
         let candidate: CanonicalCompany | undefined;
@@ -87,21 +92,29 @@ export class CompanyResolver {
             obs.normalized_name
           );
         }
+        let candidateId: string;
         if (candidate) {
-          return candidate.canonical_company_id;
+          candidateId = candidate.canonical_company_id;
+        } else {
+          const freshId = randomUUID();
+          const fresh: CanonicalCompany = {
+            canonical_company_id: freshId,
+            resolver_version: this.opts.activeResolverVersion,
+            display_name: obs.name,
+            cik: obs.cik ?? null,
+            crd_number: obs.crd_number ?? null,
+            normalized_name: obs.normalized_name ?? null,
+            created_at: new Date().toISOString(),
+          };
+          await this.opts.canonicalCompanyRepo.create(fresh);
+          candidateId = freshId;
         }
-        const freshId = randomUUID();
-        const fresh: CanonicalCompany = {
-          canonical_company_id: freshId,
-          resolver_version: this.opts.activeResolverVersion,
-          display_name: obs.name,
-          cik: obs.cik ?? null,
-          crd_number: obs.crd_number ?? null,
-          normalized_name: obs.normalized_name ?? null,
-          created_at: new Date().toISOString(),
-        };
-        await this.opts.canonicalCompanyRepo.create(fresh);
-        return freshId;
+        // Resolve the alias INSIDE the mutex so a concurrent caller that
+        // queues behind us cannot observe the freshly-minted candidate
+        // before the alias rewrite is applied. Without this, two parallel
+        // resolves could split: one returns the alias target, the other
+        // returns the pre-alias id.
+        return await this.opts.canonicalCompanyAliasRepo.resolve(candidateId);
       });
     } finally {
       entry.refs -= 1;
@@ -113,6 +126,6 @@ export class CompanyResolver {
       }
     }
 
-    return await this.opts.canonicalCompanyAliasRepo.resolve(candidateId);
+    return resolvedId;
   }
 }

--- a/src/resolver/PersonResolver.test.ts
+++ b/src/resolver/PersonResolver.test.ts
@@ -147,7 +147,7 @@ describe("PersonResolver.resolve", () => {
   });
 
   it("serialises alias lookup inside the per-key mutex (no overlapping alias.resolve calls)", async () => {
-    // H-S2: the previous regression test stubbed `aliasRepo.resolve` to always
+    // The previous regression test stubbed `aliasRepo.resolve` to always
     // return a constant id regardless of input, so both pre-fix (lookup
     // outside the mutex) and post-fix (lookup inside the mutex) code paths
     // produced the same final answer and the test could not discriminate the

--- a/src/resolver/PersonResolver.test.ts
+++ b/src/resolver/PersonResolver.test.ts
@@ -146,20 +146,19 @@ describe("PersonResolver.resolve", () => {
     expect(result).toBe("alias-target");
   });
 
-  it("alias resolution is serialised with create", async () => {
-    // Two parallel resolves on the same natural key must converge on the
-    // alias-resolved id even when the alias lookup is slow. With the alias
-    // call inside the mutex, the queued caller waits for the entire
-    // find-or-create + alias step rather than racing it, so concurrent
-    // resolves cannot split between the pre-alias candidate id and the
-    // alias target.
+  it("serialises alias lookup inside the per-key mutex (no overlapping alias.resolve calls)", async () => {
+    // H-S2: the previous regression test stubbed `aliasRepo.resolve` to always
+    // return a constant id regardless of input, so both pre-fix (lookup
+    // outside the mutex) and post-fix (lookup inside the mutex) code paths
+    // produced the same final answer and the test could not discriminate the
+    // bug. The actual difference between the two code paths is whether the
+    // alias lookups overlap in time — pre-fix runs them in parallel after
+    // the mutex releases; post-fix runs them sequentially inside the lock.
     //
-    // Stub `aliasRepo.resolve` to always return "B-id" after a 10ms sleep
-    // — the sleep widens the window where, without the fix, the second
-    // caller could overtake the first's alias lookup.
+    // Track concurrent in-flight alias.resolve calls. Pre-fix code drives the
+    // counter to 2 simultaneously when two resolves run in parallel; post-fix
+    // never sees more than one in flight.
 
-    // Spy on create to confirm exactly one canonical row was minted —
-    // proving the mutex itself still serialised the find-or-create pair.
     const originalCreate = setup.canonRepo.create.bind(setup.canonRepo);
     let createCount = 0;
     setup.canonRepo.create = (async (row: CanonicalPerson) => {
@@ -167,17 +166,30 @@ describe("PersonResolver.resolve", () => {
       return originalCreate(row);
     }) as typeof setup.canonRepo.create;
 
-    setup.aliasRepo.resolve = async (_id: string) => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let aliasCallCount = 0;
+    setup.aliasRepo.resolve = async (id: string) => {
+      inFlight += 1;
+      if (inFlight > maxInFlight) maxInFlight = inFlight;
+      aliasCallCount += 1;
+      // Sleep long enough that a parallel caller is guaranteed to start
+      // before this one resolves.
       await new Promise((r) => setTimeout(r, 10));
-      return "B-id";
+      inFlight -= 1;
+      return id; // alias not installed — we only care about the in-flight window
     };
 
-    const [a, b] = await Promise.all([
+    await Promise.all([
       resolver.resolve(obs({ cik: 4242 })),
       resolver.resolve(obs({ cik: 4242, observation_id: 2 })),
     ]);
-    expect(a).toBe("B-id");
-    expect(b).toBe("B-id");
+
+    // Post-fix: alias lookup is inside the mutex → at most one in flight.
+    // Pre-fix: alias lookup is after mutex.release → both run in parallel.
+    expect(maxInFlight).toBe(1);
+    expect(aliasCallCount).toBe(2);
+    // Exactly one canonical row was minted — find-or-create remains serialised.
     expect(createCount).toBe(1);
   });
 });

--- a/src/resolver/PersonResolver.test.ts
+++ b/src/resolver/PersonResolver.test.ts
@@ -145,4 +145,39 @@ describe("PersonResolver.resolve", () => {
     const result = await resolver.resolve(obs({ cik: 1234, observation_id: 3 }));
     expect(result).toBe("alias-target");
   });
+
+  it("alias resolution is serialised with create", async () => {
+    // Two parallel resolves on the same natural key must converge on the
+    // alias-resolved id even when the alias lookup is slow. With the alias
+    // call inside the mutex, the queued caller waits for the entire
+    // find-or-create + alias step rather than racing it, so concurrent
+    // resolves cannot split between the pre-alias candidate id and the
+    // alias target.
+    //
+    // Stub `aliasRepo.resolve` to always return "B-id" after a 10ms sleep
+    // — the sleep widens the window where, without the fix, the second
+    // caller could overtake the first's alias lookup.
+
+    // Spy on create to confirm exactly one canonical row was minted —
+    // proving the mutex itself still serialised the find-or-create pair.
+    const originalCreate = setup.canonRepo.create.bind(setup.canonRepo);
+    let createCount = 0;
+    setup.canonRepo.create = (async (row: CanonicalPerson) => {
+      createCount += 1;
+      return originalCreate(row);
+    }) as typeof setup.canonRepo.create;
+
+    setup.aliasRepo.resolve = async (_id: string) => {
+      await new Promise((r) => setTimeout(r, 10));
+      return "B-id";
+    };
+
+    const [a, b] = await Promise.all([
+      resolver.resolve(obs({ cik: 4242 })),
+      resolver.resolve(obs({ cik: 4242, observation_id: 2 })),
+    ]);
+    expect(a).toBe("B-id");
+    expect(b).toBe("B-id");
+    expect(createCount).toBe(1);
+  });
 });

--- a/src/resolver/PersonResolver.ts
+++ b/src/resolver/PersonResolver.ts
@@ -50,6 +50,12 @@ function personKey(obs: PersonObservation, resolverVersion: string): string {
  * removed from the map so the map stays bounded for long-running
  * processes that resolve millions of distinct keys.
  *
+ * The alias-resolution lookup also runs inside the mutex so the queued
+ * caller observes both the canonical row and its alias resolution, so
+ * concurrent resolves converge to the same final canonical_person_id
+ * even when one races an alias rewrite that happens between the create
+ * and the alias lookup.
+ *
  * Multi-process callers (workers, separate `sec` invocations) still need
  * a backend-level UNIQUE constraint to be race-free — single-process
  * mutexes are not visible to other processes.
@@ -71,9 +77,9 @@ export class PersonResolver {
     }
     entry.refs += 1;
 
-    let candidateId: string;
+    let resolvedId: string;
     try {
-      candidateId = await entry.mutex.lock(async () => {
+      resolvedId = await entry.mutex.lock(async () => {
         // Inside the critical section we re-query so any queued caller
         // that ran before us picks up the canonical row they just
         // inserted.
@@ -93,28 +99,36 @@ export class PersonResolver {
             obs.source_filing_issuer_cik
           );
         }
+        let candidateId: string;
         if (candidate) {
-          return candidate.canonical_person_id;
+          candidateId = candidate.canonical_person_id;
+        } else {
+          const freshId = randomUUID();
+          const fresh: CanonicalPerson = {
+            canonical_person_id: freshId,
+            resolver_version: this.opts.activeResolverVersion,
+            display_first: obs.first_name,
+            display_middle: obs.middle_name,
+            display_last: obs.last_name,
+            display_suffix: obs.suffix,
+            cik: obs.cik,
+            normalized_first: obs.normalized_first,
+            normalized_middle: obs.normalized_middle,
+            normalized_last: obs.normalized_last,
+            normalized_suffix: obs.normalized_suffix,
+            source_filing_issuer_cik:
+              obs.cik === null ? obs.source_filing_issuer_cik : null,
+            created_at: new Date().toISOString(),
+          };
+          await this.opts.canonicalPersonRepo.create(fresh);
+          candidateId = freshId;
         }
-        const freshId = randomUUID();
-        const fresh: CanonicalPerson = {
-          canonical_person_id: freshId,
-          resolver_version: this.opts.activeResolverVersion,
-          display_first: obs.first_name,
-          display_middle: obs.middle_name,
-          display_last: obs.last_name,
-          display_suffix: obs.suffix,
-          cik: obs.cik,
-          normalized_first: obs.normalized_first,
-          normalized_middle: obs.normalized_middle,
-          normalized_last: obs.normalized_last,
-          normalized_suffix: obs.normalized_suffix,
-          source_filing_issuer_cik:
-            obs.cik === null ? obs.source_filing_issuer_cik : null,
-          created_at: new Date().toISOString(),
-        };
-        await this.opts.canonicalPersonRepo.create(fresh);
-        return freshId;
+        // Resolve the alias INSIDE the mutex so a concurrent caller that
+        // queues behind us cannot observe the freshly-minted candidate
+        // before the alias rewrite is applied. Without this, two parallel
+        // resolves could split: one returns the alias target, the other
+        // returns the pre-alias id.
+        return await this.opts.canonicalPersonAliasRepo.resolve(candidateId);
       });
     } finally {
       entry.refs -= 1;
@@ -128,6 +142,6 @@ export class PersonResolver {
       }
     }
 
-    return await this.opts.canonicalPersonAliasRepo.resolve(candidateId);
+    return resolvedId;
   }
 }

--- a/src/sec/forms/registration-statements/Form_DRS.ts
+++ b/src/sec/forms/registration-statements/Form_DRS.ts
@@ -11,7 +11,7 @@ export class Form_DRS extends Form {
   static readonly name = "Draft Registration Statement (DRS)";
   static readonly description =
     "Confidential draft registration statement (JOBS Act); a draft S-1 with identical structure.";
-  static readonly forms = ["DRS", "DRS/A", "DRSLTR"] as const;
+  static readonly forms = ["DRS", "DRS/A"] as const;
 
   static override async parse(form: string, txt: string): Promise<FormS1Parsed> {
     return parseRegistrationSubmission(form, txt);

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -46,6 +46,7 @@ import type { FormS1Parsed } from "./Form_S_1";
 import { parseEdgarHtml } from "../../html/parseEdgarHtml";
 import { DocumentTreeSegmenter } from "./s1/DocumentTreeSegmenter";
 import { S1_SECTIONS, type S1SectionName } from "./s1/DocumentSegmenter";
+import { spanAppearsIn } from "./s1/verifySourceSpan";
 import {
   extractBeneficialOwnership,
   extractManagement,
@@ -59,6 +60,10 @@ import { getS1Model } from "./s1/s1Model";
 import { splitPersonName } from "./s1/splitName";
 
 const EXTRACTOR_ID = "S-1";
+// v1.1.0: SPAC sponsor extraction now requires the LLM-returned source_span to
+// appear verbatim (after light normalization) in the section text before a
+// canonical sponsor row is persisted.
+const DEFAULT_EXTRACTOR_VERSION = "1.1.0";
 const RAW_CONFIDENCE_FLOOR = Number(process.env.SEC_S1_CONFIDENCE_FLOOR ?? "0");
 // A non-numeric SEC_S1_CONFIDENCE_FLOOR would be NaN, and `confidence >= NaN` is
 // always false — silently dropping every row. Fall back to 0 (no floor).
@@ -109,7 +114,7 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
       getActiveSlot(versionRegistry, "resolver", "sponsor-family"),
       getActiveSlot(versionRegistry, "resolver", "underwriter-family"),
     ]);
-  const extractor_version = extractorSlot?.semver ?? "1.0.0";
+  const extractor_version = extractorSlot?.semver ?? DEFAULT_EXTRACTOR_VERSION;
   const activeResolverPersonVersion = personSlot?.semver ?? "1.0.0";
   const activeResolverCompanyVersion = companySlot?.semver ?? "1.0.0";
   const activeSponsorFamilyVersion = sponsorFamilySlot?.semver ?? "1.0.0";
@@ -247,6 +252,15 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
     // rows had blank names) dead-letters MODEL_INVALID_OUTPUT. Omit for sections
     // whose persist always writes every confident row, so they always markResolved.
     invalidWriteDetail?: string;
+    // Optional row-level verification applied AFTER the confidence floor. When
+    // every confident row is dropped, the section dead-letters as
+    // UNVERIFIED_SOURCE_SPAN (using `unverifiedAllDetail`); when some are
+    // dropped, the surviving rows persist normally AND a "<sectionName>-partial"
+    // dead-letter is recorded for triage (using `unverifiedPartialDetail`).
+    // Detail strings may use `$N` (dropped count) and `$T` (confident total).
+    verifyRow?: (text: string, row: TRow) => boolean;
+    unverifiedAllDetail?: string;
+    unverifiedPartialDetail?: string;
     extract: (text: string) => Promise<TRow[]>;
     persist: (rows: TRow[]) => Promise<number>;
   }): Promise<void> {
@@ -270,12 +284,34 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
 
     try {
       const raw = await sargs.extract(sargs.text);
-      const rows = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
+      const confident = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
+      const text = sargs.text;
+      const verifyRow = sargs.verifyRow;
+      let rows: TRow[];
+      let droppedUnverified = 0;
+      if (verifyRow !== undefined && confident.length > 0) {
+        rows = confident.filter((r) => verifyRow(text, r));
+        droppedUnverified = confident.length - rows.length;
+      } else {
+        rows = confident;
+      }
       if (rows.length === 0) {
-        await record(
-          raw.length === 0 ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
-          raw.length === 0 ? sargs.emptyDetail : sargs.lowConfidenceDetail
-        );
+        const allDroppedUnverified =
+          droppedUnverified > 0 && droppedUnverified === confident.length;
+        const reason = allDroppedUnverified
+          ? "UNVERIFIED_SOURCE_SPAN"
+          : raw.length === 0
+            ? "MODEL_EMPTY"
+            : "LOW_CONFIDENCE_ALL";
+        const detail = allDroppedUnverified
+          ? (sargs.unverifiedAllDetail ?? sargs.lowConfidenceDetail).replace(
+              /\$T/g,
+              String(confident.length)
+            )
+          : raw.length === 0
+            ? sargs.emptyDetail
+            : sargs.lowConfidenceDetail;
+        await record(reason, detail);
         return;
       }
       const wrote = await sargs.persist(rows);
@@ -283,6 +319,19 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
         await record("MODEL_INVALID_OUTPUT", sargs.invalidWriteDetail);
       } else {
         await deadLetters.markResolved(EXTRACTOR_ID, accession_number, sargs.sectionName);
+      }
+      if (droppedUnverified > 0 && sargs.unverifiedPartialDetail !== undefined) {
+        await deadLetters.record({
+          extractor_id: EXTRACTOR_ID,
+          accession_number,
+          section_name: `${sargs.sectionName}-partial`,
+          reason_code: "UNVERIFIED_SOURCE_SPAN",
+          detail: sargs.unverifiedPartialDetail
+            .replace(/\$N/g, String(droppedUnverified))
+            .replace(/\$T/g, String(confident.length)),
+          failed_extractor_version: extractor_version,
+          source_run_id: null,
+        });
       }
     } catch (e) {
       await record("MODEL_INVALID_OUTPUT", (e instanceof Error ? e.message : String(e)).slice(0, 1024));
@@ -635,6 +684,17 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
     emptyDetail: "no sponsors returned",
     lowConfidenceDetail: "all rows below confidence floor",
     invalidWriteDetail: "no sponsor rows had usable legal and common names",
+    // v1.1.0: verify the LLM-returned source_span actually appears in the
+    // section text we sent. The sponsor-section input may be the concatenation
+    // of management/ownership/related-party text (when "The Sponsor" heading
+    // is absent), so an LLM can hallucinate company names from director bios;
+    // this gate stops unverified rows from being written as fact-claims keyed
+    // to the issuer CIK.
+    verifyRow: (text, r) => spanAppearsIn(text, r.source_span),
+    unverifiedAllDetail:
+      "all $T confident sponsor rows had source_span not present in section text",
+    unverifiedPartialDetail:
+      "$N of $T confident sponsor rows had source_span not present in section text",
     extract: (text) => extractSpacSponsors(text, model),
     persist: async (rows) => {
       let wrote = 0;

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -258,7 +258,10 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
     // dropped, the surviving rows persist normally AND a "<sectionName>-partial"
     // dead-letter is recorded for triage (using `unverifiedPartialDetail`).
     // Detail strings may use `$N` (dropped count) and `$T` (confident total).
-    verifyRow?: (text: string, row: TRow) => boolean;
+    // `NoInfer<TRow>` keeps TRow inferred solely from `extract` — without it,
+    // contextual typing of the verifyRow callback's parameter would pin TRow
+    // to the constraint and break the persist callback's row typing.
+    verifyRow?: (text: string, row: NoInfer<TRow>) => boolean;
     unverifiedAllDetail?: string;
     unverifiedPartialDetail?: string;
     extract: (text: string) => Promise<TRow[]>;
@@ -676,7 +679,11 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
   // back to the concatenated target sections (management / ownership /
   // related-party) when that heading is absent. The text is blank only when no
   // target heading matched at all, in which case we dead-letter SECTION_NOT_FOUND.
-  await runSection({
+  // Pin TRow explicitly: the verifyRow callback's `r.source_span` access would
+  // otherwise contextually anchor TRow to the bare `{ confidence: number }`
+  // constraint and break inference for the persist callback below.
+  type SpacSponsorRow = Awaited<ReturnType<typeof extractSpacSponsors>>[number];
+  await runSection<SpacSponsorRow>({
     sectionName: "spac-sponsors",
     skip: !isSpac,
     text: byName.get(S1_SECTIONS.THE_SPONSOR) ?? [...byName.values()].join("\n\n"),

--- a/src/sec/forms/registration-statements/s1/spacSponsor.e2e.test.ts
+++ b/src/sec/forms/registration-statements/s1/spacSponsor.e2e.test.ts
@@ -13,13 +13,20 @@ import { S1ClassificationRepo } from "../../../../storage/classification/S1Class
 import { SpacSponsorLinkRepo } from "../../../../storage/canonical/SpacSponsorLinkRepo";
 import { CanonicalSponsorFamilyRepo } from "../../../../storage/canonical/CanonicalSponsorFamilyRepo";
 import { SponsorFamilyMembershipRepo } from "../../../../storage/canonical/SponsorFamilyMembershipRepo";
+import { ExtractionDeadLetterRepo } from "../../../../storage/dead-letter/ExtractionDeadLetterRepo";
 
 // Body with the three target headings so the section extractors run in a fixed
 // order (management, ownership, related); sponsor extraction runs last when SPAC.
+//
+// The related-party paragraph includes the sponsor legal names that the tests'
+// fake provider returns, so the H-S1 source_span verification (post-1.1.0)
+// accepts them. The blank "x" placeholders are kept in the other sections so
+// management / ownership extractors still run with empty input.
 const BODY = [
   "<h1>MANAGEMENT</h1><p>x</p>",
   "<h1>PRINCIPAL AND SELLING STOCKHOLDERS</h1><p>x</p>",
-  "<h1>CERTAIN RELATIONSHIPS AND RELATED TRANSACTIONS</h1><p>The Sponsor backs this SPAC.</p>",
+  "<h1>CERTAIN RELATIONSHIPS AND RELATED TRANSACTIONS</h1>",
+  "<p>The Sponsor backs this SPAC. Acme Sponsor 2, LLC and Acme Sponsor, LLC are the sponsors.</p>",
   "<h1>LEGAL MATTERS</h1><p>x</p>",
 ].join("");
 
@@ -141,6 +148,84 @@ describe("SPAC sponsor end-to-end", () => {
     expect(cls?.is_spac).toBe(false);
     const families = await new CanonicalSponsorFamilyRepo().listForResolverVersion("1.0.0");
     expect(families.length).toBe(0);
+  });
+
+  it("H-S1: drops sponsor rows whose source_span is not present in section text", async () => {
+    ({ unregister } = registerFakeStructuredProvider([
+      ...EMPTY_SECTIONS,
+      {
+        sponsors: [
+          {
+            // Both rows have plausible names but neither source_span appears
+            // anywhere in the BODY sections — this is the LLM-hallucination case.
+            legal_name: "Phantom Sponsor, LLC",
+            common_name: "Phantom Sponsor",
+            confidence: 0.95,
+            source_span: "This phrase is not anywhere in the prospectus body.",
+          },
+          {
+            legal_name: "Ghost Capital, LLC",
+            common_name: "Ghost Capital",
+            confidence: 0.95,
+            source_span: "Another fabricated quotation that does not occur.",
+          },
+        ],
+      },
+    ]));
+
+    await processFormS1(runArgs(555, "0000000000-26-000601", 6770));
+
+    // No families and no sponsor links should have been written.
+    const families = await new CanonicalSponsorFamilyRepo().listForResolverVersion("1.0.0");
+    expect(families.length).toBe(0);
+
+    // A dead-letter under UNVERIFIED_SOURCE_SPAN should be recorded.
+    const dl = await new ExtractionDeadLetterRepo().listPending("S-1");
+    const sponsorDl = dl.find(
+      (d) => d.section_name === "spac-sponsors" && d.accession_number === "0000000000-26-000601"
+    );
+    expect(sponsorDl?.reason_code).toBe("UNVERIFIED_SOURCE_SPAN");
+  });
+
+  it("H-S1: writes verified sponsor rows and dead-letters a partial for unverified ones", async () => {
+    ({ unregister } = registerFakeStructuredProvider([
+      ...EMPTY_SECTIONS,
+      {
+        sponsors: [
+          {
+            // Verified: this exact phrase appears in the related-party section.
+            legal_name: "Acme Sponsor, LLC",
+            common_name: "Acme Sponsor",
+            confidence: 0.95,
+            source_span: "The Sponsor backs this SPAC.",
+          },
+          {
+            // Hallucinated: this phrase does not appear in any section text.
+            legal_name: "Phantom Sponsor, LLC",
+            common_name: "Phantom Sponsor",
+            confidence: 0.95,
+            source_span: "Phrase definitely not present in the body.",
+          },
+        ],
+      },
+    ]));
+
+    await processFormS1(runArgs(666, "0000000000-26-000701", 6770));
+
+    // The verified sponsor still resolved to a family and a link.
+    const families = await new CanonicalSponsorFamilyRepo().listForResolverVersion("1.0.0");
+    expect(families.length).toBe(1);
+    const famId = families[0].canonical_sponsor_family_id;
+    expect(await new SpacSponsorLinkRepo().listIssuerCiksForFamily(famId)).toEqual([666]);
+
+    // A spac-sponsors-partial dead-letter records the dropped row for triage.
+    const dl = await new ExtractionDeadLetterRepo().listPending("S-1");
+    const partial = dl.find(
+      (d) =>
+        d.section_name === "spac-sponsors-partial" &&
+        d.accession_number === "0000000000-26-000701"
+    );
+    expect(partial?.reason_code).toBe("UNVERIFIED_SOURCE_SPAN");
   });
 
   it("skips a blank-named sponsor row without dropping the valid ones", async () => {

--- a/src/sec/forms/registration-statements/s1/spacSponsor.e2e.test.ts
+++ b/src/sec/forms/registration-statements/s1/spacSponsor.e2e.test.ts
@@ -19,7 +19,7 @@ import { ExtractionDeadLetterRepo } from "../../../../storage/dead-letter/Extrac
 // order (management, ownership, related); sponsor extraction runs last when SPAC.
 //
 // The related-party paragraph includes the sponsor legal names that the tests'
-// fake provider returns, so the H-S1 source_span verification (post-1.1.0)
+// fake provider returns, so the source_span verification (post-1.1.0)
 // accepts them. The blank "x" placeholders are kept in the other sections so
 // management / ownership extractors still run with empty input.
 const BODY = [
@@ -150,7 +150,7 @@ describe("SPAC sponsor end-to-end", () => {
     expect(families.length).toBe(0);
   });
 
-  it("H-S1: drops sponsor rows whose source_span is not present in section text", async () => {
+  it("drops sponsor rows whose source_span is not present in section text", async () => {
     ({ unregister } = registerFakeStructuredProvider([
       ...EMPTY_SECTIONS,
       {
@@ -187,7 +187,7 @@ describe("SPAC sponsor end-to-end", () => {
     expect(sponsorDl?.reason_code).toBe("UNVERIFIED_SOURCE_SPAN");
   });
 
-  it("H-S1: writes verified sponsor rows and dead-letters a partial for unverified ones", async () => {
+  it("writes verified sponsor rows and dead-letters a partial for unverified ones", async () => {
     ({ unregister } = registerFakeStructuredProvider([
       ...EMPTY_SECTIONS,
       {

--- a/src/sec/forms/registration-statements/s1/verifySourceSpan.test.ts
+++ b/src/sec/forms/registration-statements/s1/verifySourceSpan.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "bun:test";
+import { normalizeForSpanMatch, spanAppearsIn } from "./verifySourceSpan";
+
+describe("normalizeForSpanMatch", () => {
+  it("returns empty string for null / undefined", () => {
+    expect(normalizeForSpanMatch(null)).toBe("");
+    expect(normalizeForSpanMatch(undefined)).toBe("");
+  });
+
+  it("normalizes curly double-quotes to straight quotes", () => {
+    expect(normalizeForSpanMatch("“Acme Sponsor LLC”")).toBe('"acme sponsor llc"');
+  });
+
+  it("normalizes curly single-quotes to straight apostrophes", () => {
+    expect(normalizeForSpanMatch("‘Smith’s’")).toBe("'smith's'");
+  });
+
+  it("collapses repeated whitespace", () => {
+    expect(normalizeForSpanMatch("Acme   Sponsor\n\nLLC")).toBe("acme sponsor llc");
+  });
+
+  it("lowercases", () => {
+    expect(normalizeForSpanMatch("Acme Sponsor")).toBe("acme sponsor");
+  });
+});
+
+describe("spanAppearsIn", () => {
+  const haystack =
+    "Our sponsor, Acme Sponsor LLC, is a Delaware limited liability company. " +
+    "It was formed by John Smith and  Jane Doe in 2024.";
+
+  it("returns false for empty / null / very short spans", () => {
+    expect(spanAppearsIn(haystack, null)).toBe(false);
+    expect(spanAppearsIn(haystack, undefined)).toBe(false);
+    expect(spanAppearsIn(haystack, "")).toBe(false);
+    expect(spanAppearsIn(haystack, "a")).toBe(false);
+    expect(spanAppearsIn(haystack, "ab")).toBe(false);
+  });
+
+  it("returns true for exact substring match", () => {
+    expect(spanAppearsIn(haystack, "Acme Sponsor LLC")).toBe(true);
+  });
+
+  it("matches across collapsed whitespace differences", () => {
+    expect(spanAppearsIn(haystack, "Jane Doe")).toBe(true);
+    expect(spanAppearsIn(haystack, "John   Smith")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(spanAppearsIn(haystack, "acme SPONSOR llc")).toBe(true);
+  });
+
+  it("returns false when span not present", () => {
+    expect(spanAppearsIn(haystack, "Hallucinated Holdings Inc.")).toBe(false);
+  });
+
+  it("returns true when curly quotes in span match straight quotes in haystack", () => {
+    const haystackQ = 'Our sponsor, "Acme Sponsor LLC", was formed in 2024.';
+    expect(spanAppearsIn(haystackQ, "“Acme Sponsor LLC”")).toBe(true);
+  });
+
+  it("returns true when straight quotes in span match curly quotes in haystack", () => {
+    const haystackQ = "Our sponsor, “Acme Sponsor LLC”, was formed in 2024.";
+    expect(spanAppearsIn(haystackQ, '"Acme Sponsor LLC"')).toBe(true);
+  });
+});

--- a/src/sec/forms/registration-statements/s1/verifySourceSpan.ts
+++ b/src/sec/forms/registration-statements/s1/verifySourceSpan.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function normalizeForSpanMatch(s: string | null | undefined): string {
+  if (s == null) return "";
+  return s
+    .normalize("NFKC")
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+export function spanAppearsIn(haystack: string, span: string | null | undefined): boolean {
+  const n = normalizeForSpanMatch(span);
+  if (n.length < 3) return false;
+  return normalizeForSpanMatch(haystack).includes(n);
+}

--- a/src/storage/versioning/extractorIds.test.ts
+++ b/src/storage/versioning/extractorIds.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect, it } from "bun:test";
 import { ALL_FORMS_MAP } from "../../sec/forms/all-forms";
+import { Form_DRS } from "../../sec/forms/registration-statements/Form_DRS";
 import { EXTRACTOR_IDS, FORM_TO_EXTRACTOR_ID, formToExtractorId } from "./extractorIds";
 
 describe("extractorIds", () => {
@@ -125,5 +126,14 @@ describe("extractorIds — F-1 (foreign issuer) dispatch mapping", () => {
     expect(formToExtractorId("F-1")).toBe("S-1");
     expect(formToExtractorId("F-1/A")).toBe("S-1");
     expect(formToExtractorId("F-1MEF")).toBe("S-1");
+  });
+});
+
+describe("Form_DRS — DRSLTR not advertised (H-S0)", () => {
+  it("Form_DRS.forms does not include DRSLTR (correspondence letter, not a prospectus)", () => {
+    expect(Form_DRS.forms).not.toContain("DRSLTR");
+  });
+  it("ALL_FORMS_MAP does not include DRSLTR", () => {
+    expect(ALL_FORMS_MAP.has("DRSLTR")).toBe(false);
   });
 });

--- a/src/storage/versioning/extractorIds.test.ts
+++ b/src/storage/versioning/extractorIds.test.ts
@@ -129,7 +129,7 @@ describe("extractorIds — F-1 (foreign issuer) dispatch mapping", () => {
   });
 });
 
-describe("Form_DRS — DRSLTR not advertised (H-S0)", () => {
+describe("Form_DRS — DRSLTR not advertised", () => {
   it("Form_DRS.forms does not include DRSLTR (correspondence letter, not a prospectus)", () => {
     expect(Form_DRS.forms).not.toContain("DRSLTR");
   });

--- a/src/task/bootstrap/BootstrapDownloadTask.test.ts
+++ b/src/task/bootstrap/BootstrapDownloadTask.test.ts
@@ -236,7 +236,7 @@ describe("streamDownloadToFile", () => {
     }
   });
 
-  it("H-S3: accepts RFC 9112 duplicate-equal Content-Length values", async () => {
+  it("accepts RFC 9112 duplicate-equal Content-Length values", async () => {
     // CloudFront / Akamai / ELB sometimes emit two `Content-Length: N`
     // header lines. Headers.append combines them into a single
     // comma-joined string "N, N". RFC 9112 §6.3 explicitly allows the
@@ -270,7 +270,7 @@ describe("streamDownloadToFile", () => {
     }
   });
 
-  it("H-S3: rejects mismatched duplicate Content-Length values", async () => {
+  it("rejects mismatched duplicate Content-Length values", async () => {
     // Two Content-Length lines with different values are a genuine
     // protocol error. RFC 9112 §6.3 requires equal duplicates; mismatched
     // duplicates must fail closed.

--- a/src/task/bootstrap/BootstrapDownloadTask.test.ts
+++ b/src/task/bootstrap/BootstrapDownloadTask.test.ts
@@ -236,6 +236,69 @@ describe("streamDownloadToFile", () => {
     }
   });
 
+  it("H-S3: accepts RFC 9112 duplicate-equal Content-Length values", async () => {
+    // CloudFront / Akamai / ELB sometimes emit two `Content-Length: N`
+    // header lines. Headers.append combines them into a single
+    // comma-joined string "N, N". RFC 9112 §6.3 explicitly allows the
+    // recipient to combine duplicate equal values. The strict regex
+    // introduced in PR #125 rejected this real-world value; we now
+    // accept it while still rejecting genuinely conflicting values.
+    const body = new TextEncoder().encode("0123456789");
+    const oldFetch = global.fetch;
+    (global as any).fetch = mock(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(body);
+          controller.close();
+        },
+      });
+      // Build the header via append so we get the RFC 9112 combined form.
+      const h = new Headers();
+      h.append("content-length", "10");
+      h.append("content-length", "10");
+      return new Response(stream, { status: 200, headers: h });
+    });
+    try {
+      const dest = path.join(tmpRoot, "dup-equal-len.bin");
+      const result = await streamDownloadToFile("https://example/dup-equal", dest);
+      expect(result.bytes).toBe(10);
+      expect(result.totalBytes).toBe(10);
+      expect(readFileSync(dest, "utf-8")).toBe("0123456789");
+    } finally {
+      (global as any).fetch = oldFetch;
+      rmSync(path.join(tmpRoot, "dup-equal-len.bin"), { force: true });
+    }
+  });
+
+  it("H-S3: rejects mismatched duplicate Content-Length values", async () => {
+    // Two Content-Length lines with different values are a genuine
+    // protocol error. RFC 9112 §6.3 requires equal duplicates; mismatched
+    // duplicates must fail closed.
+    const body = new TextEncoder().encode("0123456789");
+    const oldFetch = global.fetch;
+    (global as any).fetch = mock(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(body);
+          controller.close();
+        },
+      });
+      const h = new Headers();
+      h.append("content-length", "10");
+      h.append("content-length", "20");
+      return new Response(stream, { status: 200, headers: h });
+    });
+    try {
+      const dest = path.join(tmpRoot, "dup-mismatched-len.bin");
+      await expect(
+        streamDownloadToFile("https://example/dup-mismatched", dest)
+      ).rejects.toThrow(/Conflicting Content-Length/);
+    } finally {
+      (global as any).fetch = oldFetch;
+      rmSync(path.join(tmpRoot, "dup-mismatched-len.bin"), { force: true });
+    }
+  });
+
   it("handles responses with no content-length header", async () => {
     const oldFetch = global.fetch;
     (global as any).fetch = mock(async () => {

--- a/src/task/bootstrap/BootstrapDownloadTask.test.ts
+++ b/src/task/bootstrap/BootstrapDownloadTask.test.ts
@@ -151,10 +151,9 @@ describe("streamDownloadToFile", () => {
   });
 
   it("streamDownloadToFile rejects malformed Content-Length", async () => {
-    // Server advertises `123abc` for a 10-byte body. `parseInt` would have
-    // returned 123 and triggered a size-mismatch failure that masks the
-    // root cause; with strict parsing we treat the header as absent and
-    // let the body stream through to completion.
+    // Server advertises `123abc`. `parseInt` would have returned 123 and
+    // silently downgraded integrity to a wrong-but-passable check; we
+    // fail closed instead so the caller sees the protocol violation.
     const body = new TextEncoder().encode("0123456789");
     const oldFetch = global.fetch;
     (global as any).fetch = mock(async () => {
@@ -171,10 +170,9 @@ describe("streamDownloadToFile", () => {
     });
     try {
       const dest = path.join(tmpRoot, "bad-len.bin");
-      const result = await streamDownloadToFile("https://example/bad-len", dest);
-      expect(result.bytes).toBe(body.length);
-      expect(result.totalBytes).toBeUndefined();
-      expect(readFileSync(dest, "utf-8")).toBe("0123456789");
+      await expect(
+        streamDownloadToFile("https://example/bad-len", dest)
+      ).rejects.toThrow(/Invalid Content-Length/);
     } finally {
       (global as any).fetch = oldFetch;
       rmSync(path.join(tmpRoot, "bad-len.bin"), { force: true });
@@ -211,8 +209,8 @@ describe("streamDownloadToFile", () => {
   });
 
   it("streamDownloadToFile rejects negative Content-Length", async () => {
-    // A negative value is malformed under RFC 9110; we treat it like an
-    // absent header and continue rather than fabricating a mismatch.
+    // A negative value is malformed under RFC 9110; we fail closed rather
+    // than silently downgrade to no-integrity-check.
     const body = new TextEncoder().encode("hello");
     const oldFetch = global.fetch;
     (global as any).fetch = mock(async () => {
@@ -229,10 +227,9 @@ describe("streamDownloadToFile", () => {
     });
     try {
       const dest = path.join(tmpRoot, "neg-len.bin");
-      const result = await streamDownloadToFile("https://example/neg-len", dest);
-      expect(result.bytes).toBe(body.length);
-      expect(result.totalBytes).toBeUndefined();
-      expect(readFileSync(dest, "utf-8")).toBe("hello");
+      await expect(
+        streamDownloadToFile("https://example/neg-len", dest)
+      ).rejects.toThrow(/Invalid Content-Length/);
     } finally {
       (global as any).fetch = oldFetch;
       rmSync(path.join(tmpRoot, "neg-len.bin"), { force: true });

--- a/src/task/bootstrap/BootstrapDownloadTask.test.ts
+++ b/src/task/bootstrap/BootstrapDownloadTask.test.ts
@@ -150,6 +150,95 @@ describe("streamDownloadToFile", () => {
     }
   });
 
+  it("streamDownloadToFile rejects malformed Content-Length", async () => {
+    // Server advertises `123abc` for a 10-byte body. `parseInt` would have
+    // returned 123 and triggered a size-mismatch failure that masks the
+    // root cause; with strict parsing we treat the header as absent and
+    // let the body stream through to completion.
+    const body = new TextEncoder().encode("0123456789");
+    const oldFetch = global.fetch;
+    (global as any).fetch = mock(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(body);
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { "content-length": "123abc" },
+      });
+    });
+    try {
+      const dest = path.join(tmpRoot, "bad-len.bin");
+      const result = await streamDownloadToFile("https://example/bad-len", dest);
+      expect(result.bytes).toBe(body.length);
+      expect(result.totalBytes).toBeUndefined();
+      expect(readFileSync(dest, "utf-8")).toBe("0123456789");
+    } finally {
+      (global as any).fetch = oldFetch;
+      rmSync(path.join(tmpRoot, "bad-len.bin"), { force: true });
+    }
+  });
+
+  it("streamDownloadToFile accepts whitespace-padded Content-Length", async () => {
+    // Surrounding whitespace is harmless and must not trip the strict
+    // parser — many proxies normalise headers with stray spaces.
+    const body = new TextEncoder().encode("0123456789");
+    const oldFetch = global.fetch;
+    (global as any).fetch = mock(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(body);
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { "content-length": "  10  " },
+      });
+    });
+    try {
+      const dest = path.join(tmpRoot, "padded-len.bin");
+      const result = await streamDownloadToFile("https://example/padded-len", dest);
+      expect(result.bytes).toBe(10);
+      expect(result.totalBytes).toBe(10);
+      expect(readFileSync(dest, "utf-8")).toBe("0123456789");
+    } finally {
+      (global as any).fetch = oldFetch;
+      rmSync(path.join(tmpRoot, "padded-len.bin"), { force: true });
+    }
+  });
+
+  it("streamDownloadToFile rejects negative Content-Length", async () => {
+    // A negative value is malformed under RFC 9110; we treat it like an
+    // absent header and continue rather than fabricating a mismatch.
+    const body = new TextEncoder().encode("hello");
+    const oldFetch = global.fetch;
+    (global as any).fetch = mock(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(body);
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { "content-length": "-5" },
+      });
+    });
+    try {
+      const dest = path.join(tmpRoot, "neg-len.bin");
+      const result = await streamDownloadToFile("https://example/neg-len", dest);
+      expect(result.bytes).toBe(body.length);
+      expect(result.totalBytes).toBeUndefined();
+      expect(readFileSync(dest, "utf-8")).toBe("hello");
+    } finally {
+      (global as any).fetch = oldFetch;
+      rmSync(path.join(tmpRoot, "neg-len.bin"), { force: true });
+    }
+  });
+
   it("handles responses with no content-length header", async () => {
     const oldFetch = global.fetch;
     (global as any).fetch = mock(async () => {

--- a/src/task/bootstrap/BootstrapDownloadTask.ts
+++ b/src/task/bootstrap/BootstrapDownloadTask.ts
@@ -51,22 +51,30 @@ export async function streamDownloadToFile(
   // Strict integer parse, fail-closed: `parseInt` accepts trailing garbage
   // ("123abc" → 123) which would let a malformed Content-Length defeat the
   // size-mismatch integrity check below. When the header is present we
-  // require its trimmed form to be a pure non-negative integer no larger
-  // than `MAX_SAFE_INTEGER` (beyond that point `bytes !== totalBytes` is
-  // no longer exact); otherwise we throw rather than silently treating
+  // require each comma-separated part to be a pure non-negative integer no
+  // larger than `MAX_SAFE_INTEGER` (beyond that point `bytes !== totalBytes`
+  // is no longer exact); otherwise we throw rather than silently treating
   // the response as having no advertised length. A truly-absent header
   // (chunked transfer) keeps `totalBytes` undefined and skips the
   // mismatch assertion as before.
   const len = response.headers.get("content-length");
   let totalBytes: number | undefined;
   if (len !== null) {
-    const trimmed = len.trim();
-    if (!/^\d+$/.test(trimmed)) {
+    // RFC 9112 §6.3: repeated Content-Length lines may be combined as
+    // "v1, v2, ...". Equal duplicates are valid (same length); mismatched
+    // values are a protocol error. A single value remains a single value.
+    const parts = len.split(",").map((p) => p.trim());
+    if (parts.length === 0 || parts.some((p) => !/^\d+$/.test(p))) {
       throw new Error(`Invalid Content-Length header ${JSON.stringify(len)} for ${url}`);
     }
-    const parsed = Number(trimmed);
+    if (new Set(parts).size > 1) {
+      throw new Error(
+        `Conflicting Content-Length values ${JSON.stringify(len)} for ${url} (RFC 9112 §6.3 requires duplicates to be equal)`
+      );
+    }
+    const parsed = Number(parts[0]);
     if (parsed > Number.MAX_SAFE_INTEGER) {
-      throw new Error(`Content-Length ${trimmed} exceeds MAX_SAFE_INTEGER for ${url}`);
+      throw new Error(`Content-Length ${parts[0]} exceeds MAX_SAFE_INTEGER for ${url}`);
     }
     totalBytes = parsed;
   }

--- a/src/task/bootstrap/BootstrapDownloadTask.ts
+++ b/src/task/bootstrap/BootstrapDownloadTask.ts
@@ -48,9 +48,22 @@ export async function streamDownloadToFile(
     throw new Error(`Download returned no body for ${url}`);
   }
 
+  // Strict integer parse: `parseInt` accepts trailing garbage ("123abc" →
+  // 123) which would let a malformed Content-Length defeat the
+  // size-mismatch integrity check below. We require the trimmed header
+  // to be a pure non-negative integer string, otherwise we fall back to
+  // `undefined` (the no-Content-Length path), which still streams to
+  // completion but skips the mismatch assertion. Values above
+  // `MAX_SAFE_INTEGER` (extremely unlikely in practice) are also clamped
+  // to `undefined` because beyond that point arithmetic on
+  // `bytes !== totalBytes` is no longer exact.
   const len = response.headers.get("content-length");
-  const totalBytesParsed = len !== null ? parseInt(len, 10) : NaN;
-  const totalBytes = Number.isFinite(totalBytesParsed) ? totalBytesParsed : undefined;
+  const parsedTotal =
+    len !== null && /^\d+$/.test(len.trim()) ? Number(len.trim()) : undefined;
+  const totalBytes =
+    parsedTotal !== undefined && parsedTotal <= Number.MAX_SAFE_INTEGER
+      ? parsedTotal
+      : undefined;
 
   const writer = Bun.file(destPath).writer();
   let bytes = 0;

--- a/src/task/bootstrap/BootstrapDownloadTask.ts
+++ b/src/task/bootstrap/BootstrapDownloadTask.ts
@@ -48,22 +48,28 @@ export async function streamDownloadToFile(
     throw new Error(`Download returned no body for ${url}`);
   }
 
-  // Strict integer parse: `parseInt` accepts trailing garbage ("123abc" →
-  // 123) which would let a malformed Content-Length defeat the
-  // size-mismatch integrity check below. We require the trimmed header
-  // to be a pure non-negative integer string, otherwise we fall back to
-  // `undefined` (the no-Content-Length path), which still streams to
-  // completion but skips the mismatch assertion. Values above
-  // `MAX_SAFE_INTEGER` (extremely unlikely in practice) are also clamped
-  // to `undefined` because beyond that point arithmetic on
-  // `bytes !== totalBytes` is no longer exact.
+  // Strict integer parse, fail-closed: `parseInt` accepts trailing garbage
+  // ("123abc" → 123) which would let a malformed Content-Length defeat the
+  // size-mismatch integrity check below. When the header is present we
+  // require its trimmed form to be a pure non-negative integer no larger
+  // than `MAX_SAFE_INTEGER` (beyond that point `bytes !== totalBytes` is
+  // no longer exact); otherwise we throw rather than silently treating
+  // the response as having no advertised length. A truly-absent header
+  // (chunked transfer) keeps `totalBytes` undefined and skips the
+  // mismatch assertion as before.
   const len = response.headers.get("content-length");
-  const parsedTotal =
-    len !== null && /^\d+$/.test(len.trim()) ? Number(len.trim()) : undefined;
-  const totalBytes =
-    parsedTotal !== undefined && parsedTotal <= Number.MAX_SAFE_INTEGER
-      ? parsedTotal
-      : undefined;
+  let totalBytes: number | undefined;
+  if (len !== null) {
+    const trimmed = len.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error(`Invalid Content-Length header ${JSON.stringify(len)} for ${url}`);
+    }
+    const parsed = Number(trimmed);
+    if (parsed > Number.MAX_SAFE_INTEGER) {
+      throw new Error(`Content-Length ${trimmed} exceeds MAX_SAFE_INTEGER for ${url}`);
+    }
+    totalBytes = parsed;
+  }
 
   const writer = Bun.file(destPath).writer();
   let bytes = 0;


### PR DESCRIPTION
## Summary

Four fixes. Two are corrections to PR #125 (cherry-picked here on top of `origin/main`); two are new fixes that target `main` directly.

### Drop `DRSLTR` from `Form_DRS.forms` (targets `main`)

`Form_DRS.forms` advertised `DRSLTR` but `FORM_TO_EXTRACTOR_ID` intentionally did not map it (DRSLTR is a SEC correspondence letter, not a registration prospectus). Every `sec fetch form <cik> DRSLTR` attempt threw `"No extractor registered for form 'DRSLTR'"` after Form_DRS advertised support. Dropped from `Form_DRS.forms` and added an invariant test pinning that `DRSLTR` is not in `ALL_FORMS_MAP`.

### Verify SPAC sponsor `source_span` before persisting (targets `main`)

`processFormS1`'s SPAC sponsor extraction passed LLM-returned rows to `SpacSponsorLinkRepo` with only a confidence-floor check. The extractor input concatenates management / beneficial-ownership / related-party section text (no dedicated "Sponsor" section), so LLM hallucination of company names from director bios could write permanent fact-claims keyed to the issuer CIK.

Added a `source_span` verbatim verification pass (NFKC + curly-quote + whitespace + case normalization). Drops any returned row whose `source_span` is not present in the sponsor section text:
- All rows dropped → dead-letter as `UNVERIFIED_SOURCE_SPAN`.
- Some rows dropped → write the verified ones AND record a `"spac-sponsors-partial"` dead-letter for triage.

Bumped S-1 extractor default `1.0.0` → `1.1.0`; version-slot machinery re-runs S-1 against existing filings under stricter verification.

### Make resolver alias-race test actually discriminate the race (correction to PR #125)

PR #125's alias-serialisation test stubbed `aliasRepo.resolve` to return a constant id regardless of input, so both the pre-fix code path (alias lookup outside the mutex) and the post-fix code path (alias lookup inside the mutex) produced identical final ids — the test signaled nothing.

Replaced with a stub that tracks concurrent in-flight `aliasRepo.resolve` calls:
- Pre-fix: alias lookup runs after `mutex.release()` → two parallel resolves drive `maxInFlight` to 2.
- Post-fix: alias lookup runs inside the lock → `maxInFlight` is bounded at 1.

Verified by checking out `origin/main:src/resolver/PersonResolver.ts` and running the rewritten test — fails with `Expected: 1 / Received: 2` on pre-fix code, passes once the fix is reapplied.

### Accept RFC 9112 duplicate-equal Content-Length values (correction to PR #125)

PR #125's strict `/^\d+$/` regex rejected `"100, 100"` — the value `Headers.append` produces when a real CDN (CloudFront / Akamai / ELB) sends two `Content-Length: 100` lines. RFC 9112 §6.3 explicitly allows the recipient to combine duplicate equal values. Because bootstrap downloads are operator-triggered and not auto-retried, this surfaced as confusing failures on previously-working downloads.

Split on `,`, trim each part, require each to match the integer regex, then require all parts equal. Mismatched values are still rejected (genuine protocol error). Single-value behavior is byte-for-byte identical.

## Relationship to PR #125

PR #125's underlying intent (strict Content-Length parse + alias-resolution inside mutex) was correct. The three commits from PR #125 are cherry-picked here as the base, with the test correction and the Content-Length tolerance correction layered on top.

**Maintainer should choose one:**
- Merge this PR (supersedes #125); close #125.
- Apply the two corrections as fixup commits on the #125 branch and merge that instead.

## Test plan

- [x] `bun test src/storage/versioning/extractorIds.test.ts` (17 pass)
- [x] `bun test src/sec/forms/registration-statements/s1/verifySourceSpan.test.ts` — utility (12 pass)
- [x] `bun test src/sec/forms/registration-statements/s1/spacSponsor.e2e.test.ts` — storage e2e (6 pass)
- [x] `bun test src/resolver/PersonResolver.test.ts src/resolver/CompanyResolver.test.ts` (18 pass)
- [x] `bun test src/task/bootstrap/BootstrapDownloadTask.test.ts` (13 pass)
- [x] `bun test src/sec/forms/` (243 pass)
- [x] `bun test src/storage/` (412 pass)
- [x] `bun test` whole repo (1042 pass)
- [x] Discrimination check: reverted resolver to `origin/main`, confirmed new test fails with `Expected: 1 / Received: 2`.

https://claude.ai/code/session_01EswfjUtvDWz8z1wQJspg2v

---
_Generated by [Claude Code](https://claude.ai/code/session_01EswfjUtvDWz8z1wQJspg2v)_