### PR TITLE
Add offering terms, underwriters, and use-of-proceeds extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,13 +91,15 @@ sec canonical underwriter-family alias "<from>" "<into>" --reason "subsidiary"
 sec canonical underwriter-family alias-remove "<name>"
 sec canonical underwriter-family alias-list [--orphans]
 
-# Versioning for the new resolver kind
-sec version coverage resolver underwriter-family
-sec version drop-previous resolver underwriter-family
-
 # Point-in-time ticker series for an issuer
 sec issuer tickers <cik>
 ```
+
+> Note: the version ceremonies `coverage` / `drop-previous` and the batch `resolve`
+> command are **not** supported for the family-tier resolver kinds
+> (`underwriter-family`, `sponsor-family`) — they intentionally error rather than
+> operate on the company tier. Family-tier coverage/purge wiring is deferred (see the
+> status doc's deferred cleanups).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,33 @@ sec fetch s1-fixtures                 # ~10 real S-1s (>= 3 SPACs) -> mock_data/
 sec fetch s1-fixtures -c 20 --min-spac 5
 ```
 
+#### Offering terms / underwriters / use of proceeds
+
+S-1/F-1 prospectuses also yield the deal itself: offering terms (equity →
+`offering_terms`, SPAC units → `spac_unit_terms`), a point-in-time exact ticker
+series (`issuer_ticker`, distinct from the mutable submissions-API `entity_tickers`),
+use-of-proceeds line items, and underwriters on the company tier rolled up to an
+`underwriter-family` resolver tier (mirroring sponsor families). The segmenter
+recognizes focused `The Offering` / `Underwriting` / `Use of Proceeds` / `The Sponsor`
+sections; the last one also gives SPAC sponsor extraction a dedicated home (it falls
+back to concatenated section text when the heading is absent).
+
+```bash
+# IPOs underwritten by a family (alias-aware)
+sec underwriter by-family "Goldman Sachs"
+
+# Underwriter-family alias management
+sec canonical underwriter-family alias "<from>" "<into>" --reason "subsidiary"
+sec canonical underwriter-family alias-list
+
+# Versioning for the new resolver kind
+sec version coverage resolver underwriter-family
+sec version drop-previous resolver underwriter-family
+
+# Point-in-time ticker series for an issuer
+sec issuer tickers <cik>
+```
+
 ## Architecture
 
 ### Layered Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,8 @@ sec underwriter by-family "Goldman Sachs"
 
 # Underwriter-family alias management
 sec canonical underwriter-family alias "<from>" "<into>" --reason "subsidiary"
-sec canonical underwriter-family alias-list
+sec canonical underwriter-family alias-remove "<name>"
+sec canonical underwriter-family alias-list [--orphans]
 
 # Versioning for the new resolver kind
 sec version coverage resolver underwriter-family

--- a/src/cli/groups/resolve.ts
+++ b/src/cli/groups/resolve.ts
@@ -15,7 +15,7 @@ import { CanonicalPersonAliasRepo } from "../../storage/canonical/CanonicalPerso
 import { CanonicalCompanyAliasRepo } from "../../storage/canonical/CanonicalCompanyAliasRepo";
 import { PersonResolver } from "../../resolver/PersonResolver";
 import { CompanyResolver } from "../../resolver/CompanyResolver";
-import { RESOLVER_IDS, type ResolverId } from "../../resolver/resolverIds";
+import { RESOLVER_IDS, isFamilyResolverId, type ResolverId } from "../../resolver/resolverIds";
 import { isValidSemver } from "../../storage/versioning/VersionRegistry";
 
 export function addResolveCommands(program: Command): void {
@@ -28,6 +28,17 @@ export function addResolveCommands(program: Command): void {
     .action(async (opts: { kind: string; resolverVersion: string; all: boolean }) => {
       if (!RESOLVER_IDS.includes(opts.kind as ResolverId)) {
         console.error(`error: --kind must be one of ${RESOLVER_IDS.join("|")}`);
+        process.exit(1);
+      }
+      // Family-tier resolvers run inline during S-1 extraction (keyed off the
+      // sponsor/underwriter common name), not as a batch pass over observations.
+      // Refuse here rather than silently running the company resolver and writing
+      // mislabeled company identity-link rows.
+      if (isFamilyResolverId(opts.kind)) {
+        console.error(
+          `error: 'sec resolve' does not support family resolver kind '${opts.kind}'; ` +
+            `family resolution happens inline during S-1 extraction`
+        );
         process.exit(1);
       }
       if (!opts.all) {

--- a/src/cli/queries/ResolverCoverage.test.ts
+++ b/src/cli/queries/ResolverCoverage.test.ts
@@ -114,4 +114,13 @@ describe("computeResolverCoverage", () => {
     expect(countCalls).toBe(2);
     expect(lastLinkCriteria).toEqual({ resolver_version: "1.0.0" });
   });
+
+  it("refuses family resolver kinds instead of reporting company coverage", async () => {
+    await expect(computeResolverCoverage("underwriter-family", "1.0.0")).rejects.toThrow(
+      /family resolver kind/
+    );
+    await expect(computeResolverCoverage("sponsor-family", "1.0.0")).rejects.toThrow(
+      /family resolver kind/
+    );
+  });
 });

--- a/src/cli/queries/ResolverCoverage.ts
+++ b/src/cli/queries/ResolverCoverage.ts
@@ -8,7 +8,7 @@ import { PersonObservationRepo } from "../../storage/observation/PersonObservati
 import { CompanyObservationRepo } from "../../storage/observation/CompanyObservationRepo";
 import { PersonIdentityLinkRepo } from "../../storage/canonical/PersonIdentityLinkRepo";
 import { CompanyIdentityLinkRepo } from "../../storage/canonical/CompanyIdentityLinkRepo";
-import type { ResolverId } from "../../resolver/resolverIds";
+import { isFamilyResolverId, type ResolverId } from "../../resolver/resolverIds";
 
 export interface ResolverCoverageResult {
   readonly kind: ResolverId;
@@ -22,6 +22,15 @@ export async function computeResolverCoverage(
   kind: ResolverId,
   resolver_version: string
 ): Promise<ResolverCoverageResult> {
+  // Family-tier resolvers (sponsor-family / underwriter-family) have no
+  // observation → identity-link coverage model; refuse rather than silently
+  // reporting the company tier's coverage under a family-kind label.
+  if (isFamilyResolverId(kind)) {
+    throw new Error(
+      `coverage is not defined for family resolver kind '${kind}' ` +
+        `(family resolvers track membership, not observation identity-links)`
+    );
+  }
   // Use the storage layer's COUNT path instead of materializing every row.
   // At Form D + Section 16 scale `listAll()` OOMs.
   if (kind === "person") {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -19,6 +19,7 @@ import { addResolveCommands } from "../cli/groups/resolve";
 import { addCanonicalCommands } from "../cli/groups/canonical";
 import { addExtractorCommands } from "../cli/groups/extractor";
 import { registerSponsorFamilyCommands } from "./sponsorFamily";
+import { registerUnderwriterFamilyCommands } from "./underwriterFamily";
 import { DefaultDI } from "../config/DefaultDI";
 import { EnvToDI } from "../config/EnvToDI";
 import { SEC_DRY_RUN } from "../config/tokens";
@@ -68,5 +69,6 @@ export const AddCommands = (program: Command): void => {
   addResolveCommands(program);
   addCanonicalCommands(program);
   registerSponsorFamilyCommands(program);
+  registerUnderwriterFamilyCommands(program);
   addExtractorCommands(program);
 };

--- a/src/commands/underwriterFamily.test.ts
+++ b/src/commands/underwriterFamily.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it } from "bun:test";
 import { resetDependencyInjectionsForTesting } from "../config/TestingDI";
 import { setupAllDatabases } from "../config/setupAllDatabases";
 import { CanonicalUnderwriterFamilyRepo } from "../storage/canonical/CanonicalUnderwriterFamilyRepo";
+import { CanonicalUnderwriterFamilyAliasRepo } from "../storage/canonical/CanonicalUnderwriterFamilyAliasRepo";
 import { UnderwriterLinkRepo } from "../storage/canonical/UnderwriterLinkRepo";
 import { ipoIssuersByUnderwriterFamilyName } from "./underwriterFamily";
 
@@ -38,5 +39,54 @@ describe("ipoIssuersByUnderwriterFamilyName", () => {
       resolver_version: "1.0.0",
     });
     expect(await ipoIssuersByUnderwriterFamilyName("Goldman Sachs", "1.0.0")).toEqual([1018724]);
+  });
+
+  it("unions issuer CIKs across aliased variant families", async () => {
+    const families = new CanonicalUnderwriterFamilyRepo();
+    await families.create({
+      canonical_underwriter_family_id: "fam-1",
+      resolver_version: "1.0.0",
+      display_name: "Goldman Sachs",
+      normalized_name: "goldman sachs",
+      created_at: new Date().toISOString(),
+    });
+    await families.create({
+      canonical_underwriter_family_id: "gs-variant",
+      resolver_version: "1.0.0",
+      display_name: "Goldman Sachs Group",
+      normalized_name: "goldman sachs group",
+      created_at: new Date().toISOString(),
+    });
+    // The AI-emitted variant is merged into the canonical family.
+    await new CanonicalUnderwriterFamilyAliasRepo().add("gs-variant", "fam-1", "variant", "op");
+
+    const links = new UnderwriterLinkRepo();
+    await links.save({
+      accession_number: "0000000000-26-000001",
+      extractor_id: "S-1",
+      observation_index: 5,
+      issuer_cik: 1018724,
+      underwriter_canonical_company_id: "co-1",
+      underwriter_family_id: "fam-1",
+      role_detail: "lead",
+      shares_allocated: null,
+      over_allotment_shares: null,
+      resolver_version: "1.0.0",
+    });
+    await links.save({
+      accession_number: "0000000000-26-000002",
+      extractor_id: "S-1",
+      observation_index: 3,
+      issuer_cik: 2222222,
+      underwriter_canonical_company_id: "co-2",
+      underwriter_family_id: "gs-variant",
+      role_detail: "bookrunner",
+      shares_allocated: null,
+      over_allotment_shares: null,
+      resolver_version: "1.0.0",
+    });
+
+    const ciks = (await ipoIssuersByUnderwriterFamilyName("Goldman Sachs", "1.0.0")).sort();
+    expect(ciks).toEqual([1018724, 2222222]);
   });
 });

--- a/src/commands/underwriterFamily.test.ts
+++ b/src/commands/underwriterFamily.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../config/TestingDI";
+import { setupAllDatabases } from "../config/setupAllDatabases";
+import { CanonicalUnderwriterFamilyRepo } from "../storage/canonical/CanonicalUnderwriterFamilyRepo";
+import { UnderwriterLinkRepo } from "../storage/canonical/UnderwriterLinkRepo";
+import { ipoIssuersByUnderwriterFamilyName } from "./underwriterFamily";
+
+describe("ipoIssuersByUnderwriterFamilyName", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+
+  it("returns issuer CIKs for the named underwriter family", async () => {
+    await new CanonicalUnderwriterFamilyRepo().create({
+      canonical_underwriter_family_id: "fam-1",
+      resolver_version: "1.0.0",
+      display_name: "Goldman Sachs",
+      normalized_name: "goldman sachs",
+      created_at: new Date().toISOString(),
+    });
+    await new UnderwriterLinkRepo().save({
+      accession_number: "0000000000-26-000001",
+      extractor_id: "S-1",
+      observation_index: 5,
+      issuer_cik: 1018724,
+      underwriter_canonical_company_id: "co-1",
+      underwriter_family_id: "fam-1",
+      role_detail: "lead",
+      shares_allocated: null,
+      over_allotment_shares: null,
+      resolver_version: "1.0.0",
+    });
+    expect(await ipoIssuersByUnderwriterFamilyName("Goldman Sachs", "1.0.0")).toEqual([1018724]);
+  });
+});

--- a/src/commands/underwriterFamily.ts
+++ b/src/commands/underwriterFamily.ts
@@ -40,7 +40,7 @@ export async function ipoIssuersByUnderwriterFamilyName(
 }
 
 /**
- * Registers `sec canonical underwriter-family alias|alias-list`,
+ * Registers `sec canonical underwriter-family alias|alias-remove|alias-list`,
  * `sec underwriter by-family`, and `sec issuer tickers`. Must be called after
  * the `canonical` subcommand is registered.
  */
@@ -91,12 +91,46 @@ export function registerUnderwriterFamilyCommands(program: Command): void {
     );
 
   fam
+    .command("alias-remove <name>")
+    .description("Remove an alias for an underwriter-family name")
+    .option("--resolver-version <v>", "resolver version", "1.0.0")
+    .action(async (name: string, opts: { resolverVersion: string }) => {
+      const families = new CanonicalUnderwriterFamilyRepo();
+      const family = await families.findByResolverAndName(
+        opts.resolverVersion,
+        normalizeUnderwriterFamilyName(name)
+      );
+      if (!family) {
+        console.error(`error: no underwriter-family found for '${name}'`);
+        process.exit(1);
+      }
+      await new CanonicalUnderwriterFamilyAliasRepo().remove(family.canonical_underwriter_family_id);
+      console.log(`removed alias for ${family.canonical_underwriter_family_id}`);
+    });
+
+  fam
     .command("alias-list")
     .description("List all underwriter-family aliases")
-    .action(async () => {
-      const rows = await new CanonicalUnderwriterFamilyAliasRepo().list();
-      for (const r of rows) {
-        console.log(`${r.alias_canonical_id}\t->\t${r.target_canonical_id}\t${r.reason ?? ""}`);
+    .option("--orphans", "show only aliases referencing missing canonicals", false)
+    .option("--resolver-version <v>", "resolver version", "1.0.0")
+    .action(async (opts: { orphans: boolean; resolverVersion: string }) => {
+      const aliasRepo = new CanonicalUnderwriterFamilyAliasRepo();
+      if (opts.orphans) {
+        const familyRepo = new CanonicalUnderwriterFamilyRepo();
+        const allIds = new Set(
+          (await familyRepo.listForResolverVersion(opts.resolverVersion)).map(
+            (r) => r.canonical_underwriter_family_id
+          )
+        );
+        const list = await aliasRepo.listOrphans(allIds);
+        for (const r of list) {
+          console.log(`${r.alias_canonical_id}\t->\t${r.target_canonical_id}\t${r.reason ?? ""}`);
+        }
+      } else {
+        const rows = await aliasRepo.list();
+        for (const r of rows) {
+          console.log(`${r.alias_canonical_id}\t->\t${r.target_canonical_id}\t${r.reason ?? ""}`);
+        }
       }
     });
 

--- a/src/commands/underwriterFamily.ts
+++ b/src/commands/underwriterFamily.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Command } from "commander";
+import { normalizeUnderwriterFamilyName } from "../resolver/UnderwriterFamilyResolver";
+import { CanonicalUnderwriterFamilyRepo } from "../storage/canonical/CanonicalUnderwriterFamilyRepo";
+import { CanonicalUnderwriterFamilyAliasRepo } from "../storage/canonical/CanonicalUnderwriterFamilyAliasRepo";
+import { UnderwriterLinkRepo } from "../storage/canonical/UnderwriterLinkRepo";
+import { IssuerTickerRepo } from "../storage/offering/IssuerTickerRepo";
+
+/**
+ * Returns the issuer CIKs of every IPO underwritten by the named family.
+ * Alias-aware: unions the resolved target family with every variant family id
+ * aliased into it, since link rows keep the family id assigned at extraction time.
+ */
+export async function ipoIssuersByUnderwriterFamilyName(
+  name: string,
+  resolverVersion: string
+): Promise<number[]> {
+  const normalized = normalizeUnderwriterFamilyName(name);
+  if (!normalized) return [];
+  const families = new CanonicalUnderwriterFamilyRepo();
+  const family = await families.findByResolverAndName(resolverVersion, normalized);
+  if (!family) return [];
+
+  const aliases = new CanonicalUnderwriterFamilyAliasRepo();
+  const target = await aliases.resolve(family.canonical_underwriter_family_id);
+  const variantIds = (await aliases.listByTarget(target)).map((a) => a.alias_canonical_id);
+  const familyIds = [target, ...variantIds];
+
+  const links = new UnderwriterLinkRepo();
+  const ciks = new Set<number>();
+  for (const id of familyIds) {
+    for (const cik of await links.listIssuerCiksForFamily(id)) ciks.add(cik);
+  }
+  return [...ciks];
+}
+
+/**
+ * Registers `sec canonical underwriter-family alias|alias-list`,
+ * `sec underwriter by-family`, and `sec issuer tickers`. Must be called after
+ * the `canonical` subcommand is registered.
+ */
+export function registerUnderwriterFamilyCommands(program: Command): void {
+  const canonical = program.commands.find((c) => c.name() === "canonical") ?? program;
+
+  const fam = new Command("underwriter-family").description(
+    "Manage underwriter-family canonical entities"
+  );
+
+  fam
+    .command("alias <fromName> <intoName>")
+    .description("Merge an AI-emitted variant family name into another")
+    .option("--reason <reason>", "why these were merged")
+    .option("--resolver-version <v>", "resolver version", "1.0.0")
+    .action(
+      async (
+        fromName: string,
+        intoName: string,
+        opts: { reason?: string; resolverVersion: string }
+      ) => {
+        const families = new CanonicalUnderwriterFamilyRepo();
+        const from = await families.findByResolverAndName(
+          opts.resolverVersion,
+          normalizeUnderwriterFamilyName(fromName)
+        );
+        const into = await families.findByResolverAndName(
+          opts.resolverVersion,
+          normalizeUnderwriterFamilyName(intoName)
+        );
+        if (!from || !into) {
+          console.error("error: both family names must already exist");
+          process.exit(1);
+        }
+        try {
+          await new CanonicalUnderwriterFamilyAliasRepo().add(
+            from.canonical_underwriter_family_id,
+            into.canonical_underwriter_family_id,
+            opts.reason ?? null,
+            "cli"
+          );
+          console.log(`aliased '${fromName}' -> '${intoName}'`);
+        } catch (e) {
+          console.error(`error: ${(e as Error).message}`);
+          process.exit(1);
+        }
+      }
+    );
+
+  fam
+    .command("alias-list")
+    .description("List all underwriter-family aliases")
+    .action(async () => {
+      const rows = await new CanonicalUnderwriterFamilyAliasRepo().list();
+      for (const r of rows) {
+        console.log(`${r.alias_canonical_id}\t->\t${r.target_canonical_id}\t${r.reason ?? ""}`);
+      }
+    });
+
+  canonical.addCommand(fam);
+
+  program
+    .command("underwriter")
+    .description("Underwriter queries")
+    .addCommand(
+      new Command("by-family")
+        .description("List issuer CIKs for IPOs underwritten by a family")
+        .argument("<name>", "underwriter family display name")
+        .option("--resolver-version <v>", "resolver version", "1.0.0")
+        .action(async (name: string, opts: { resolverVersion: string }) => {
+          const ciks = await ipoIssuersByUnderwriterFamilyName(name, opts.resolverVersion);
+          console.log(JSON.stringify(ciks));
+        })
+    );
+
+  program
+    .command("issuer")
+    .description("Issuer queries")
+    .addCommand(
+      new Command("tickers")
+        .description("List the point-in-time ticker series for an issuer CIK")
+        .argument("<cik>", "issuer CIK")
+        .action(async (cik: string) => {
+          const rows = await new IssuerTickerRepo().history(Number(cik));
+          for (const r of rows) {
+            console.log(
+              `${r.filing_date ?? ""}\t${r.exchange}\t${r.ticker}\t${r.is_primary ? "primary" : ""}`
+            );
+          }
+        })
+    );
+}

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -216,6 +216,11 @@ import {
   CanonicalUnderwriterFamilySchema,
 } from "../storage/canonical/CanonicalUnderwriterFamilySchema";
 import {
+  UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN,
+  UnderwriterFamilyMembershipPrimaryKeyNames,
+  UnderwriterFamilyMembershipSchema,
+} from "../storage/canonical/UnderwriterFamilyMembershipSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -818,6 +823,15 @@ export const DefaultDI = () => {
       CanonicalUnderwriterFamilyAliasSchema,
       CanonicalUnderwriterFamilyAliasPrimaryKeyNames,
       [["target_canonical_id"]]
+    )
+  );
+  globalServiceRegistry.registerInstance(
+    UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN,
+    createStorage(
+      "underwriter_family_membership",
+      UnderwriterFamilyMembershipSchema,
+      UnderwriterFamilyMembershipPrimaryKeyNames,
+      [["resolver_version", "canonical_underwriter_family_id"]]
     )
   );
 };

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -193,6 +193,11 @@ import {
   SpacSponsorLinkSchema,
 } from "../storage/canonical/SpacSponsorLinkSchema";
 import {
+  OFFERING_TERMS_REPOSITORY_TOKEN,
+  OfferingTermsPrimaryKeyNames,
+  OfferingTermsSchema,
+} from "../storage/offering/OfferingTermsSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -763,5 +768,9 @@ export const DefaultDI = () => {
       ["accession_number"],
       ["sponsor_family_id"],
     ])
+  );
+  globalServiceRegistry.registerInstance(
+    OFFERING_TERMS_REPOSITORY_TOKEN,
+    createStorage("offering_terms", OfferingTermsSchema, OfferingTermsPrimaryKeyNames, [])
   );
 };

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -170,12 +170,15 @@ import {
   CANONICAL_COMPANY_ALIAS_REPOSITORY_TOKEN,
   CANONICAL_PERSON_ALIAS_REPOSITORY_TOKEN,
   CANONICAL_SPONSOR_FAMILY_ALIAS_REPOSITORY_TOKEN,
+  CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN,
   CanonicalCompanyAliasSchema,
   CanonicalCompanyAliasPrimaryKeyNames,
   CanonicalPersonAliasSchema,
   CanonicalPersonAliasPrimaryKeyNames,
   CanonicalSponsorFamilyAliasSchema,
   CanonicalSponsorFamilyAliasPrimaryKeyNames,
+  CanonicalUnderwriterFamilyAliasSchema,
+  CanonicalUnderwriterFamilyAliasPrimaryKeyNames,
 } from "../storage/canonical/CanonicalAliasSchemas";
 import {
   CANONICAL_SPONSOR_FAMILY_REPOSITORY_TOKEN,
@@ -806,6 +809,15 @@ export const DefaultDI = () => {
       CanonicalUnderwriterFamilySchema,
       CanonicalUnderwriterFamilyPrimaryKeyNames,
       [["resolver_version", "normalized_name"]]
+    )
+  );
+  globalServiceRegistry.registerInstance(
+    CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN,
+    createStorage(
+      "canonical_underwriter_family_alias",
+      CanonicalUnderwriterFamilyAliasSchema,
+      CanonicalUnderwriterFamilyAliasPrimaryKeyNames,
+      [["target_canonical_id"]]
     )
   );
 };

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -221,6 +221,11 @@ import {
   UnderwriterFamilyMembershipSchema,
 } from "../storage/canonical/UnderwriterFamilyMembershipSchema";
 import {
+  UNDERWRITER_LINK_REPOSITORY_TOKEN,
+  UnderwriterLinkPrimaryKeyNames,
+  UnderwriterLinkSchema,
+} from "../storage/canonical/UnderwriterLinkSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -833,5 +838,12 @@ export const DefaultDI = () => {
       UnderwriterFamilyMembershipPrimaryKeyNames,
       [["resolver_version", "canonical_underwriter_family_id"]]
     )
+  );
+  globalServiceRegistry.registerInstance(
+    UNDERWRITER_LINK_REPOSITORY_TOKEN,
+    createStorage("underwriter_link", UnderwriterLinkSchema, UnderwriterLinkPrimaryKeyNames, [
+      ["accession_number"],
+      ["underwriter_family_id"],
+    ])
   );
 };

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -203,6 +203,11 @@ import {
   SpacUnitTermsSchema,
 } from "../storage/offering/SpacUnitTermsSchema";
 import {
+  ISSUER_TICKER_REPOSITORY_TOKEN,
+  IssuerTickerPrimaryKeyNames,
+  IssuerTickerSchema,
+} from "../storage/offering/IssuerTickerSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -781,5 +786,12 @@ export const DefaultDI = () => {
   globalServiceRegistry.registerInstance(
     SPAC_UNIT_TERMS_REPOSITORY_TOKEN,
     createStorage("spac_unit_terms", SpacUnitTermsSchema, SpacUnitTermsPrimaryKeyNames, [])
+  );
+  globalServiceRegistry.registerInstance(
+    ISSUER_TICKER_REPOSITORY_TOKEN,
+    createStorage("issuer_ticker", IssuerTickerSchema, IssuerTickerPrimaryKeyNames, [
+      ["cik"],
+      ["accession_number"],
+    ])
   );
 };

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -198,6 +198,11 @@ import {
   OfferingTermsSchema,
 } from "../storage/offering/OfferingTermsSchema";
 import {
+  SPAC_UNIT_TERMS_REPOSITORY_TOKEN,
+  SpacUnitTermsPrimaryKeyNames,
+  SpacUnitTermsSchema,
+} from "../storage/offering/SpacUnitTermsSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -772,5 +777,9 @@ export const DefaultDI = () => {
   globalServiceRegistry.registerInstance(
     OFFERING_TERMS_REPOSITORY_TOKEN,
     createStorage("offering_terms", OfferingTermsSchema, OfferingTermsPrimaryKeyNames, [])
+  );
+  globalServiceRegistry.registerInstance(
+    SPAC_UNIT_TERMS_REPOSITORY_TOKEN,
+    createStorage("spac_unit_terms", SpacUnitTermsSchema, SpacUnitTermsPrimaryKeyNames, [])
   );
 };

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -208,6 +208,11 @@ import {
   IssuerTickerSchema,
 } from "../storage/offering/IssuerTickerSchema";
 import {
+  CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN,
+  CanonicalUnderwriterFamilyPrimaryKeyNames,
+  CanonicalUnderwriterFamilySchema,
+} from "../storage/canonical/CanonicalUnderwriterFamilySchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -793,5 +798,14 @@ export const DefaultDI = () => {
       ["cik"],
       ["accession_number"],
     ])
+  );
+  globalServiceRegistry.registerInstance(
+    CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN,
+    createStorage(
+      "canonical_underwriter_family",
+      CanonicalUnderwriterFamilySchema,
+      CanonicalUnderwriterFamilyPrimaryKeyNames,
+      [["resolver_version", "normalized_name"]]
+    )
   );
 };

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -226,6 +226,11 @@ import {
   UnderwriterLinkSchema,
 } from "../storage/canonical/UnderwriterLinkSchema";
 import {
+  USE_OF_PROCEEDS_REPOSITORY_TOKEN,
+  UseOfProceedsPrimaryKeyNames,
+  UseOfProceedsSchema,
+} from "../storage/use-of-proceeds/UseOfProceedsSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -844,6 +849,12 @@ export const DefaultDI = () => {
     createStorage("underwriter_link", UnderwriterLinkSchema, UnderwriterLinkPrimaryKeyNames, [
       ["accession_number"],
       ["underwriter_family_id"],
+    ])
+  );
+  globalServiceRegistry.registerInstance(
+    USE_OF_PROCEEDS_REPOSITORY_TOKEN,
+    createStorage("use_of_proceeds", UseOfProceedsSchema, UseOfProceedsPrimaryKeyNames, [
+      ["accession_number"],
     ])
   );
 };

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -196,6 +196,11 @@ import {
   OfferingTermsSchema,
 } from "../storage/offering/OfferingTermsSchema";
 import {
+  SPAC_UNIT_TERMS_REPOSITORY_TOKEN,
+  SpacUnitTermsPrimaryKeyNames,
+  SpacUnitTermsSchema,
+} from "../storage/offering/SpacUnitTermsSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -673,5 +678,9 @@ export function resetDependencyInjectionsForTesting() {
   globalServiceRegistry.registerInstance(
     OFFERING_TERMS_REPOSITORY_TOKEN,
     new InMemoryTabularStorage(OfferingTermsSchema, OfferingTermsPrimaryKeyNames, [])
+  );
+  globalServiceRegistry.registerInstance(
+    SPAC_UNIT_TERMS_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(SpacUnitTermsSchema, SpacUnitTermsPrimaryKeyNames, [])
   );
 }

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -168,12 +168,15 @@ import {
   CANONICAL_COMPANY_ALIAS_REPOSITORY_TOKEN,
   CANONICAL_PERSON_ALIAS_REPOSITORY_TOKEN,
   CANONICAL_SPONSOR_FAMILY_ALIAS_REPOSITORY_TOKEN,
+  CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN,
   CanonicalCompanyAliasSchema,
   CanonicalCompanyAliasPrimaryKeyNames,
   CanonicalPersonAliasSchema,
   CanonicalPersonAliasPrimaryKeyNames,
   CanonicalSponsorFamilyAliasSchema,
   CanonicalSponsorFamilyAliasPrimaryKeyNames,
+  CanonicalUnderwriterFamilyAliasSchema,
+  CanonicalUnderwriterFamilyAliasPrimaryKeyNames,
 } from "../storage/canonical/CanonicalAliasSchemas";
 import {
   CANONICAL_SPONSOR_FAMILY_REPOSITORY_TOKEN,
@@ -706,6 +709,14 @@ export function resetDependencyInjectionsForTesting() {
       CanonicalUnderwriterFamilySchema,
       CanonicalUnderwriterFamilyPrimaryKeyNames,
       [["resolver_version", "normalized_name"]]
+    )
+  );
+  globalServiceRegistry.registerInstance(
+    CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(
+      CanonicalUnderwriterFamilyAliasSchema,
+      CanonicalUnderwriterFamilyAliasPrimaryKeyNames,
+      [["target_canonical_id"]]
     )
   );
 }

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -201,6 +201,11 @@ import {
   SpacUnitTermsSchema,
 } from "../storage/offering/SpacUnitTermsSchema";
 import {
+  ISSUER_TICKER_REPOSITORY_TOKEN,
+  IssuerTickerPrimaryKeyNames,
+  IssuerTickerSchema,
+} from "../storage/offering/IssuerTickerSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -682,5 +687,12 @@ export function resetDependencyInjectionsForTesting() {
   globalServiceRegistry.registerInstance(
     SPAC_UNIT_TERMS_REPOSITORY_TOKEN,
     new InMemoryTabularStorage(SpacUnitTermsSchema, SpacUnitTermsPrimaryKeyNames, [])
+  );
+  globalServiceRegistry.registerInstance(
+    ISSUER_TICKER_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(IssuerTickerSchema, IssuerTickerPrimaryKeyNames, [
+      ["cik"],
+      ["accession_number"],
+    ])
   );
 }

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -206,6 +206,11 @@ import {
   IssuerTickerSchema,
 } from "../storage/offering/IssuerTickerSchema";
 import {
+  CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN,
+  CanonicalUnderwriterFamilyPrimaryKeyNames,
+  CanonicalUnderwriterFamilySchema,
+} from "../storage/canonical/CanonicalUnderwriterFamilySchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -694,5 +699,13 @@ export function resetDependencyInjectionsForTesting() {
       ["cik"],
       ["accession_number"],
     ])
+  );
+  globalServiceRegistry.registerInstance(
+    CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(
+      CanonicalUnderwriterFamilySchema,
+      CanonicalUnderwriterFamilyPrimaryKeyNames,
+      [["resolver_version", "normalized_name"]]
+    )
   );
 }

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -214,6 +214,11 @@ import {
   CanonicalUnderwriterFamilySchema,
 } from "../storage/canonical/CanonicalUnderwriterFamilySchema";
 import {
+  UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN,
+  UnderwriterFamilyMembershipPrimaryKeyNames,
+  UnderwriterFamilyMembershipSchema,
+} from "../storage/canonical/UnderwriterFamilyMembershipSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -717,6 +722,14 @@ export function resetDependencyInjectionsForTesting() {
       CanonicalUnderwriterFamilyAliasSchema,
       CanonicalUnderwriterFamilyAliasPrimaryKeyNames,
       [["target_canonical_id"]]
+    )
+  );
+  globalServiceRegistry.registerInstance(
+    UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(
+      UnderwriterFamilyMembershipSchema,
+      UnderwriterFamilyMembershipPrimaryKeyNames,
+      [["resolver_version", "canonical_underwriter_family_id"]]
     )
   );
 }

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -191,6 +191,11 @@ import {
   SpacSponsorLinkSchema,
 } from "../storage/canonical/SpacSponsorLinkSchema";
 import {
+  OFFERING_TERMS_REPOSITORY_TOKEN,
+  OfferingTermsPrimaryKeyNames,
+  OfferingTermsSchema,
+} from "../storage/offering/OfferingTermsSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -664,5 +669,9 @@ export function resetDependencyInjectionsForTesting() {
       ["accession_number"],
       ["sponsor_family_id"],
     ])
+  );
+  globalServiceRegistry.registerInstance(
+    OFFERING_TERMS_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(OfferingTermsSchema, OfferingTermsPrimaryKeyNames, [])
   );
 }

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -224,6 +224,11 @@ import {
   UnderwriterLinkSchema,
 } from "../storage/canonical/UnderwriterLinkSchema";
 import {
+  USE_OF_PROCEEDS_REPOSITORY_TOKEN,
+  UseOfProceedsPrimaryKeyNames,
+  UseOfProceedsSchema,
+} from "../storage/use-of-proceeds/UseOfProceedsSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -742,6 +747,12 @@ export function resetDependencyInjectionsForTesting() {
     new InMemoryTabularStorage(UnderwriterLinkSchema, UnderwriterLinkPrimaryKeyNames, [
       ["accession_number"],
       ["underwriter_family_id"],
+    ])
+  );
+  globalServiceRegistry.registerInstance(
+    USE_OF_PROCEEDS_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(UseOfProceedsSchema, UseOfProceedsPrimaryKeyNames, [
+      ["accession_number"],
     ])
   );
 }

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -219,6 +219,11 @@ import {
   UnderwriterFamilyMembershipSchema,
 } from "../storage/canonical/UnderwriterFamilyMembershipSchema";
 import {
+  UNDERWRITER_LINK_REPOSITORY_TOKEN,
+  UnderwriterLinkPrimaryKeyNames,
+  UnderwriterLinkSchema,
+} from "../storage/canonical/UnderwriterLinkSchema";
+import {
   CANONICAL_COMPANY_REPOSITORY_TOKEN,
   CanonicalCompanyPrimaryKeyNames,
   CanonicalCompanySchema,
@@ -731,5 +736,12 @@ export function resetDependencyInjectionsForTesting() {
       UnderwriterFamilyMembershipPrimaryKeyNames,
       [["resolver_version", "canonical_underwriter_family_id"]]
     )
+  );
+  globalServiceRegistry.registerInstance(
+    UNDERWRITER_LINK_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(UnderwriterLinkSchema, UnderwriterLinkPrimaryKeyNames, [
+      ["accession_number"],
+      ["underwriter_family_id"],
+    ])
   );
 }

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -65,6 +65,7 @@ import { ISSUER_TICKER_REPOSITORY_TOKEN } from "../storage/offering/IssuerTicker
 import { CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalUnderwriterFamilySchema";
 import { UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN } from "../storage/canonical/UnderwriterFamilyMembershipSchema";
 import { UNDERWRITER_LINK_REPOSITORY_TOKEN } from "../storage/canonical/UnderwriterLinkSchema";
+import { USE_OF_PROCEEDS_REPOSITORY_TOKEN } from "../storage/use-of-proceeds/UseOfProceedsSchema";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
@@ -173,6 +174,7 @@ export async function setupAllDatabases(): Promise<void> {
     .get(UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN)
     .setupDatabase();
   await globalServiceRegistry.get(UNDERWRITER_LINK_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(USE_OF_PROCEEDS_REPOSITORY_TOKEN).setupDatabase();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
   // isn't sqlite). Tests use the in-memory backend where views don't apply.

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -59,6 +59,7 @@ import { CANONICAL_SPONSOR_FAMILY_REPOSITORY_TOKEN } from "../storage/canonical/
 import { SPONSOR_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN } from "../storage/canonical/SponsorFamilyMembershipSchema";
 import { SPAC_SPONSOR_LINK_REPOSITORY_TOKEN } from "../storage/canonical/SpacSponsorLinkSchema";
 import { OFFERING_TERMS_REPOSITORY_TOKEN } from "../storage/offering/OfferingTermsSchema";
+import { SPAC_UNIT_TERMS_REPOSITORY_TOKEN } from "../storage/offering/SpacUnitTermsSchema";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
@@ -157,6 +158,7 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(SPONSOR_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(SPAC_SPONSOR_LINK_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(OFFERING_TERMS_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(SPAC_UNIT_TERMS_REPOSITORY_TOKEN).setupDatabase();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
   // isn't sqlite). Tests use the in-memory backend where views don't apply.

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -63,6 +63,7 @@ import { OFFERING_TERMS_REPOSITORY_TOKEN } from "../storage/offering/OfferingTer
 import { SPAC_UNIT_TERMS_REPOSITORY_TOKEN } from "../storage/offering/SpacUnitTermsSchema";
 import { ISSUER_TICKER_REPOSITORY_TOKEN } from "../storage/offering/IssuerTickerSchema";
 import { CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalUnderwriterFamilySchema";
+import { UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN } from "../storage/canonical/UnderwriterFamilyMembershipSchema";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
@@ -166,6 +167,9 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry
     .get(CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN)
+    .setupDatabase();
+  await globalServiceRegistry
+    .get(UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN)
     .setupDatabase();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -58,6 +58,7 @@ import {
 import { CANONICAL_SPONSOR_FAMILY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalSponsorFamilySchema";
 import { SPONSOR_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN } from "../storage/canonical/SponsorFamilyMembershipSchema";
 import { SPAC_SPONSOR_LINK_REPOSITORY_TOKEN } from "../storage/canonical/SpacSponsorLinkSchema";
+import { OFFERING_TERMS_REPOSITORY_TOKEN } from "../storage/offering/OfferingTermsSchema";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
@@ -155,6 +156,7 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(CANONICAL_SPONSOR_FAMILY_ALIAS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(SPONSOR_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(SPAC_SPONSOR_LINK_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(OFFERING_TERMS_REPOSITORY_TOKEN).setupDatabase();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
   // isn't sqlite). Tests use the in-memory backend where views don't apply.

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -54,6 +54,7 @@ import {
   CANONICAL_COMPANY_ALIAS_REPOSITORY_TOKEN,
   CANONICAL_PERSON_ALIAS_REPOSITORY_TOKEN,
   CANONICAL_SPONSOR_FAMILY_ALIAS_REPOSITORY_TOKEN,
+  CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN,
 } from "../storage/canonical/CanonicalAliasSchemas";
 import { CANONICAL_SPONSOR_FAMILY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalSponsorFamilySchema";
 import { SPONSOR_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN } from "../storage/canonical/SponsorFamilyMembershipSchema";
@@ -163,6 +164,9 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(SPAC_UNIT_TERMS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(ISSUER_TICKER_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry
+    .get(CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN)
+    .setupDatabase();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
   // isn't sqlite). Tests use the in-memory backend where views don't apply.

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -60,6 +60,7 @@ import { SPONSOR_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN } from "../storage/canonical
 import { SPAC_SPONSOR_LINK_REPOSITORY_TOKEN } from "../storage/canonical/SpacSponsorLinkSchema";
 import { OFFERING_TERMS_REPOSITORY_TOKEN } from "../storage/offering/OfferingTermsSchema";
 import { SPAC_UNIT_TERMS_REPOSITORY_TOKEN } from "../storage/offering/SpacUnitTermsSchema";
+import { ISSUER_TICKER_REPOSITORY_TOKEN } from "../storage/offering/IssuerTickerSchema";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
@@ -159,6 +160,7 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(SPAC_SPONSOR_LINK_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(OFFERING_TERMS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(SPAC_UNIT_TERMS_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(ISSUER_TICKER_REPOSITORY_TOKEN).setupDatabase();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
   // isn't sqlite). Tests use the in-memory backend where views don't apply.

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -61,6 +61,7 @@ import { SPAC_SPONSOR_LINK_REPOSITORY_TOKEN } from "../storage/canonical/SpacSpo
 import { OFFERING_TERMS_REPOSITORY_TOKEN } from "../storage/offering/OfferingTermsSchema";
 import { SPAC_UNIT_TERMS_REPOSITORY_TOKEN } from "../storage/offering/SpacUnitTermsSchema";
 import { ISSUER_TICKER_REPOSITORY_TOKEN } from "../storage/offering/IssuerTickerSchema";
+import { CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalUnderwriterFamilySchema";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
@@ -161,6 +162,7 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(OFFERING_TERMS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(SPAC_UNIT_TERMS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(ISSUER_TICKER_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN).setupDatabase();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
   // isn't sqlite). Tests use the in-memory backend where views don't apply.

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -64,6 +64,7 @@ import { SPAC_UNIT_TERMS_REPOSITORY_TOKEN } from "../storage/offering/SpacUnitTe
 import { ISSUER_TICKER_REPOSITORY_TOKEN } from "../storage/offering/IssuerTickerSchema";
 import { CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalUnderwriterFamilySchema";
 import { UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN } from "../storage/canonical/UnderwriterFamilyMembershipSchema";
+import { UNDERWRITER_LINK_REPOSITORY_TOKEN } from "../storage/canonical/UnderwriterLinkSchema";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
@@ -171,6 +172,7 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry
     .get(UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN)
     .setupDatabase();
+  await globalServiceRegistry.get(UNDERWRITER_LINK_REPOSITORY_TOKEN).setupDatabase();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
   // isn't sqlite). Tests use the in-memory backend where views don't apply.

--- a/src/resolver/FamilyResolver.ts
+++ b/src/resolver/FamilyResolver.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { normalizeCompanyName } from "../storage/company/CompanyNormalization";
+import { AsyncMutex } from "../util/AsyncMutex";
+
+/**
+ * The single source of truth for a family natural key (sponsor or underwriter).
+ * Normalizes the name via {@link normalizeCompanyName} (punctuation/whitespace
+ * canonicalization plus the suffix handling that helper applies), then
+ * lower-cases so matching is case-insensitive. Every caller that looks up a
+ * family by name (resolver, CLI query, alias commands) MUST use this so keys
+ * line up. Returns "" when the name normalizes to nothing.
+ */
+export function normalizeFamilyName(name: string): string {
+  return normalizeCompanyName(name)?.toLowerCase() ?? "";
+}
+
+interface FamilyResolverOptions {
+  /** Resolver-kind discriminator used in the mutex key so kinds never collide. */
+  readonly kind: string;
+  readonly activeResolverVersion: string;
+  /** Find an existing family id for the active resolver version + normalized name. */
+  readonly findIdByNormalizedName: (normalized: string) => Promise<string | undefined>;
+  /** Mint a fresh canonical family row and return its id. */
+  readonly createFamily: (displayName: string, normalized: string) => Promise<string>;
+  /** Resolve a candidate id through the single-hop alias table. */
+  readonly resolveAlias: (id: string) => Promise<string>;
+}
+
+/**
+ * Shared core for the sponsor-family / underwriter-family resolvers: normalize ->
+ * find-or-create at the active resolver version (serialized per key) -> alias
+ * resolve. Name-only analogue of CompanyResolver's normalized-name fallback.
+ */
+export class FamilyResolver {
+  private static readonly _keyMutexes = new Map<string, { mutex: AsyncMutex; refs: number }>();
+
+  constructor(private opts: FamilyResolverOptions) {}
+
+  async resolve(commonName: string): Promise<string> {
+    const normalized = normalizeFamilyName(commonName);
+    if (!normalized) {
+      throw new Error(`cannot resolve ${this.opts.kind} family: empty common name`);
+    }
+    const key = `${this.opts.activeResolverVersion}|${this.opts.kind}-family|${normalized}`;
+
+    let entry = FamilyResolver._keyMutexes.get(key);
+    if (entry === undefined) {
+      entry = { mutex: new AsyncMutex(), refs: 0 };
+      FamilyResolver._keyMutexes.set(key, entry);
+    }
+    entry.refs += 1;
+
+    let candidateId: string;
+    try {
+      candidateId = await entry.mutex.lock(async () => {
+        const existing = await this.opts.findIdByNormalizedName(normalized);
+        if (existing) return existing;
+        return this.opts.createFamily(commonName, normalized);
+      });
+    } finally {
+      entry.refs -= 1;
+      if (entry.refs === 0 && FamilyResolver._keyMutexes.get(key) === entry) {
+        FamilyResolver._keyMutexes.delete(key);
+      }
+    }
+
+    return this.opts.resolveAlias(candidateId);
+  }
+}

--- a/src/resolver/SponsorFamilyResolver.ts
+++ b/src/resolver/SponsorFamilyResolver.ts
@@ -7,8 +7,7 @@
 import { randomUUID } from "node:crypto";
 import type { CanonicalSponsorFamilyRepo } from "../storage/canonical/CanonicalSponsorFamilyRepo";
 import type { CanonicalSponsorFamilyAliasRepo } from "../storage/canonical/CanonicalSponsorFamilyAliasRepo";
-import { normalizeCompanyName } from "../storage/company/CompanyNormalization";
-import { AsyncMutex } from "../util/AsyncMutex";
+import { FamilyResolver, normalizeFamilyName } from "./FamilyResolver";
 
 interface SponsorFamilyResolverOptions {
   canonicalSponsorFamilyRepo: CanonicalSponsorFamilyRepo;
@@ -17,64 +16,53 @@ interface SponsorFamilyResolverOptions {
 }
 
 /**
- * The single source of truth for the sponsor-family natural key. Normalizes the
- * name via {@link normalizeCompanyName} (punctuation/whitespace canonicalization
- * plus the suffix handling that helper applies), then upper-cases so matching is
- * case-insensitive. Every caller that looks up a family by name (resolver, CLI
- * query, alias commands) MUST use this so keys line up. Returns "" when the name
+ * The single source of truth for the sponsor-family natural key. Delegates to
+ * {@link normalizeFamilyName} (punctuation/whitespace canonicalization plus the
+ * suffix handling that helper applies, then lower-casing for case-insensitive
+ * matching). Every caller that looks up a family by name (resolver, CLI query,
+ * alias commands) MUST use this so keys line up. Returns "" when the name
  * normalizes to nothing.
  */
 export function normalizeSponsorFamilyName(name: string): string {
-  return normalizeCompanyName(name)?.toUpperCase() ?? "";
+  return normalizeFamilyName(name);
 }
 
 /**
  * Resolves a sponsor *common* name to a CanonicalSponsorFamily id: normalize ->
  * find-or-create at the active resolver version -> alias resolve. Name-only
- * analogue of CompanyResolver's normalized-name fallback.
+ * analogue of CompanyResolver's normalized-name fallback. Thin wrapper over the
+ * shared {@link FamilyResolver}.
  */
 export class SponsorFamilyResolver {
-  private static readonly _keyMutexes = new Map<string, { mutex: AsyncMutex; refs: number }>();
+  private core: FamilyResolver;
 
-  constructor(private opts: SponsorFamilyResolverOptions) {}
-
-  async resolve(commonName: string): Promise<string> {
-    const normalized = normalizeSponsorFamilyName(commonName);
-    if (!normalized) throw new Error("cannot resolve sponsor family: empty common name");
-    const key = `${this.opts.activeResolverVersion}|sponsor-family|${normalized}`;
-
-    let entry = SponsorFamilyResolver._keyMutexes.get(key);
-    if (entry === undefined) {
-      entry = { mutex: new AsyncMutex(), refs: 0 };
-      SponsorFamilyResolver._keyMutexes.set(key, entry);
-    }
-    entry.refs += 1;
-
-    let candidateId: string;
-    try {
-      candidateId = await entry.mutex.lock(async () => {
-        const existing = await this.opts.canonicalSponsorFamilyRepo.findByResolverAndName(
-          this.opts.activeResolverVersion,
+  constructor(private opts: SponsorFamilyResolverOptions) {
+    this.core = new FamilyResolver({
+      kind: "sponsor",
+      activeResolverVersion: opts.activeResolverVersion,
+      findIdByNormalizedName: async (normalized) => {
+        const existing = await opts.canonicalSponsorFamilyRepo.findByResolverAndName(
+          opts.activeResolverVersion,
           normalized
         );
-        if (existing) return existing.canonical_sponsor_family_id;
+        return existing?.canonical_sponsor_family_id;
+      },
+      createFamily: async (displayName, normalized) => {
         const freshId = randomUUID();
-        await this.opts.canonicalSponsorFamilyRepo.create({
+        await opts.canonicalSponsorFamilyRepo.create({
           canonical_sponsor_family_id: freshId,
-          resolver_version: this.opts.activeResolverVersion,
-          display_name: commonName,
+          resolver_version: opts.activeResolverVersion,
+          display_name: displayName,
           normalized_name: normalized,
           created_at: new Date().toISOString(),
         });
         return freshId;
-      });
-    } finally {
-      entry.refs -= 1;
-      if (entry.refs === 0 && SponsorFamilyResolver._keyMutexes.get(key) === entry) {
-        SponsorFamilyResolver._keyMutexes.delete(key);
-      }
-    }
+      },
+      resolveAlias: (id) => opts.canonicalSponsorFamilyAliasRepo.resolve(id),
+    });
+  }
 
-    return this.opts.canonicalSponsorFamilyAliasRepo.resolve(candidateId);
+  async resolve(commonName: string): Promise<string> {
+    return this.core.resolve(commonName);
   }
 }

--- a/src/resolver/UnderwriterFamilyResolver.test.ts
+++ b/src/resolver/UnderwriterFamilyResolver.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../config/TestingDI";
+import { CanonicalUnderwriterFamilyRepo } from "../storage/canonical/CanonicalUnderwriterFamilyRepo";
+import { CanonicalUnderwriterFamilyAliasRepo } from "../storage/canonical/CanonicalUnderwriterFamilyAliasRepo";
+import { UnderwriterFamilyResolver } from "./UnderwriterFamilyResolver";
+
+describe("UnderwriterFamilyResolver", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+
+  it("creates one family per normalized common name and reuses it", async () => {
+    const resolver = new UnderwriterFamilyResolver({
+      canonicalUnderwriterFamilyRepo: new CanonicalUnderwriterFamilyRepo(),
+      canonicalUnderwriterFamilyAliasRepo: new CanonicalUnderwriterFamilyAliasRepo(),
+      activeResolverVersion: "1.0.0",
+    });
+    const a = await resolver.resolve("Goldman Sachs");
+    const b = await resolver.resolve("GOLDMAN   SACHS");
+    expect(a).toBe(b);
+  });
+
+  it("follows an alias to the merged family", async () => {
+    const families = new CanonicalUnderwriterFamilyRepo();
+    const aliases = new CanonicalUnderwriterFamilyAliasRepo();
+    const resolver = new UnderwriterFamilyResolver({
+      canonicalUnderwriterFamilyRepo: families,
+      canonicalUnderwriterFamilyAliasRepo: aliases,
+      activeResolverVersion: "1.0.0",
+    });
+    const x = await resolver.resolve("Morgan Stanley");
+    const y = await resolver.resolve("Morgan Stanley & Co.");
+    await aliases.add(y, x, "variant", "op");
+    expect(await resolver.resolve("Morgan Stanley & Co.")).toBe(x);
+  });
+});

--- a/src/resolver/UnderwriterFamilyResolver.ts
+++ b/src/resolver/UnderwriterFamilyResolver.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from "node:crypto";
+import type { CanonicalUnderwriterFamilyRepo } from "../storage/canonical/CanonicalUnderwriterFamilyRepo";
+import type { CanonicalUnderwriterFamilyAliasRepo } from "../storage/canonical/CanonicalUnderwriterFamilyAliasRepo";
+import { normalizeCompanyName } from "../storage/company/CompanyNormalization";
+import { AsyncMutex } from "../util/AsyncMutex";
+
+/** Shared normalization so the CLI and the extractor key families identically. */
+export function normalizeUnderwriterFamilyName(name: string): string {
+  return normalizeCompanyName(name)?.toLowerCase() ?? "";
+}
+
+interface UnderwriterFamilyResolverOptions {
+  canonicalUnderwriterFamilyRepo: CanonicalUnderwriterFamilyRepo;
+  canonicalUnderwriterFamilyAliasRepo: CanonicalUnderwriterFamilyAliasRepo;
+  activeResolverVersion: string;
+}
+
+/**
+ * Resolves an underwriter *common* name to a CanonicalUnderwriterFamily id:
+ * normalize → find-or-create at the active resolver version → alias resolve.
+ * Name-only analogue of SponsorFamilyResolver.
+ */
+export class UnderwriterFamilyResolver {
+  private static readonly _keyMutexes = new Map<string, { mutex: AsyncMutex; refs: number }>();
+
+  constructor(private opts: UnderwriterFamilyResolverOptions) {}
+
+  async resolve(commonName: string): Promise<string> {
+    const normalized = normalizeUnderwriterFamilyName(commonName);
+    if (!normalized) throw new Error("cannot resolve underwriter family: empty common name");
+    const key = `${this.opts.activeResolverVersion}|underwriter-family|${normalized}`;
+
+    let entry = UnderwriterFamilyResolver._keyMutexes.get(key);
+    if (entry === undefined) {
+      entry = { mutex: new AsyncMutex(), refs: 0 };
+      UnderwriterFamilyResolver._keyMutexes.set(key, entry);
+    }
+    entry.refs += 1;
+
+    let candidateId: string;
+    try {
+      candidateId = await entry.mutex.lock(async () => {
+        const existing = await this.opts.canonicalUnderwriterFamilyRepo.findByResolverAndName(
+          this.opts.activeResolverVersion,
+          normalized
+        );
+        if (existing) return existing.canonical_underwriter_family_id;
+        const freshId = randomUUID();
+        await this.opts.canonicalUnderwriterFamilyRepo.create({
+          canonical_underwriter_family_id: freshId,
+          resolver_version: this.opts.activeResolverVersion,
+          display_name: commonName,
+          normalized_name: normalized,
+          created_at: new Date().toISOString(),
+        });
+        return freshId;
+      });
+    } finally {
+      entry.refs -= 1;
+      if (entry.refs === 0 && UnderwriterFamilyResolver._keyMutexes.get(key) === entry) {
+        UnderwriterFamilyResolver._keyMutexes.delete(key);
+      }
+    }
+
+    return this.opts.canonicalUnderwriterFamilyAliasRepo.resolve(candidateId);
+  }
+}

--- a/src/resolver/UnderwriterFamilyResolver.ts
+++ b/src/resolver/UnderwriterFamilyResolver.ts
@@ -7,12 +7,11 @@
 import { randomUUID } from "node:crypto";
 import type { CanonicalUnderwriterFamilyRepo } from "../storage/canonical/CanonicalUnderwriterFamilyRepo";
 import type { CanonicalUnderwriterFamilyAliasRepo } from "../storage/canonical/CanonicalUnderwriterFamilyAliasRepo";
-import { normalizeCompanyName } from "../storage/company/CompanyNormalization";
-import { AsyncMutex } from "../util/AsyncMutex";
+import { FamilyResolver, normalizeFamilyName } from "./FamilyResolver";
 
 /** Shared normalization so the CLI and the extractor key families identically. */
 export function normalizeUnderwriterFamilyName(name: string): string {
-  return normalizeCompanyName(name)?.toLowerCase() ?? "";
+  return normalizeFamilyName(name);
 }
 
 interface UnderwriterFamilyResolverOptions {
@@ -24,50 +23,39 @@ interface UnderwriterFamilyResolverOptions {
 /**
  * Resolves an underwriter *common* name to a CanonicalUnderwriterFamily id:
  * normalize → find-or-create at the active resolver version → alias resolve.
- * Name-only analogue of SponsorFamilyResolver.
+ * Name-only analogue of SponsorFamilyResolver. Thin wrapper over the shared
+ * {@link FamilyResolver}.
  */
 export class UnderwriterFamilyResolver {
-  private static readonly _keyMutexes = new Map<string, { mutex: AsyncMutex; refs: number }>();
+  private core: FamilyResolver;
 
-  constructor(private opts: UnderwriterFamilyResolverOptions) {}
-
-  async resolve(commonName: string): Promise<string> {
-    const normalized = normalizeUnderwriterFamilyName(commonName);
-    if (!normalized) throw new Error("cannot resolve underwriter family: empty common name");
-    const key = `${this.opts.activeResolverVersion}|underwriter-family|${normalized}`;
-
-    let entry = UnderwriterFamilyResolver._keyMutexes.get(key);
-    if (entry === undefined) {
-      entry = { mutex: new AsyncMutex(), refs: 0 };
-      UnderwriterFamilyResolver._keyMutexes.set(key, entry);
-    }
-    entry.refs += 1;
-
-    let candidateId: string;
-    try {
-      candidateId = await entry.mutex.lock(async () => {
-        const existing = await this.opts.canonicalUnderwriterFamilyRepo.findByResolverAndName(
-          this.opts.activeResolverVersion,
+  constructor(private opts: UnderwriterFamilyResolverOptions) {
+    this.core = new FamilyResolver({
+      kind: "underwriter",
+      activeResolverVersion: opts.activeResolverVersion,
+      findIdByNormalizedName: async (normalized) => {
+        const existing = await opts.canonicalUnderwriterFamilyRepo.findByResolverAndName(
+          opts.activeResolverVersion,
           normalized
         );
-        if (existing) return existing.canonical_underwriter_family_id;
+        return existing?.canonical_underwriter_family_id;
+      },
+      createFamily: async (displayName, normalized) => {
         const freshId = randomUUID();
-        await this.opts.canonicalUnderwriterFamilyRepo.create({
+        await opts.canonicalUnderwriterFamilyRepo.create({
           canonical_underwriter_family_id: freshId,
-          resolver_version: this.opts.activeResolverVersion,
-          display_name: commonName,
+          resolver_version: opts.activeResolverVersion,
+          display_name: displayName,
           normalized_name: normalized,
           created_at: new Date().toISOString(),
         });
         return freshId;
-      });
-    } finally {
-      entry.refs -= 1;
-      if (entry.refs === 0 && UnderwriterFamilyResolver._keyMutexes.get(key) === entry) {
-        UnderwriterFamilyResolver._keyMutexes.delete(key);
-      }
-    }
+      },
+      resolveAlias: (id) => opts.canonicalUnderwriterFamilyAliasRepo.resolve(id),
+    });
+  }
 
-    return this.opts.canonicalUnderwriterFamilyAliasRepo.resolve(candidateId);
+  async resolve(commonName: string): Promise<string> {
+    return this.core.resolve(commonName);
   }
 }

--- a/src/resolver/resolverIds.test.ts
+++ b/src/resolver/resolverIds.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "bun:test";
 import { RESOLVER_IDS } from "./resolverIds";
 
 describe("resolverIds", () => {
-  it("contains person, company, and sponsor-family", () => {
-    expect(RESOLVER_IDS).toEqual(["person", "company", "sponsor-family"]);
+  it("contains person, company, sponsor-family, and underwriter-family", () => {
+    expect(RESOLVER_IDS).toEqual(["person", "company", "sponsor-family", "underwriter-family"]);
   });
 });

--- a/src/resolver/resolverIds.ts
+++ b/src/resolver/resolverIds.ts
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const RESOLVER_IDS = ["person", "company", "sponsor-family"] as const;
+export const RESOLVER_IDS = ["person", "company", "sponsor-family", "underwriter-family"] as const;
 export type ResolverId = (typeof RESOLVER_IDS)[number];

--- a/src/resolver/resolverIds.ts
+++ b/src/resolver/resolverIds.ts
@@ -6,3 +6,19 @@
 
 export const RESOLVER_IDS = ["person", "company", "sponsor-family", "underwriter-family"] as const;
 export type ResolverId = (typeof RESOLVER_IDS)[number];
+
+/**
+ * Resolver kinds that operate on the *family* tier (a name-only canonical +
+ * membership model) rather than the person/company observation → identity-link
+ * model. The observation-coverage query, the batch `resolve` command, and the
+ * `drop-previous` purge ceremony are built around identity links and do **not**
+ * yet support these kinds; callers must branch on this so a family kind is never
+ * silently treated as the company tier.
+ */
+export const FAMILY_RESOLVER_IDS = ["sponsor-family", "underwriter-family"] as const;
+
+/** True when `id` is a family-tier resolver kind (see {@link FAMILY_RESOLVER_IDS}). */
+export function isFamilyResolverId(id: string): boolean {
+  return (FAMILY_RESOLVER_IDS as readonly string[]).includes(id);
+}
+

--- a/src/sec/forms/registration-statements/Form_S_1.storage.offering.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.offering.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../../config/TestingDI";
+import { setupAllDatabases } from "../../../config/setupAllDatabases";
+import { processFormS1 } from "./Form_S_1.storage";
+import { OfferingTermsRepo } from "../../../storage/offering/OfferingTermsRepo";
+import { SpacUnitTermsRepo } from "../../../storage/offering/SpacUnitTermsRepo";
+import { IssuerTickerRepo } from "../../../storage/offering/IssuerTickerRepo";
+import { fakeS1Model, registerFakeStructuredProvider } from "./s1/testing/fakeStructuredProvider";
+
+const OFFERING_HTML = [
+  "<h1>THE OFFERING</h1><p>We are offering 5,000,000 shares.</p>",
+  "<h1>UNDERWRITING</h1><p>Goldman Sachs &amp; Co. LLC is the representative.</p>",
+].join("");
+
+const SPAC_HEADER = {
+  sic: 6770,
+  sicDescription: "BLANK CHECKS",
+  cik: 1848507,
+  companyName: "Acme Acquisition Corp",
+  filingDate: "20260102",
+};
+const NULL_HEADER = { sic: null, sicDescription: null, cik: null, companyName: null, filingDate: null };
+
+let cleanup: (() => void) | undefined;
+
+describe("processFormS1 offering terms", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("writes equity offering terms + tickers for a non-SPAC filing", async () => {
+    // Sections present: The Offering + Underwriting -> offering-terms (1st call),
+    // then underwriters (2nd call). Use-of-proceeds absent. Sponsors gated off.
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        security_type: "Common Stock",
+        shares_offered: 5000000,
+        price: null,
+        price_low: 14,
+        price_high: 16,
+        gross_proceeds: 75000000,
+        net_proceeds: 69000000,
+        over_allotment_shares: 750000,
+        units_offered: null,
+        price_per_unit: null,
+        unit_composition: null,
+        warrant_fraction_per_unit: null,
+        right_fraction_per_unit: null,
+        trust_per_unit: null,
+        over_allotment_units: null,
+        exchange: "NASDAQ",
+        par_value: 0.0001,
+        confidence: 0.9,
+        source_span: "5,000,000 shares",
+        tickers: [{ ticker: "ACME", exchange: "NASDAQ", security_type: "Common Stock", is_primary: true }],
+      },
+      { underwriters: [] },
+    ]);
+    cleanup = unregister;
+
+    await processFormS1({
+      cik: 1018724,
+      file_number: "333-1",
+      accession_number: "0000000000-26-000001",
+      filing_date: "2026-01-02",
+      primary_doc: "s1.htm",
+      form: "S-1",
+      formS1: { header: NULL_HEADER, html: OFFERING_HTML },
+      model: fakeS1Model(),
+    });
+
+    const terms = await new OfferingTermsRepo().get("S-1", "0000000000-26-000001");
+    expect(terms?.price_high).toBe(16);
+    expect(terms?.ticker).toBe("ACME");
+    const history = await new IssuerTickerRepo().history(1018724);
+    expect(history.map((t) => t.ticker)).toEqual(["ACME"]);
+  });
+
+  it("writes SPAC unit terms + multiple tickers for a SPAC filing", async () => {
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        security_type: "Units",
+        shares_offered: null,
+        price: null,
+        price_low: null,
+        price_high: null,
+        gross_proceeds: 200000000,
+        net_proceeds: null,
+        over_allotment_shares: null,
+        units_offered: 20000000,
+        price_per_unit: 10,
+        unit_composition: "one share and one-half warrant",
+        warrant_fraction_per_unit: 0.5,
+        right_fraction_per_unit: null,
+        trust_per_unit: 10.1,
+        over_allotment_units: 3000000,
+        exchange: "NASDAQ",
+        par_value: null,
+        confidence: 0.9,
+        source_span: "each unit",
+        tickers: [
+          { ticker: "ACQU", exchange: "NASDAQ", security_type: "Units", is_primary: true },
+          { ticker: "ACQ", exchange: "NASDAQ", security_type: "Class A", is_primary: false },
+          { ticker: "ACQW", exchange: "NASDAQ", security_type: "Warrants", is_primary: false },
+        ],
+      },
+      { underwriters: [] },
+    ]);
+    cleanup = unregister;
+
+    await processFormS1({
+      cik: 1848507,
+      file_number: "333-2",
+      accession_number: "0000000000-26-000002",
+      filing_date: "2026-01-02",
+      primary_doc: "s1.htm",
+      form: "S-1",
+      formS1: { header: SPAC_HEADER, html: OFFERING_HTML },
+      model: fakeS1Model(),
+    });
+
+    const unit = await new SpacUnitTermsRepo().get("S-1", "0000000000-26-000002");
+    expect(unit?.warrant_fraction_per_unit).toBe(0.5);
+    expect(unit?.trust_per_unit).toBe(10.1);
+    expect(await new OfferingTermsRepo().get("S-1", "0000000000-26-000002")).toBeUndefined();
+    const history = await new IssuerTickerRepo().history(1848507);
+    expect(history.map((t) => t.ticker).sort()).toEqual(["ACQ", "ACQU", "ACQW"]);
+  });
+});

--- a/src/sec/forms/registration-statements/Form_S_1.storage.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.test.ts
@@ -118,7 +118,13 @@ describe("processFormS1", () => {
     expect(tx[0].amount).toBe(120000);
 
     const dl = await new ExtractionDeadLetterRepo().listPending("S-1");
-    expect(dl).toHaveLength(0);
+    // The Offering / Underwriting / Use of Proceeds headings are absent from this
+    // fixture, so those three sections dead-letter as SECTION_NOT_FOUND.
+    expect(dl.map((d) => d.section_name).sort()).toEqual([
+      "offering-terms",
+      "underwriters",
+      "use-of-proceeds",
+    ]);
   });
 
   it("dead-letters a section that yields no rows", async () => {

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -36,6 +36,11 @@ import { SpacSponsorLinkRepo } from "../../../storage/canonical/SpacSponsorLinkR
 import { OfferingTermsRepo } from "../../../storage/offering/OfferingTermsRepo";
 import { SpacUnitTermsRepo } from "../../../storage/offering/SpacUnitTermsRepo";
 import { IssuerTickerRepo } from "../../../storage/offering/IssuerTickerRepo";
+import { CanonicalUnderwriterFamilyRepo } from "../../../storage/canonical/CanonicalUnderwriterFamilyRepo";
+import { CanonicalUnderwriterFamilyAliasRepo } from "../../../storage/canonical/CanonicalUnderwriterFamilyAliasRepo";
+import { UnderwriterFamilyResolver } from "../../../resolver/UnderwriterFamilyResolver";
+import { UnderwriterFamilyMembershipRepo } from "../../../storage/canonical/UnderwriterFamilyMembershipRepo";
+import { UnderwriterLinkRepo } from "../../../storage/canonical/UnderwriterLinkRepo";
 import type { FormS1Parsed } from "./Form_S_1";
 import { parseEdgarHtml } from "../../html/parseEdgarHtml";
 import { DocumentTreeSegmenter } from "./s1/DocumentTreeSegmenter";
@@ -46,6 +51,7 @@ import {
   extractOfferingTerms,
   extractRelatedParty,
   extractSpacSponsors,
+  extractUnderwriters,
 } from "./s1/sectionExtractors";
 import { getS1Model } from "./s1/s1Model";
 import { splitPersonName } from "./s1/splitName";
@@ -83,16 +89,19 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
   const versionRegistry = new VersionRegistry(
     globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN)
   );
-  const [extractorSlot, personSlot, companySlot, sponsorFamilySlot] = await Promise.all([
-    getActiveSlot(versionRegistry, "extractor", EXTRACTOR_ID),
-    getActiveSlot(versionRegistry, "resolver", "person"),
-    getActiveSlot(versionRegistry, "resolver", "company"),
-    getActiveSlot(versionRegistry, "resolver", "sponsor-family"),
-  ]);
+  const [extractorSlot, personSlot, companySlot, sponsorFamilySlot, underwriterFamilySlot] =
+    await Promise.all([
+      getActiveSlot(versionRegistry, "extractor", EXTRACTOR_ID),
+      getActiveSlot(versionRegistry, "resolver", "person"),
+      getActiveSlot(versionRegistry, "resolver", "company"),
+      getActiveSlot(versionRegistry, "resolver", "sponsor-family"),
+      getActiveSlot(versionRegistry, "resolver", "underwriter-family"),
+    ]);
   const extractor_version = extractorSlot?.semver ?? "1.0.0";
   const activeResolverPersonVersion = personSlot?.semver ?? "1.0.0";
   const activeResolverCompanyVersion = companySlot?.semver ?? "1.0.0";
   const activeSponsorFamilyVersion = sponsorFamilySlot?.semver ?? "1.0.0";
+  const activeUnderwriterFamilyVersion = underwriterFamilySlot?.semver ?? "1.0.0";
 
   const personResolver = new PersonResolver({
     canonicalPersonRepo: new CanonicalPersonRepo(),
@@ -136,10 +145,19 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
   const spacUnitTermsRepo = new SpacUnitTermsRepo();
   const issuerTickerRepo = new IssuerTickerRepo();
 
+  const underwriterFamilyResolver = new UnderwriterFamilyResolver({
+    canonicalUnderwriterFamilyRepo: new CanonicalUnderwriterFamilyRepo(),
+    canonicalUnderwriterFamilyAliasRepo: new CanonicalUnderwriterFamilyAliasRepo(),
+    activeResolverVersion: activeUnderwriterFamilyVersion,
+  });
+  const underwriterMembershipRepo = new UnderwriterFamilyMembershipRepo();
+  const underwriterLinkRepo = new UnderwriterLinkRepo();
+
   await ownershipRepo.clear(accession_number);
   await relatedRepo.clear(accession_number);
   await linkRepo.clear(accession_number);
   await issuerTickerRepo.clear(accession_number);
+  await underwriterLinkRepo.clear(accession_number);
 
   const base = { accession_number, extractor_id: EXTRACTOR_ID, extractor_version };
   let idx = 0;
@@ -494,6 +512,103 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
         extractor_id: EXTRACTOR_ID,
         accession_number,
         section_name: "offering-terms",
+        reason_code: "MODEL_INVALID_OUTPUT",
+        detail: (e instanceof Error ? e.message : String(e)).slice(0, 1024),
+        failed_extractor_version: extractor_version,
+        source_run_id: null,
+      });
+    }
+  }
+
+  // --- Underwriters (Underwriting section; all filings) ---
+  const underwritingText = byName.get(S1_SECTIONS.UNDERWRITING);
+  if (underwritingText === undefined) {
+    await deadLetters.record({
+      extractor_id: EXTRACTOR_ID,
+      accession_number,
+      section_name: "underwriters",
+      reason_code: "SECTION_NOT_FOUND",
+      detail: null,
+      failed_extractor_version: extractor_version,
+      source_run_id: null,
+    });
+  } else {
+    try {
+      const raw = await extractUnderwriters(underwritingText, model);
+      const rows = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
+      if (rows.length === 0) {
+        await deadLetters.record({
+          extractor_id: EXTRACTOR_ID,
+          accession_number,
+          section_name: "underwriters",
+          reason_code: raw.length === 0 ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
+          detail: raw.length === 0 ? "no underwriters returned" : "all rows below confidence floor",
+          failed_extractor_version: extractor_version,
+          source_run_id: null,
+        });
+      } else {
+        let wrote = 0;
+        for (const r of rows) {
+          const legalName = r.legal_name?.trim() ?? "";
+          const commonName = r.common_name?.trim() ?? "";
+          if (legalName === "" || commonName === "") continue;
+          const observation_index = idx++;
+          const { observation_id, canonical_company_id } = await observer.observeCompany({
+            ...base,
+            observation_index,
+            name: legalName,
+            source_context: JSON.stringify({ relation: "s1:underwriter" }),
+          });
+          await provenance.save({
+            kind: "company",
+            observation_id,
+            confidence: r.confidence,
+            source_span: r.source_span,
+            section_name: "underwriters",
+            model_id,
+            prompt_version: extractor_version,
+            extra: null,
+          });
+          const underwriter_family_id = await underwriterFamilyResolver.resolve(commonName);
+          await underwriterMembershipRepo.record({
+            resolver_version: activeUnderwriterFamilyVersion,
+            canonical_company_id,
+            canonical_underwriter_family_id: underwriter_family_id,
+            seen_at: new Date().toISOString(),
+          });
+          await underwriterLinkRepo.save({
+            accession_number,
+            extractor_id: EXTRACTOR_ID,
+            observation_index,
+            issuer_cik: cik,
+            underwriter_canonical_company_id: canonical_company_id,
+            underwriter_family_id,
+            role_detail: r.role,
+            shares_allocated: r.shares_allocated,
+            over_allotment_shares: r.over_allotment_shares,
+            resolver_version: activeUnderwriterFamilyVersion,
+          });
+          wrote++;
+        }
+        if (wrote === 0) {
+          await deadLetters.record({
+            extractor_id: EXTRACTOR_ID,
+            accession_number,
+            section_name: "underwriters",
+            reason_code: "MODEL_INVALID_OUTPUT",
+            detail: "no underwriter rows had usable legal and common names",
+            failed_extractor_version: extractor_version,
+            source_run_id: null,
+          });
+        } else {
+          await deadLetters.markResolved(EXTRACTOR_ID, accession_number, "underwriters");
+        }
+      }
+    } catch (e) {
+      await deadLetters.record({
+        extractor_id: EXTRACTOR_ID,
+        accession_number,
+        section_name: "underwriters",
         reason_code: "MODEL_INVALID_OUTPUT",
         detail: (e instanceof Error ? e.message : String(e)).slice(0, 1024),
         failed_extractor_version: extractor_version,

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -41,6 +41,7 @@ import { CanonicalUnderwriterFamilyAliasRepo } from "../../../storage/canonical/
 import { UnderwriterFamilyResolver } from "../../../resolver/UnderwriterFamilyResolver";
 import { UnderwriterFamilyMembershipRepo } from "../../../storage/canonical/UnderwriterFamilyMembershipRepo";
 import { UnderwriterLinkRepo } from "../../../storage/canonical/UnderwriterLinkRepo";
+import { UseOfProceedsRepo } from "../../../storage/use-of-proceeds/UseOfProceedsRepo";
 import type { FormS1Parsed } from "./Form_S_1";
 import { parseEdgarHtml } from "../../html/parseEdgarHtml";
 import { DocumentTreeSegmenter } from "./s1/DocumentTreeSegmenter";
@@ -52,6 +53,7 @@ import {
   extractRelatedParty,
   extractSpacSponsors,
   extractUnderwriters,
+  extractUseOfProceeds,
 } from "./s1/sectionExtractors";
 import { getS1Model } from "./s1/s1Model";
 import { splitPersonName } from "./s1/splitName";
@@ -152,12 +154,14 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
   });
   const underwriterMembershipRepo = new UnderwriterFamilyMembershipRepo();
   const underwriterLinkRepo = new UnderwriterLinkRepo();
+  const useOfProceedsRepo = new UseOfProceedsRepo();
 
   await ownershipRepo.clear(accession_number);
   await relatedRepo.clear(accession_number);
   await linkRepo.clear(accession_number);
   await issuerTickerRepo.clear(accession_number);
   await underwriterLinkRepo.clear(accession_number);
+  await useOfProceedsRepo.clear(accession_number);
 
   const base = { accession_number, extractor_id: EXTRACTOR_ID, extractor_version };
   let idx = 0;
@@ -617,6 +621,65 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
     }
   }
 
+  // --- Use of proceeds ---
+  const proceedsText = byName.get(S1_SECTIONS.USE_OF_PROCEEDS);
+  if (proceedsText === undefined) {
+    await deadLetters.record({
+      extractor_id: EXTRACTOR_ID,
+      accession_number,
+      section_name: "use-of-proceeds",
+      reason_code: "SECTION_NOT_FOUND",
+      detail: null,
+      failed_extractor_version: extractor_version,
+      source_run_id: null,
+    });
+  } else {
+    try {
+      const raw = await extractUseOfProceeds(proceedsText, model);
+      const rows = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
+      if (rows.length === 0) {
+        await deadLetters.record({
+          extractor_id: EXTRACTOR_ID,
+          accession_number,
+          section_name: "use-of-proceeds",
+          reason_code: raw.length === 0 ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
+          detail: raw.length === 0 ? "no line items returned" : "all rows below confidence floor",
+          failed_extractor_version: extractor_version,
+          source_run_id: null,
+        });
+      } else {
+        const now = new Date().toISOString();
+        let lineIndex = 0;
+        for (const r of rows) {
+          await useOfProceedsRepo.save({
+            extractor_id: EXTRACTOR_ID,
+            accession_number,
+            line_index: lineIndex++,
+            cik,
+            purpose: r.purpose,
+            amount: r.amount,
+            percent: r.percent,
+            note: r.note,
+            confidence: r.confidence,
+            source_span: r.source_span,
+            created_at: now,
+          });
+        }
+        await deadLetters.markResolved(EXTRACTOR_ID, accession_number, "use-of-proceeds");
+      }
+    } catch (e) {
+      await deadLetters.record({
+        extractor_id: EXTRACTOR_ID,
+        accession_number,
+        section_name: "use-of-proceeds",
+        reason_code: "MODEL_INVALID_OUTPUT",
+        detail: (e instanceof Error ? e.message : String(e)).slice(0, 1024),
+        failed_extractor_version: extractor_version,
+        source_run_id: null,
+      });
+    }
+  }
+
   // --- SPAC sponsors (gated on deterministic classification) ---
   if (isSpac) {
     // v1 strategy: sponsor names are not under a single canonical heading, so we
@@ -626,7 +689,10 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
     // heading matched, in which case there is no text to extract from and we
     // dead-letter the sponsor step as SECTION_NOT_FOUND. A future spec may add a
     // focused "The Sponsor" section to the segmenter (see design doc Future work).
-    const sponsorText = [...byName.values()].join("\n\n");
+    // Prefer the focused "The Sponsor" section; fall back to the concatenated
+    // target sections when that heading is absent (legacy v1 behavior).
+    const sponsorText =
+      byName.get(S1_SECTIONS.THE_SPONSOR) ?? [...byName.values()].join("\n\n");
     if (sponsorText.trim() === "") {
       await deadLetters.record({
         extractor_id: EXTRACTOR_ID,

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -682,15 +682,10 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
 
   // --- SPAC sponsors (gated on deterministic classification) ---
   if (isSpac) {
-    // v1 strategy: sponsor names are not under a single canonical heading, so we
-    // run the extractor over the concatenated text of the target sections we
-    // already segmented (management / ownership / related-party) rather than
-    // adding a dedicated segmenter section. `byName` is empty only when no target
-    // heading matched, in which case there is no text to extract from and we
-    // dead-letter the sponsor step as SECTION_NOT_FOUND. A future spec may add a
-    // focused "The Sponsor" section to the segmenter (see design doc Future work).
-    // Prefer the focused "The Sponsor" section; fall back to the concatenated
-    // target sections when that heading is absent (legacy v1 behavior).
+    // Prefer the dedicated "The Sponsor" section when the segmenter found it;
+    // fall back to the concatenated target sections (management / ownership /
+    // related-party) when that heading is absent. `byName` is empty only when no
+    // target heading matched at all, in which case we dead-letter as SECTION_NOT_FOUND.
     const sponsorText =
       byName.get(S1_SECTIONS.THE_SPONSOR) ?? [...byName.values()].join("\n\n");
     if (sponsorText.trim() === "") {

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -64,6 +64,16 @@ const RAW_CONFIDENCE_FLOOR = Number(process.env.SEC_S1_CONFIDENCE_FLOOR ?? "0");
 // always false — silently dropping every row. Fall back to 0 (no floor).
 const CONFIDENCE_FLOOR = Number.isFinite(RAW_CONFIDENCE_FLOOR) ? RAW_CONFIDENCE_FLOOR : 0;
 
+/**
+ * Share/unit counts are emitted by the model as plain numbers but stored in
+ * integer-typed columns. Round a finite value to the nearest integer (a stray
+ * decimal would otherwise be rejected on write and dead-letter the whole
+ * section); pass through null.
+ */
+function toIntCount(n: number | null | undefined): number | null {
+  return n == null || !Number.isFinite(n) ? null : Math.round(n);
+}
+
 export interface ProcessFormS1Args {
   readonly cik: number;
   readonly file_number: string;
@@ -456,13 +466,13 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
             extractor_id: EXTRACTOR_ID,
             accession_number,
             cik,
-            units_offered: terms.units_offered,
+            units_offered: toIntCount(terms.units_offered),
             price_per_unit: terms.price_per_unit,
             unit_composition: terms.unit_composition,
             warrant_fraction_per_unit: terms.warrant_fraction_per_unit,
             right_fraction_per_unit: terms.right_fraction_per_unit,
             trust_per_unit: terms.trust_per_unit,
-            over_allotment_units: terms.over_allotment_units,
+            over_allotment_units: toIntCount(terms.over_allotment_units),
             exchange: terms.exchange,
             ticker: terms.tickers.find((t) => t.is_primary)?.ticker ?? null,
             gross_proceeds: terms.gross_proceeds,
@@ -477,13 +487,13 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
             accession_number,
             cik,
             security_type: terms.security_type,
-            shares_offered: terms.shares_offered,
+            shares_offered: toIntCount(terms.shares_offered),
             price: terms.price,
             price_low: terms.price_low,
             price_high: terms.price_high,
             gross_proceeds: terms.gross_proceeds,
             net_proceeds: terms.net_proceeds,
-            over_allotment_shares: terms.over_allotment_shares,
+            over_allotment_shares: toIntCount(terms.over_allotment_shares),
             exchange: terms.exchange,
             ticker: terms.tickers.find((t) => t.is_primary)?.ticker ?? null,
             par_value: terms.par_value,
@@ -588,8 +598,8 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
             underwriter_canonical_company_id: canonical_company_id,
             underwriter_family_id,
             role_detail: r.role,
-            shares_allocated: r.shares_allocated,
-            over_allotment_shares: r.over_allotment_shares,
+            shares_allocated: toIntCount(r.shares_allocated),
+            over_allotment_shares: toIntCount(r.over_allotment_shares),
             resolver_version: activeUnderwriterFamilyVersion,
           });
           wrote++;

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -226,571 +226,461 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
   const recordOk = (section: S1SectionName) =>
     deadLetters.markResolved(EXTRACTOR_ID, accession_number, section);
 
-  // --- Management ---
-  const mgmt = byName.get(S1_SECTIONS.MANAGEMENT);
-  if (mgmt === undefined) {
-    await recordFail(S1_SECTIONS.MANAGEMENT, "SECTION_NOT_FOUND", null);
-  } else {
+  /**
+   * Shared per-section ceremony: resolve text, dead-letter when absent, run the
+   * extractor, apply the confidence floor, persist surviving rows, and emit the
+   * resolved / empty / low-confidence / invalid-output dead letters. All seven
+   * S-1 sections funnel through here so the policy lives in exactly one place.
+   *
+   * `section_name` doubles as the dead-letter `section_name`; it is the
+   * `S1SectionName` for the entity sections and a literal string for the
+   * derived offering / underwriter / proceeds / sponsor sections.
+   */
+  async function runSection<TRow extends { confidence: number }>(sargs: {
+    sectionName: string;
+    text: string | undefined;
+    skip?: boolean;
+    notFoundDetail?: string | null;
+    emptyDetail: string;
+    lowConfidenceDetail: string;
+    // When set, a persist that writes 0 of N rows (e.g. all underwriter/sponsor
+    // rows had blank names) dead-letters MODEL_INVALID_OUTPUT. Omit for sections
+    // whose persist always writes every confident row, so they always markResolved.
+    invalidWriteDetail?: string;
+    extract: (text: string) => Promise<TRow[]>;
+    persist: (rows: TRow[]) => Promise<number>;
+  }): Promise<void> {
+    if (sargs.skip) return;
+
+    const record = (reason: string, detail: string | null) =>
+      deadLetters.record({
+        extractor_id: EXTRACTOR_ID,
+        accession_number,
+        section_name: sargs.sectionName,
+        reason_code: reason,
+        detail,
+        failed_extractor_version: extractor_version,
+        source_run_id: null,
+      });
+
+    if (sargs.text === undefined || sargs.text.trim() === "") {
+      await record("SECTION_NOT_FOUND", sargs.notFoundDetail ?? null);
+      return;
+    }
+
     try {
-      const raw = await extractManagement(mgmt, model);
+      const raw = await sargs.extract(sargs.text);
       const rows = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
       if (rows.length === 0) {
-        await recordFail(
-          S1_SECTIONS.MANAGEMENT,
+        await record(
           raw.length === 0 ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
-          raw.length === 0 ? "no people returned" : "all rows below confidence floor"
+          raw.length === 0 ? sargs.emptyDetail : sargs.lowConfidenceDetail
         );
+        return;
+      }
+      const wrote = await sargs.persist(rows);
+      if (sargs.invalidWriteDetail !== undefined && wrote === 0) {
+        await record("MODEL_INVALID_OUTPUT", sargs.invalidWriteDetail);
       } else {
-        for (const r of rows) {
-          const name = splitPersonName(r.full_name);
-          const { observation_id } = await observer.observePerson({
+        await deadLetters.markResolved(EXTRACTOR_ID, accession_number, sargs.sectionName);
+      }
+    } catch (e) {
+      await record("MODEL_INVALID_OUTPUT", (e instanceof Error ? e.message : String(e)).slice(0, 1024));
+    }
+  }
+
+  // The entity sections feed a SECTION_NOT_FOUND with a `null` detail when the
+  // text is undefined. `runSection` also treats a blank string as not-found,
+  // but the original entity blocks only checked `=== undefined`. Section text
+  // sourced directly from `byName` is never the empty string (the segmenter
+  // emits non-empty section bodies), so the two checks coincide in practice.
+
+  // --- Management ---
+  await runSection({
+    sectionName: S1_SECTIONS.MANAGEMENT,
+    text: byName.get(S1_SECTIONS.MANAGEMENT),
+    emptyDetail: "no people returned",
+    lowConfidenceDetail: "all rows below confidence floor",
+    extract: (text) => extractManagement(text, model),
+    persist: async (rows) => {
+      for (const r of rows) {
+        const name = splitPersonName(r.full_name);
+        const { observation_id } = await observer.observePerson({
+          ...base,
+          observation_index: idx++,
+          source_filing_issuer_cik: cik,
+          first_name: name.first,
+          middle_name: name.middle,
+          last_name: name.last,
+          suffix: name.suffix,
+          title: r.title,
+          relationship: r.relationship ?? "s1:management",
+          source_context: JSON.stringify({ relation: "s1:management" }),
+        });
+        await provenance.save({
+          kind: "person",
+          observation_id,
+          confidence: r.confidence,
+          source_span: r.source_span,
+          section_name: S1_SECTIONS.MANAGEMENT,
+          model_id,
+          prompt_version: extractor_version,
+          extra: null,
+        });
+      }
+      return rows.length;
+    },
+  });
+
+  // --- Beneficial ownership ---
+  await runSection({
+    sectionName: S1_SECTIONS.BENEFICIAL_OWNERSHIP,
+    text: byName.get(S1_SECTIONS.BENEFICIAL_OWNERSHIP),
+    emptyDetail: "no owners returned",
+    lowConfidenceDetail: "all rows below confidence floor",
+    extract: (text) => extractBeneficialOwnership(text, model),
+    persist: async (rows) => {
+      for (const r of rows) {
+        const observation_index = idx++;
+        let observation_id: number;
+        if (r.owner_kind === "person") {
+          const name = splitPersonName(r.name);
+          ({ observation_id } = await observer.observePerson({
             ...base,
-            observation_index: idx++,
+            observation_index,
             source_filing_issuer_cik: cik,
             first_name: name.first,
             middle_name: name.middle,
             last_name: name.last,
             suffix: name.suffix,
-            title: r.title,
-            relationship: r.relationship ?? "s1:management",
-            source_context: JSON.stringify({ relation: "s1:management" }),
-          });
-          await provenance.save({
-            kind: "person",
-            observation_id,
-            confidence: r.confidence,
-            source_span: r.source_span,
-            section_name: S1_SECTIONS.MANAGEMENT,
-            model_id,
-            prompt_version: extractor_version,
-            extra: null,
-          });
-        }
-        await recordOk(S1_SECTIONS.MANAGEMENT);
-      }
-    } catch (e) {
-      await recordFail(
-        S1_SECTIONS.MANAGEMENT,
-        "MODEL_INVALID_OUTPUT",
-        (e as Error).message.slice(0, 1024)
-      );
-    }
-  }
-
-  // --- Beneficial ownership ---
-  const own = byName.get(S1_SECTIONS.BENEFICIAL_OWNERSHIP);
-  if (own === undefined) {
-    await recordFail(S1_SECTIONS.BENEFICIAL_OWNERSHIP, "SECTION_NOT_FOUND", null);
-  } else {
-    try {
-      const raw = await extractBeneficialOwnership(own, model);
-      const rows = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
-      if (rows.length === 0) {
-        await recordFail(
-          S1_SECTIONS.BENEFICIAL_OWNERSHIP,
-          raw.length === 0 ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
-          raw.length === 0 ? "no owners returned" : "all rows below confidence floor"
-        );
-      } else {
-        for (const r of rows) {
-          const observation_index = idx++;
-          let observation_id: number;
-          if (r.owner_kind === "person") {
-            const name = splitPersonName(r.name);
-            ({ observation_id } = await observer.observePerson({
-              ...base,
-              observation_index,
-              source_filing_issuer_cik: cik,
-              first_name: name.first,
-              middle_name: name.middle,
-              last_name: name.last,
-              suffix: name.suffix,
-              relationship: "s1:beneficial-owner",
-              source_context: JSON.stringify({ relation: "s1:beneficial-owner" }),
-            }));
-          } else {
-            ({ observation_id } = await observer.observeCompany({
-              ...base,
-              observation_index,
-              name: r.name,
-              source_context: JSON.stringify({ relation: "s1:beneficial-owner" }),
-            }));
-          }
-          await ownershipRepo.save({
-            accession_number,
-            extractor_id: EXTRACTOR_ID,
-            observation_index,
-            owner_kind: r.owner_kind,
-            observation_id,
-            security_class: r.security_class,
-            shares_owned: r.shares_owned,
-            percent_owned: r.percent_owned,
-            shares_offered: r.shares_offered,
-            shares_after: r.shares_after,
-            percent_after: r.percent_after,
-            is_selling_stockholder: r.is_selling_stockholder,
-            footnote: r.footnote,
-          });
-          await provenance.save({
-            kind: r.owner_kind,
-            observation_id,
-            confidence: r.confidence,
-            source_span: r.source_span,
-            section_name: S1_SECTIONS.BENEFICIAL_OWNERSHIP,
-            model_id,
-            prompt_version: extractor_version,
-            extra: null,
-          });
-        }
-        await recordOk(S1_SECTIONS.BENEFICIAL_OWNERSHIP);
-      }
-    } catch (e) {
-      await recordFail(
-        S1_SECTIONS.BENEFICIAL_OWNERSHIP,
-        "MODEL_INVALID_OUTPUT",
-        (e as Error).message.slice(0, 1024)
-      );
-    }
-  }
-
-  // --- Related-party transactions ---
-  const rel = byName.get(S1_SECTIONS.RELATED_PARTY);
-  if (rel === undefined) {
-    await recordFail(S1_SECTIONS.RELATED_PARTY, "SECTION_NOT_FOUND", null);
-  } else {
-    try {
-      const raw = await extractRelatedParty(rel, model);
-      const rows = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
-      if (rows.length === 0) {
-        await recordFail(
-          S1_SECTIONS.RELATED_PARTY,
-          raw.length === 0 ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
-          raw.length === 0 ? "no parties returned" : "all rows below confidence floor"
-        );
-      } else {
-        let txIndex = 0;
-        for (const r of rows) {
-          const observation_index = idx++;
-          let observation_id: number;
-          if (r.party_kind === "person") {
-            const name = splitPersonName(r.name);
-            ({ observation_id } = await observer.observePerson({
-              ...base,
-              observation_index,
-              source_filing_issuer_cik: cik,
-              first_name: name.first,
-              middle_name: name.middle,
-              last_name: name.last,
-              suffix: name.suffix,
-              relationship: "s1:related-party",
-              source_context: JSON.stringify({ relation: "s1:related-party" }),
-            }));
-          } else {
-            ({ observation_id } = await observer.observeCompany({
-              ...base,
-              observation_index,
-              name: r.name,
-              source_context: JSON.stringify({ relation: "s1:related-party" }),
-            }));
-          }
-          await provenance.save({
-            kind: r.party_kind,
-            observation_id,
-            confidence: r.confidence,
-            source_span: r.source_span,
-            section_name: S1_SECTIONS.RELATED_PARTY,
-            model_id,
-            prompt_version: extractor_version,
-            extra: null,
-          });
-          for (const t of r.transactions) {
-            await relatedRepo.save({
-              accession_number,
-              extractor_id: EXTRACTOR_ID,
-              transaction_index: txIndex++,
-              party_kind: r.party_kind,
-              observation_id,
-              counterparty: t.counterparty,
-              nature: t.nature,
-              amount: t.amount,
-              period: t.period,
-              footnote: t.footnote,
-            });
-          }
-        }
-        await recordOk(S1_SECTIONS.RELATED_PARTY);
-      }
-    } catch (e) {
-      await recordFail(
-        S1_SECTIONS.RELATED_PARTY,
-        "MODEL_INVALID_OUTPUT",
-        (e as Error).message.slice(0, 1024)
-      );
-    }
-  }
-
-  // --- Offering terms (read from The Offering + Underwriting) ---
-  const offeringText = [
-    byName.get(S1_SECTIONS.THE_OFFERING),
-    byName.get(S1_SECTIONS.UNDERWRITING),
-  ]
-    .filter((t): t is string => typeof t === "string")
-    .join("\n\n");
-  if (offeringText.trim() === "") {
-    await deadLetters.record({
-      extractor_id: EXTRACTOR_ID,
-      accession_number,
-      section_name: "offering-terms",
-      reason_code: "SECTION_NOT_FOUND",
-      detail: "no The Offering / Underwriting section text",
-      failed_extractor_version: extractor_version,
-      source_run_id: null,
-    });
-  } else {
-    try {
-      const terms = await extractOfferingTerms(offeringText, model);
-      if (terms === null || terms.confidence < CONFIDENCE_FLOOR) {
-        await deadLetters.record({
-          extractor_id: EXTRACTOR_ID,
-          accession_number,
-          section_name: "offering-terms",
-          reason_code: terms === null ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
-          detail: terms === null ? "no offering terms returned" : "below confidence floor",
-          failed_extractor_version: extractor_version,
-          source_run_id: null,
-        });
-      } else {
-        const now = new Date().toISOString();
-        if (isSpac) {
-          await spacUnitTermsRepo.save({
-            extractor_id: EXTRACTOR_ID,
-            accession_number,
-            cik,
-            units_offered: toIntCount(terms.units_offered),
-            price_per_unit: terms.price_per_unit,
-            unit_composition: terms.unit_composition,
-            warrant_fraction_per_unit: terms.warrant_fraction_per_unit,
-            right_fraction_per_unit: terms.right_fraction_per_unit,
-            trust_per_unit: terms.trust_per_unit,
-            over_allotment_units: toIntCount(terms.over_allotment_units),
-            exchange: terms.exchange,
-            ticker: terms.tickers.find((t) => t.is_primary)?.ticker ?? null,
-            gross_proceeds: terms.gross_proceeds,
-            net_proceeds: terms.net_proceeds,
-            confidence: terms.confidence,
-            source_span: terms.source_span,
-            created_at: now,
-          });
+            relationship: "s1:beneficial-owner",
+            source_context: JSON.stringify({ relation: "s1:beneficial-owner" }),
+          }));
         } else {
-          await offeringTermsRepo.save({
-            extractor_id: EXTRACTOR_ID,
-            accession_number,
-            cik,
-            security_type: terms.security_type,
-            shares_offered: toIntCount(terms.shares_offered),
-            price: terms.price,
-            price_low: terms.price_low,
-            price_high: terms.price_high,
-            gross_proceeds: terms.gross_proceeds,
-            net_proceeds: terms.net_proceeds,
-            over_allotment_shares: toIntCount(terms.over_allotment_shares),
-            exchange: terms.exchange,
-            ticker: terms.tickers.find((t) => t.is_primary)?.ticker ?? null,
-            par_value: terms.par_value,
-            confidence: terms.confidence,
-            source_span: terms.source_span,
-            created_at: now,
-          });
-        }
-        for (const t of terms.tickers) {
-          const ticker = t.ticker?.trim() ?? "";
-          if (ticker === "") continue;
-          await issuerTickerRepo.save({
-            extractor_id: EXTRACTOR_ID,
-            accession_number,
-            exchange: (t.exchange ?? terms.exchange ?? "").trim(),
-            ticker,
-            cik,
-            filing_date: args.filing_date,
-            security_type: t.security_type,
-            is_primary: t.is_primary,
-            confidence: terms.confidence,
-            source_span: terms.source_span,
-            created_at: now,
-          });
-        }
-        await deadLetters.markResolved(EXTRACTOR_ID, accession_number, "offering-terms");
-      }
-    } catch (e) {
-      await deadLetters.record({
-        extractor_id: EXTRACTOR_ID,
-        accession_number,
-        section_name: "offering-terms",
-        reason_code: "MODEL_INVALID_OUTPUT",
-        detail: (e instanceof Error ? e.message : String(e)).slice(0, 1024),
-        failed_extractor_version: extractor_version,
-        source_run_id: null,
-      });
-    }
-  }
-
-  // --- Underwriters (Underwriting section; all filings) ---
-  const underwritingText = byName.get(S1_SECTIONS.UNDERWRITING);
-  if (underwritingText === undefined) {
-    await deadLetters.record({
-      extractor_id: EXTRACTOR_ID,
-      accession_number,
-      section_name: "underwriters",
-      reason_code: "SECTION_NOT_FOUND",
-      detail: null,
-      failed_extractor_version: extractor_version,
-      source_run_id: null,
-    });
-  } else {
-    try {
-      const raw = await extractUnderwriters(underwritingText, model);
-      const rows = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
-      if (rows.length === 0) {
-        await deadLetters.record({
-          extractor_id: EXTRACTOR_ID,
-          accession_number,
-          section_name: "underwriters",
-          reason_code: raw.length === 0 ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
-          detail: raw.length === 0 ? "no underwriters returned" : "all rows below confidence floor",
-          failed_extractor_version: extractor_version,
-          source_run_id: null,
-        });
-      } else {
-        let wrote = 0;
-        for (const r of rows) {
-          const legalName = r.legal_name?.trim() ?? "";
-          const commonName = r.common_name?.trim() ?? "";
-          if (legalName === "" || commonName === "") continue;
-          const observation_index = idx++;
-          const { observation_id, canonical_company_id } = await observer.observeCompany({
+          ({ observation_id } = await observer.observeCompany({
             ...base,
             observation_index,
-            name: legalName,
-            source_context: JSON.stringify({ relation: "s1:underwriter" }),
-          });
-          await provenance.save({
-            kind: "company",
-            observation_id,
-            confidence: r.confidence,
-            source_span: r.source_span,
-            section_name: "underwriters",
-            model_id,
-            prompt_version: extractor_version,
-            extra: null,
-          });
-          const underwriter_family_id = await underwriterFamilyResolver.resolve(commonName);
-          await underwriterMembershipRepo.record({
-            resolver_version: activeUnderwriterFamilyVersion,
-            canonical_company_id,
-            canonical_underwriter_family_id: underwriter_family_id,
-            seen_at: new Date().toISOString(),
-          });
-          await underwriterLinkRepo.save({
-            accession_number,
-            extractor_id: EXTRACTOR_ID,
-            observation_index,
-            issuer_cik: cik,
-            underwriter_canonical_company_id: canonical_company_id,
-            underwriter_family_id,
-            role_detail: r.role,
-            shares_allocated: toIntCount(r.shares_allocated),
-            over_allotment_shares: toIntCount(r.over_allotment_shares),
-            resolver_version: activeUnderwriterFamilyVersion,
-          });
-          wrote++;
+            name: r.name,
+            source_context: JSON.stringify({ relation: "s1:beneficial-owner" }),
+          }));
         }
-        if (wrote === 0) {
-          await deadLetters.record({
-            extractor_id: EXTRACTOR_ID,
-            accession_number,
-            section_name: "underwriters",
-            reason_code: "MODEL_INVALID_OUTPUT",
-            detail: "no underwriter rows had usable legal and common names",
-            failed_extractor_version: extractor_version,
-            source_run_id: null,
-          });
+        await ownershipRepo.save({
+          accession_number,
+          extractor_id: EXTRACTOR_ID,
+          observation_index,
+          owner_kind: r.owner_kind,
+          observation_id,
+          security_class: r.security_class,
+          shares_owned: r.shares_owned,
+          percent_owned: r.percent_owned,
+          shares_offered: r.shares_offered,
+          shares_after: r.shares_after,
+          percent_after: r.percent_after,
+          is_selling_stockholder: r.is_selling_stockholder,
+          footnote: r.footnote,
+        });
+        await provenance.save({
+          kind: r.owner_kind,
+          observation_id,
+          confidence: r.confidence,
+          source_span: r.source_span,
+          section_name: S1_SECTIONS.BENEFICIAL_OWNERSHIP,
+          model_id,
+          prompt_version: extractor_version,
+          extra: null,
+        });
+      }
+      return rows.length;
+    },
+  });
+
+  // --- Related-party transactions ---
+  await runSection({
+    sectionName: S1_SECTIONS.RELATED_PARTY,
+    text: byName.get(S1_SECTIONS.RELATED_PARTY),
+    emptyDetail: "no parties returned",
+    lowConfidenceDetail: "all rows below confidence floor",
+    extract: (text) => extractRelatedParty(text, model),
+    persist: async (rows) => {
+      let txIndex = 0;
+      for (const r of rows) {
+        const observation_index = idx++;
+        let observation_id: number;
+        if (r.party_kind === "person") {
+          const name = splitPersonName(r.name);
+          ({ observation_id } = await observer.observePerson({
+            ...base,
+            observation_index,
+            source_filing_issuer_cik: cik,
+            first_name: name.first,
+            middle_name: name.middle,
+            last_name: name.last,
+            suffix: name.suffix,
+            relationship: "s1:related-party",
+            source_context: JSON.stringify({ relation: "s1:related-party" }),
+          }));
         } else {
-          await deadLetters.markResolved(EXTRACTOR_ID, accession_number, "underwriters");
+          ({ observation_id } = await observer.observeCompany({
+            ...base,
+            observation_index,
+            name: r.name,
+            source_context: JSON.stringify({ relation: "s1:related-party" }),
+          }));
+        }
+        await provenance.save({
+          kind: r.party_kind,
+          observation_id,
+          confidence: r.confidence,
+          source_span: r.source_span,
+          section_name: S1_SECTIONS.RELATED_PARTY,
+          model_id,
+          prompt_version: extractor_version,
+          extra: null,
+        });
+        for (const t of r.transactions) {
+          await relatedRepo.save({
+            accession_number,
+            extractor_id: EXTRACTOR_ID,
+            transaction_index: txIndex++,
+            party_kind: r.party_kind,
+            observation_id,
+            counterparty: t.counterparty,
+            nature: t.nature,
+            amount: t.amount,
+            period: t.period,
+            footnote: t.footnote,
+          });
         }
       }
-    } catch (e) {
-      await deadLetters.record({
-        extractor_id: EXTRACTOR_ID,
-        accession_number,
-        section_name: "underwriters",
-        reason_code: "MODEL_INVALID_OUTPUT",
-        detail: (e instanceof Error ? e.message : String(e)).slice(0, 1024),
-        failed_extractor_version: extractor_version,
-        source_run_id: null,
-      });
-    }
-  }
+      return rows.length;
+    },
+  });
 
-  // --- Use of proceeds ---
-  const proceedsText = byName.get(S1_SECTIONS.USE_OF_PROCEEDS);
-  if (proceedsText === undefined) {
-    await deadLetters.record({
-      extractor_id: EXTRACTOR_ID,
-      accession_number,
-      section_name: "use-of-proceeds",
-      reason_code: "SECTION_NOT_FOUND",
-      detail: null,
-      failed_extractor_version: extractor_version,
-      source_run_id: null,
-    });
-  } else {
-    try {
-      const raw = await extractUseOfProceeds(proceedsText, model);
-      const rows = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
-      if (rows.length === 0) {
-        await deadLetters.record({
+  // --- Offering terms (read from The Offering + Underwriting) ---
+  // The extractor returns a single object; adapt it onto runSection by treating
+  // a null result as an empty array and wrapping a present result as `[terms]`.
+  const offeringText = [byName.get(S1_SECTIONS.THE_OFFERING), byName.get(S1_SECTIONS.UNDERWRITING)]
+    .filter((t): t is string => typeof t === "string")
+    .join("\n\n");
+  await runSection({
+    sectionName: "offering-terms",
+    text: offeringText,
+    notFoundDetail: "no The Offering / Underwriting section text",
+    emptyDetail: "no offering terms returned",
+    lowConfidenceDetail: "below confidence floor",
+    extract: async (text) => {
+      const terms = await extractOfferingTerms(text, model);
+      return terms === null ? [] : [terms];
+    },
+    persist: async (rows) => {
+      const terms = rows[0];
+      const now = new Date().toISOString();
+      if (isSpac) {
+        await spacUnitTermsRepo.save({
           extractor_id: EXTRACTOR_ID,
           accession_number,
-          section_name: "use-of-proceeds",
-          reason_code: raw.length === 0 ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
-          detail: raw.length === 0 ? "no line items returned" : "all rows below confidence floor",
-          failed_extractor_version: extractor_version,
-          source_run_id: null,
+          cik,
+          units_offered: toIntCount(terms.units_offered),
+          price_per_unit: terms.price_per_unit,
+          unit_composition: terms.unit_composition,
+          warrant_fraction_per_unit: terms.warrant_fraction_per_unit,
+          right_fraction_per_unit: terms.right_fraction_per_unit,
+          trust_per_unit: terms.trust_per_unit,
+          over_allotment_units: toIntCount(terms.over_allotment_units),
+          exchange: terms.exchange,
+          ticker: terms.tickers.find((t) => t.is_primary)?.ticker ?? null,
+          gross_proceeds: terms.gross_proceeds,
+          net_proceeds: terms.net_proceeds,
+          confidence: terms.confidence,
+          source_span: terms.source_span,
+          created_at: now,
         });
       } else {
-        const now = new Date().toISOString();
-        let lineIndex = 0;
-        for (const r of rows) {
-          await useOfProceedsRepo.save({
-            extractor_id: EXTRACTOR_ID,
-            accession_number,
-            line_index: lineIndex++,
-            cik,
-            purpose: r.purpose,
-            amount: r.amount,
-            percent: r.percent,
-            note: r.note,
-            confidence: r.confidence,
-            source_span: r.source_span,
-            created_at: now,
-          });
-        }
-        await deadLetters.markResolved(EXTRACTOR_ID, accession_number, "use-of-proceeds");
-      }
-    } catch (e) {
-      await deadLetters.record({
-        extractor_id: EXTRACTOR_ID,
-        accession_number,
-        section_name: "use-of-proceeds",
-        reason_code: "MODEL_INVALID_OUTPUT",
-        detail: (e instanceof Error ? e.message : String(e)).slice(0, 1024),
-        failed_extractor_version: extractor_version,
-        source_run_id: null,
-      });
-    }
-  }
-
-  // --- SPAC sponsors (gated on deterministic classification) ---
-  if (isSpac) {
-    // Prefer the dedicated "The Sponsor" section when the segmenter found it;
-    // fall back to the concatenated target sections (management / ownership /
-    // related-party) when that heading is absent. `byName` is empty only when no
-    // target heading matched at all, in which case we dead-letter as SECTION_NOT_FOUND.
-    const sponsorText =
-      byName.get(S1_SECTIONS.THE_SPONSOR) ?? [...byName.values()].join("\n\n");
-    if (sponsorText.trim() === "") {
-      await deadLetters.record({
-        extractor_id: EXTRACTOR_ID,
-        accession_number,
-        section_name: "spac-sponsors",
-        reason_code: "SECTION_NOT_FOUND",
-        detail: "no section text available for sponsor extraction",
-        failed_extractor_version: extractor_version,
-        source_run_id: null,
-      });
-    } else {
-      try {
-        const raw = await extractSpacSponsors(sponsorText, model);
-        const rows = raw.filter((r) => r.confidence >= CONFIDENCE_FLOOR);
-        if (rows.length === 0) {
-          await deadLetters.record({
-            extractor_id: EXTRACTOR_ID,
-            accession_number,
-            section_name: "spac-sponsors",
-            reason_code: raw.length === 0 ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
-            detail: raw.length === 0 ? "no sponsors returned" : "all rows below confidence floor",
-            failed_extractor_version: extractor_version,
-            source_run_id: null,
-          });
-        } else {
-          let wrote = 0;
-          for (const r of rows) {
-            // A row whose legal or common name is blank (degenerate model output)
-            // is skipped rather than allowed to throw inside the resolver and abort
-            // every other valid sponsor in this filing.
-            const legalName = r.legal_name?.trim() ?? "";
-            const commonName = r.common_name?.trim() ?? "";
-            if (legalName === "" || commonName === "") continue;
-            const observation_index = idx++;
-            const { observation_id, canonical_company_id } = await observer.observeCompany({
-              ...base,
-              observation_index,
-              name: legalName,
-              source_context: JSON.stringify({ relation: "s1:spac-sponsor" }),
-            });
-            await provenance.save({
-              kind: "company",
-              observation_id,
-              confidence: r.confidence,
-              source_span: r.source_span,
-              section_name: "spac-sponsors",
-              model_id,
-              prompt_version: extractor_version,
-              extra: null,
-            });
-            const sponsor_family_id = await sponsorFamilyResolver.resolve(commonName);
-            await membershipRepo.record({
-              resolver_version: activeSponsorFamilyVersion,
-              canonical_company_id,
-              canonical_sponsor_family_id: sponsor_family_id,
-              seen_at: new Date().toISOString(),
-            });
-            await linkRepo.save({
-              accession_number,
-              extractor_id: EXTRACTOR_ID,
-              observation_index,
-              issuer_cik: cik,
-              sponsor_canonical_company_id: canonical_company_id,
-              sponsor_family_id,
-              resolver_version: activeSponsorFamilyVersion,
-            });
-            wrote++;
-          }
-          if (wrote === 0) {
-            await deadLetters.record({
-              extractor_id: EXTRACTOR_ID,
-              accession_number,
-              section_name: "spac-sponsors",
-              reason_code: "MODEL_INVALID_OUTPUT",
-              detail: "no sponsor rows had usable legal and common names",
-              failed_extractor_version: extractor_version,
-              source_run_id: null,
-            });
-          } else {
-            await deadLetters.markResolved(EXTRACTOR_ID, accession_number, "spac-sponsors");
-          }
-        }
-      } catch (e) {
-        await deadLetters.record({
+        await offeringTermsRepo.save({
           extractor_id: EXTRACTOR_ID,
           accession_number,
-          section_name: "spac-sponsors",
-          reason_code: "MODEL_INVALID_OUTPUT",
-          detail: (e instanceof Error ? e.message : String(e)).slice(0, 1024),
-          failed_extractor_version: extractor_version,
-          source_run_id: null,
+          cik,
+          security_type: terms.security_type,
+          shares_offered: toIntCount(terms.shares_offered),
+          price: terms.price,
+          price_low: terms.price_low,
+          price_high: terms.price_high,
+          gross_proceeds: terms.gross_proceeds,
+          net_proceeds: terms.net_proceeds,
+          over_allotment_shares: toIntCount(terms.over_allotment_shares),
+          exchange: terms.exchange,
+          ticker: terms.tickers.find((t) => t.is_primary)?.ticker ?? null,
+          par_value: terms.par_value,
+          confidence: terms.confidence,
+          source_span: terms.source_span,
+          created_at: now,
         });
       }
-    }
-  }
+      for (const t of terms.tickers) {
+        const ticker = t.ticker?.trim() ?? "";
+        if (ticker === "") continue;
+        await issuerTickerRepo.save({
+          extractor_id: EXTRACTOR_ID,
+          accession_number,
+          exchange: (t.exchange ?? terms.exchange ?? "").trim(),
+          ticker,
+          cik,
+          filing_date: args.filing_date,
+          security_type: t.security_type,
+          is_primary: t.is_primary,
+          confidence: terms.confidence,
+          source_span: terms.source_span,
+          created_at: now,
+        });
+      }
+      return 1;
+    },
+  });
+
+  // --- Underwriters (Underwriting section; all filings) ---
+  await runSection({
+    sectionName: "underwriters",
+    text: byName.get(S1_SECTIONS.UNDERWRITING),
+    emptyDetail: "no underwriters returned",
+    lowConfidenceDetail: "all rows below confidence floor",
+    invalidWriteDetail: "no underwriter rows had usable legal and common names",
+    extract: (text) => extractUnderwriters(text, model),
+    persist: async (rows) => {
+      let wrote = 0;
+      for (const r of rows) {
+        const legalName = r.legal_name?.trim() ?? "";
+        const commonName = r.common_name?.trim() ?? "";
+        if (legalName === "" || commonName === "") continue;
+        const observation_index = idx++;
+        const { observation_id, canonical_company_id } = await observer.observeCompany({
+          ...base,
+          observation_index,
+          name: legalName,
+          source_context: JSON.stringify({ relation: "s1:underwriter" }),
+        });
+        await provenance.save({
+          kind: "company",
+          observation_id,
+          confidence: r.confidence,
+          source_span: r.source_span,
+          section_name: "underwriters",
+          model_id,
+          prompt_version: extractor_version,
+          extra: null,
+        });
+        const underwriter_family_id = await underwriterFamilyResolver.resolve(commonName);
+        await underwriterMembershipRepo.record({
+          resolver_version: activeUnderwriterFamilyVersion,
+          canonical_company_id,
+          canonical_underwriter_family_id: underwriter_family_id,
+          seen_at: new Date().toISOString(),
+        });
+        await underwriterLinkRepo.save({
+          accession_number,
+          extractor_id: EXTRACTOR_ID,
+          observation_index,
+          issuer_cik: cik,
+          underwriter_canonical_company_id: canonical_company_id,
+          underwriter_family_id,
+          role_detail: r.role,
+          shares_allocated: toIntCount(r.shares_allocated),
+          over_allotment_shares: toIntCount(r.over_allotment_shares),
+          resolver_version: activeUnderwriterFamilyVersion,
+        });
+        wrote++;
+      }
+      return wrote;
+    },
+  });
+
+  // --- Use of proceeds ---
+  await runSection({
+    sectionName: "use-of-proceeds",
+    text: byName.get(S1_SECTIONS.USE_OF_PROCEEDS),
+    emptyDetail: "no line items returned",
+    lowConfidenceDetail: "all rows below confidence floor",
+    extract: (text) => extractUseOfProceeds(text, model),
+    persist: async (rows) => {
+      const now = new Date().toISOString();
+      let lineIndex = 0;
+      for (const r of rows) {
+        await useOfProceedsRepo.save({
+          extractor_id: EXTRACTOR_ID,
+          accession_number,
+          line_index: lineIndex++,
+          cik,
+          purpose: r.purpose,
+          amount: r.amount,
+          percent: r.percent,
+          note: r.note,
+          confidence: r.confidence,
+          source_span: r.source_span,
+          created_at: now,
+        });
+      }
+      return rows.length;
+    },
+  });
+
+  // --- SPAC sponsors (gated on deterministic classification) ---
+  // Prefer the dedicated "The Sponsor" section when the segmenter found it; fall
+  // back to the concatenated target sections (management / ownership /
+  // related-party) when that heading is absent. The text is blank only when no
+  // target heading matched at all, in which case we dead-letter SECTION_NOT_FOUND.
+  await runSection({
+    sectionName: "spac-sponsors",
+    skip: !isSpac,
+    text: byName.get(S1_SECTIONS.THE_SPONSOR) ?? [...byName.values()].join("\n\n"),
+    notFoundDetail: "no section text available for sponsor extraction",
+    emptyDetail: "no sponsors returned",
+    lowConfidenceDetail: "all rows below confidence floor",
+    invalidWriteDetail: "no sponsor rows had usable legal and common names",
+    extract: (text) => extractSpacSponsors(text, model),
+    persist: async (rows) => {
+      let wrote = 0;
+      for (const r of rows) {
+        // A row whose legal or common name is blank (degenerate model output)
+        // is skipped rather than allowed to throw inside the resolver and abort
+        // every other valid sponsor in this filing.
+        const legalName = r.legal_name?.trim() ?? "";
+        const commonName = r.common_name?.trim() ?? "";
+        if (legalName === "" || commonName === "") continue;
+        const observation_index = idx++;
+        const { observation_id, canonical_company_id } = await observer.observeCompany({
+          ...base,
+          observation_index,
+          name: legalName,
+          source_context: JSON.stringify({ relation: "s1:spac-sponsor" }),
+        });
+        await provenance.save({
+          kind: "company",
+          observation_id,
+          confidence: r.confidence,
+          source_span: r.source_span,
+          section_name: "spac-sponsors",
+          model_id,
+          prompt_version: extractor_version,
+          extra: null,
+        });
+        const sponsor_family_id = await sponsorFamilyResolver.resolve(commonName);
+        await membershipRepo.record({
+          resolver_version: activeSponsorFamilyVersion,
+          canonical_company_id,
+          canonical_sponsor_family_id: sponsor_family_id,
+          seen_at: new Date().toISOString(),
+        });
+        await linkRepo.save({
+          accession_number,
+          extractor_id: EXTRACTOR_ID,
+          observation_index,
+          issuer_cik: cik,
+          sponsor_canonical_company_id: canonical_company_id,
+          sponsor_family_id,
+          resolver_version: activeSponsorFamilyVersion,
+        });
+        wrote++;
+      }
+      return wrote;
+    },
+  });
 }

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -33,6 +33,9 @@ import { CanonicalSponsorFamilyAliasRepo } from "../../../storage/canonical/Cano
 import { SponsorFamilyResolver } from "../../../resolver/SponsorFamilyResolver";
 import { SponsorFamilyMembershipRepo } from "../../../storage/canonical/SponsorFamilyMembershipRepo";
 import { SpacSponsorLinkRepo } from "../../../storage/canonical/SpacSponsorLinkRepo";
+import { OfferingTermsRepo } from "../../../storage/offering/OfferingTermsRepo";
+import { SpacUnitTermsRepo } from "../../../storage/offering/SpacUnitTermsRepo";
+import { IssuerTickerRepo } from "../../../storage/offering/IssuerTickerRepo";
 import type { FormS1Parsed } from "./Form_S_1";
 import { parseEdgarHtml } from "../../html/parseEdgarHtml";
 import { DocumentTreeSegmenter } from "./s1/DocumentTreeSegmenter";
@@ -40,6 +43,7 @@ import { S1_SECTIONS, type S1SectionName } from "./s1/DocumentSegmenter";
 import {
   extractBeneficialOwnership,
   extractManagement,
+  extractOfferingTerms,
   extractRelatedParty,
   extractSpacSponsors,
 } from "./s1/sectionExtractors";
@@ -128,9 +132,14 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
   const membershipRepo = new SponsorFamilyMembershipRepo();
   const linkRepo = new SpacSponsorLinkRepo();
 
+  const offeringTermsRepo = new OfferingTermsRepo();
+  const spacUnitTermsRepo = new SpacUnitTermsRepo();
+  const issuerTickerRepo = new IssuerTickerRepo();
+
   await ownershipRepo.clear(accession_number);
   await relatedRepo.clear(accession_number);
   await linkRepo.clear(accession_number);
+  await issuerTickerRepo.clear(accession_number);
 
   const base = { accession_number, extractor_id: EXTRACTOR_ID, extractor_version };
   let idx = 0;
@@ -385,6 +394,111 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
         "MODEL_INVALID_OUTPUT",
         (e as Error).message.slice(0, 1024)
       );
+    }
+  }
+
+  // --- Offering terms (read from The Offering + Underwriting) ---
+  const offeringText = [
+    byName.get(S1_SECTIONS.THE_OFFERING),
+    byName.get(S1_SECTIONS.UNDERWRITING),
+  ]
+    .filter((t): t is string => typeof t === "string")
+    .join("\n\n");
+  if (offeringText.trim() === "") {
+    await deadLetters.record({
+      extractor_id: EXTRACTOR_ID,
+      accession_number,
+      section_name: "offering-terms",
+      reason_code: "SECTION_NOT_FOUND",
+      detail: "no The Offering / Underwriting section text",
+      failed_extractor_version: extractor_version,
+      source_run_id: null,
+    });
+  } else {
+    try {
+      const terms = await extractOfferingTerms(offeringText, model);
+      if (terms === null || terms.confidence < CONFIDENCE_FLOOR) {
+        await deadLetters.record({
+          extractor_id: EXTRACTOR_ID,
+          accession_number,
+          section_name: "offering-terms",
+          reason_code: terms === null ? "MODEL_EMPTY" : "LOW_CONFIDENCE_ALL",
+          detail: terms === null ? "no offering terms returned" : "below confidence floor",
+          failed_extractor_version: extractor_version,
+          source_run_id: null,
+        });
+      } else {
+        const now = new Date().toISOString();
+        if (isSpac) {
+          await spacUnitTermsRepo.save({
+            extractor_id: EXTRACTOR_ID,
+            accession_number,
+            cik,
+            units_offered: terms.units_offered,
+            price_per_unit: terms.price_per_unit,
+            unit_composition: terms.unit_composition,
+            warrant_fraction_per_unit: terms.warrant_fraction_per_unit,
+            right_fraction_per_unit: terms.right_fraction_per_unit,
+            trust_per_unit: terms.trust_per_unit,
+            over_allotment_units: terms.over_allotment_units,
+            exchange: terms.exchange,
+            ticker: terms.tickers.find((t) => t.is_primary)?.ticker ?? null,
+            gross_proceeds: terms.gross_proceeds,
+            net_proceeds: terms.net_proceeds,
+            confidence: terms.confidence,
+            source_span: terms.source_span,
+            created_at: now,
+          });
+        } else {
+          await offeringTermsRepo.save({
+            extractor_id: EXTRACTOR_ID,
+            accession_number,
+            cik,
+            security_type: terms.security_type,
+            shares_offered: terms.shares_offered,
+            price: terms.price,
+            price_low: terms.price_low,
+            price_high: terms.price_high,
+            gross_proceeds: terms.gross_proceeds,
+            net_proceeds: terms.net_proceeds,
+            over_allotment_shares: terms.over_allotment_shares,
+            exchange: terms.exchange,
+            ticker: terms.tickers.find((t) => t.is_primary)?.ticker ?? null,
+            par_value: terms.par_value,
+            confidence: terms.confidence,
+            source_span: terms.source_span,
+            created_at: now,
+          });
+        }
+        for (const t of terms.tickers) {
+          const ticker = t.ticker?.trim() ?? "";
+          if (ticker === "") continue;
+          await issuerTickerRepo.save({
+            extractor_id: EXTRACTOR_ID,
+            accession_number,
+            exchange: (t.exchange ?? terms.exchange ?? "").trim(),
+            ticker,
+            cik,
+            filing_date: args.filing_date,
+            security_type: t.security_type,
+            is_primary: t.is_primary,
+            confidence: terms.confidence,
+            source_span: terms.source_span,
+            created_at: now,
+          });
+        }
+        await deadLetters.markResolved(EXTRACTOR_ID, accession_number, "offering-terms");
+      }
+    } catch (e) {
+      await deadLetters.record({
+        extractor_id: EXTRACTOR_ID,
+        accession_number,
+        section_name: "offering-terms",
+        reason_code: "MODEL_INVALID_OUTPUT",
+        detail: (e instanceof Error ? e.message : String(e)).slice(0, 1024),
+        failed_extractor_version: extractor_version,
+        source_run_id: null,
+      });
     }
   }
 

--- a/src/sec/forms/registration-statements/Form_S_1.storage.underwriters.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.underwriters.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../../config/TestingDI";
+import { setupAllDatabases } from "../../../config/setupAllDatabases";
+import { processFormS1 } from "./Form_S_1.storage";
+import { CompanyObservationRepo } from "../../../storage/observation/CompanyObservationRepo";
+import { UnderwriterLinkRepo } from "../../../storage/canonical/UnderwriterLinkRepo";
+import { CanonicalUnderwriterFamilyRepo } from "../../../storage/canonical/CanonicalUnderwriterFamilyRepo";
+import { UnderwriterFamilyMembershipRepo } from "../../../storage/canonical/UnderwriterFamilyMembershipRepo";
+import { fakeS1Model, registerFakeStructuredProvider } from "./s1/testing/fakeStructuredProvider";
+
+const HTML = "<h1>UNDERWRITING</h1><p>Goldman Sachs &amp; Co. LLC and GS Securities.</p>";
+const NULL_HEADER = { sic: null, sicDescription: null, cik: null, companyName: null, filingDate: null };
+
+let cleanup: (() => void) | undefined;
+
+describe("processFormS1 underwriters", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("links two Goldman entities to one family and answers the headline query", async () => {
+    // Sections present: Underwriting only. Call order: offering-terms (1st; reads
+    // Underwriting text), then underwriters (2nd). Provide both payloads.
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        security_type: null, shares_offered: null, price: null, price_low: null, price_high: null,
+        gross_proceeds: null, net_proceeds: null, over_allotment_shares: null, units_offered: null,
+        price_per_unit: null, unit_composition: null, warrant_fraction_per_unit: null,
+        right_fraction_per_unit: null, trust_per_unit: null, over_allotment_units: null,
+        exchange: null, par_value: null, confidence: 0.5, source_span: "x", tickers: [],
+      },
+      {
+        underwriters: [
+          { legal_name: "Goldman Sachs & Co. LLC", common_name: "Goldman Sachs", role: "lead", shares_allocated: 3000000, over_allotment_shares: 450000, confidence: 0.95, source_span: "Goldman Sachs & Co. LLC" },
+          { legal_name: "GS Securities LLC", common_name: "Goldman Sachs", role: "bookrunner", shares_allocated: 1000000, over_allotment_shares: null, confidence: 0.9, source_span: "GS Securities" },
+        ],
+      },
+    ]);
+    cleanup = unregister;
+
+    await processFormS1({
+      cik: 1018724,
+      file_number: "333-1",
+      accession_number: "0000000000-26-000001",
+      filing_date: "2026-01-02",
+      primary_doc: "s1.htm",
+      form: "S-1",
+      formS1: { header: NULL_HEADER, html: HTML },
+      model: fakeS1Model(),
+    });
+
+    const companies = await new CompanyObservationRepo().listAll();
+    expect(companies.some((c) => c.name === "Goldman Sachs & Co. LLC")).toBe(true);
+
+    const family = await new CanonicalUnderwriterFamilyRepo().findByResolverAndName("1.0.0", "goldman sachs");
+    expect(family).toBeDefined();
+    const members = await new UnderwriterFamilyMembershipRepo().listCompaniesForFamily(
+      "1.0.0",
+      family!.canonical_underwriter_family_id
+    );
+    expect(members.length).toBe(2);
+
+    const ciks = await new UnderwriterLinkRepo().listIssuerCiksForFamily(
+      family!.canonical_underwriter_family_id
+    );
+    expect(ciks).toEqual([1018724]);
+  });
+});

--- a/src/sec/forms/registration-statements/Form_S_1.storage.useofproceeds.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.useofproceeds.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../../config/TestingDI";
+import { setupAllDatabases } from "../../../config/setupAllDatabases";
+import { processFormS1 } from "./Form_S_1.storage";
+import { UseOfProceedsRepo } from "../../../storage/use-of-proceeds/UseOfProceedsRepo";
+import { fakeS1Model, registerFakeStructuredProvider } from "./s1/testing/fakeStructuredProvider";
+
+const HTML = "<h1>USE OF PROCEEDS</h1><p>We intend to use net proceeds as follows.</p>";
+const NULL_HEADER = { sic: null, sicDescription: null, cik: null, companyName: null, filingDate: null };
+
+let cleanup: (() => void) | undefined;
+
+describe("processFormS1 use of proceeds", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("writes use-of-proceeds line items", async () => {
+    // Sections present: Use of Proceeds only. The Offering / Underwriting absent
+    // (offering-terms + underwriters dead-letter SECTION_NOT_FOUND, no model call).
+    // So the FIRST model call is use-of-proceeds.
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        line_items: [
+          { purpose: "repay debt", amount: 20000000, percent: 40, note: null, confidence: 0.8, source_span: "repay" },
+          { purpose: "working capital", amount: null, percent: null, note: "remainder", confidence: 0.6, source_span: "wc" },
+        ],
+      },
+    ]);
+    cleanup = unregister;
+
+    await processFormS1({
+      cik: 1018724,
+      file_number: "333-1",
+      accession_number: "0000000000-26-000001",
+      filing_date: "2026-01-02",
+      primary_doc: "s1.htm",
+      form: "S-1",
+      formS1: { header: NULL_HEADER, html: HTML },
+      model: fakeS1Model(),
+    });
+
+    const rows = await new UseOfProceedsRepo().queryByAccession("0000000000-26-000001");
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.purpose === "repay debt")?.amount).toBe(20000000);
+  });
+});

--- a/src/sec/forms/registration-statements/s1/DocumentSegmenter.ts
+++ b/src/sec/forms/registration-statements/s1/DocumentSegmenter.ts
@@ -11,6 +11,10 @@ export const S1_SECTIONS = {
   MANAGEMENT: "Management",
   BENEFICIAL_OWNERSHIP: "Principal and Selling Stockholders",
   RELATED_PARTY: "Certain Relationships and Related Transactions",
+  THE_OFFERING: "The Offering",
+  UNDERWRITING: "Underwriting",
+  USE_OF_PROCEEDS: "Use of Proceeds",
+  THE_SPONSOR: "The Sponsor",
 } as const;
 export type S1SectionName = (typeof S1_SECTIONS)[keyof typeof S1_SECTIONS];
 
@@ -34,6 +38,18 @@ export const SECTION_HEADING_PATTERNS: Readonly<Record<S1SectionName, readonly R
     /^\s*certain relationships and related (party |person |persons )?transactions\s*$/i,
     /^\s*related (part(y|ies)|persons?) transactions\s*$/i,
     /^\s*transactions with related persons\s*$/i,
+  ],
+  [S1_SECTIONS.THE_OFFERING]: [/^\s*the offering\s*$/i, /^\s*our offering\s*$/i],
+  [S1_SECTIONS.UNDERWRITING]: [
+    /^\s*underwriting\s*$/i,
+    /^\s*underwriting\s*\(conflicts of interest\)\s*$/i,
+    /^\s*plan of distribution\s*$/i,
+  ],
+  [S1_SECTIONS.USE_OF_PROCEEDS]: [/^\s*use of proceeds\s*$/i],
+  // SPAC-specific; intentionally tight to avoid matching sponsor mentions in body text.
+  [S1_SECTIONS.THE_SPONSOR]: [
+    /^\s*(the|our) sponsor\s*$/i,
+    /^\s*the sponsor and its affiliates\s*$/i,
   ],
 };
 

--- a/src/sec/forms/registration-statements/s1/DocumentTreeSegmenter.test.ts
+++ b/src/sec/forms/registration-statements/s1/DocumentTreeSegmenter.test.ts
@@ -57,4 +57,24 @@ describe("DocumentTreeSegmenter", () => {
     const sections = new DocumentTreeSegmenter().segment(doc);
     expect(sections.some((s) => s.name === S1_SECTIONS.MANAGEMENT)).toBe(false);
   });
+
+  it("resolves the four new offering sections from the tree", () => {
+    const html = `
+      <html><body>
+        <p style="font-weight:700;text-align:center;font-size:16pt">THE OFFERING</p>
+        <p>We are offering 5,000,000 shares.</p>
+        <p style="font-weight:700;text-align:center;font-size:16pt">USE OF PROCEEDS</p>
+        <p>We intend to use the net proceeds for working capital.</p>
+        <p style="font-weight:700;text-align:center;font-size:16pt">UNDERWRITING</p>
+        <p>Goldman Sachs &amp; Co. LLC is acting as representative.</p>
+        <p style="font-weight:700;text-align:center;font-size:16pt">THE SPONSOR</p>
+        <p>Our sponsor is Acme Sponsor, LLC.</p>
+      </body></html>`;
+    const doc = parseEdgarHtml(html, "S-1");
+    const byName = new Map(new DocumentTreeSegmenter().segment(doc).map((s) => [s.name, s.text]));
+    expect(byName.get(S1_SECTIONS.THE_OFFERING)).toContain("5,000,000 shares");
+    expect(byName.get(S1_SECTIONS.USE_OF_PROCEEDS)).toContain("working capital");
+    expect(byName.get(S1_SECTIONS.UNDERWRITING)).toContain("Goldman Sachs");
+    expect(byName.get(S1_SECTIONS.THE_SPONSOR)).toContain("Acme Sponsor");
+  });
 });

--- a/src/sec/forms/registration-statements/s1/offeringTermsSchema.ts
+++ b/src/sec/forms/registration-statements/s1/offeringTermsSchema.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DataPortSchema } from "workglow";
+
+const NULLABLE_STRING = { type: ["string", "null"] } as const;
+const NULLABLE_NUMBER = { type: ["number", "null"] } as const;
+
+/**
+ * One offering-terms object. The model fills equity fields for a normal IPO and
+ * unit fields for a SPAC; `processFormS1` routes by the deterministic is_spac
+ * flag. `tickers` feeds the point-in-time IssuerTicker series.
+ */
+export const OfferingTermsOutputSchema = {
+  type: "object",
+  properties: {
+    security_type: NULLABLE_STRING,
+    shares_offered: NULLABLE_NUMBER,
+    price: NULLABLE_NUMBER,
+    price_low: NULLABLE_NUMBER,
+    price_high: NULLABLE_NUMBER,
+    gross_proceeds: NULLABLE_NUMBER,
+    net_proceeds: NULLABLE_NUMBER,
+    over_allotment_shares: NULLABLE_NUMBER,
+    units_offered: NULLABLE_NUMBER,
+    price_per_unit: NULLABLE_NUMBER,
+    unit_composition: NULLABLE_STRING,
+    warrant_fraction_per_unit: NULLABLE_NUMBER,
+    right_fraction_per_unit: NULLABLE_NUMBER,
+    trust_per_unit: NULLABLE_NUMBER,
+    over_allotment_units: NULLABLE_NUMBER,
+    exchange: NULLABLE_STRING,
+    par_value: NULLABLE_NUMBER,
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+    source_span: { type: "string" },
+    tickers: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          ticker: { type: "string" },
+          exchange: NULLABLE_STRING,
+          security_type: NULLABLE_STRING,
+          is_primary: { type: "boolean" },
+        },
+        required: ["ticker", "is_primary"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["confidence", "source_span", "tickers"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export interface OfferingTickerRow {
+  ticker: string;
+  exchange: string | null;
+  security_type: string | null;
+  is_primary: boolean;
+}
+
+export interface OfferingTermsRow {
+  security_type: string | null;
+  shares_offered: number | null;
+  price: number | null;
+  price_low: number | null;
+  price_high: number | null;
+  gross_proceeds: number | null;
+  net_proceeds: number | null;
+  over_allotment_shares: number | null;
+  units_offered: number | null;
+  price_per_unit: number | null;
+  unit_composition: string | null;
+  warrant_fraction_per_unit: number | null;
+  right_fraction_per_unit: number | null;
+  trust_per_unit: number | null;
+  over_allotment_units: number | null;
+  exchange: string | null;
+  par_value: number | null;
+  confidence: number;
+  source_span: string;
+  tickers: ReadonlyArray<OfferingTickerRow>;
+}

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
@@ -12,6 +12,7 @@ import {
   extractSpacSponsors,
   extractOfferingTerms,
   extractUnderwriters,
+  extractUseOfProceeds,
 } from "./sectionExtractors";
 import { fakeS1Model, registerFakeStructuredProvider } from "./testing/fakeStructuredProvider";
 
@@ -175,6 +176,24 @@ it("extractSpacSponsors returns scripted sponsor rows", async () => {
     );
     expect(rows[0].common_name).toBe("Pershing Square Sponsor");
     expect(rows[0].legal_name).toBe("Pershing Square Sponsor 2, LLC");
+  } finally {
+    unregister();
+  }
+});
+
+it("extractUseOfProceeds returns parsed line items", async () => {
+  const { unregister } = registerFakeStructuredProvider([
+    {
+      line_items: [
+        { purpose: "repay debt", amount: 20000000, percent: 40, note: null, confidence: 0.8, source_span: "repay" },
+        { purpose: "working capital", amount: null, percent: null, note: "remainder", confidence: 0.6, source_span: "wc" },
+      ],
+    },
+  ]);
+  try {
+    const rows = await extractUseOfProceeds("USE OF PROCEEDS ...", fakeS1Model());
+    expect(rows).toHaveLength(2);
+    expect(rows[0].amount).toBe(20000000);
   } finally {
     unregister();
   }

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
@@ -131,6 +131,15 @@ it("extractOfferingTerms returns the parsed offering object", async () => {
   }
 });
 
+it("extractOfferingTerms returns null when the model omits confidence/source_span", async () => {
+  const { unregister } = registerFakeStructuredProvider([{ tickers: [] }]);
+  try {
+    expect(await extractOfferingTerms("THE OFFERING ...", fakeS1Model())).toBeNull();
+  } finally {
+    unregister();
+  }
+});
+
 it("extractUnderwriters returns parsed underwriter rows", async () => {
   const { unregister } = registerFakeStructuredProvider([
     {

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
@@ -131,10 +131,10 @@ it("extractOfferingTerms returns the parsed offering object", async () => {
   }
 });
 
-it("extractOfferingTerms returns null when the model omits confidence/source_span", async () => {
+it("extractOfferingTerms throws on schema-invalid model output (caller dead-letters it)", async () => {
   const { unregister } = registerFakeStructuredProvider([{ tickers: [] }]);
   try {
-    expect(await extractOfferingTerms("THE OFFERING ...", fakeS1Model())).toBeNull();
+    await expect(extractOfferingTerms("THE OFFERING ...", fakeS1Model())).rejects.toThrow();
   } finally {
     unregister();
   }

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
@@ -11,6 +11,7 @@ import {
   extractRelatedParty,
   extractSpacSponsors,
   extractOfferingTerms,
+  extractUnderwriters,
 } from "./sectionExtractors";
 import { fakeS1Model, registerFakeStructuredProvider } from "./testing/fakeStructuredProvider";
 
@@ -124,6 +125,31 @@ it("extractOfferingTerms returns the parsed offering object", async () => {
     const got = await extractOfferingTerms("THE OFFERING ...", fakeS1Model());
     expect(got?.units_offered).toBe(20000000);
     expect(got?.tickers[0].ticker).toBe("ACQU");
+  } finally {
+    unregister();
+  }
+});
+
+it("extractUnderwriters returns parsed underwriter rows", async () => {
+  const { unregister } = registerFakeStructuredProvider([
+    {
+      underwriters: [
+        {
+          legal_name: "Goldman Sachs & Co. LLC",
+          common_name: "Goldman Sachs",
+          role: "lead",
+          shares_allocated: 3000000,
+          over_allotment_shares: 450000,
+          confidence: 0.95,
+          source_span: "Goldman Sachs & Co. LLC",
+        },
+      ],
+    },
+  ]);
+  try {
+    const rows = await extractUnderwriters("UNDERWRITING ...", fakeS1Model());
+    expect(rows[0].common_name).toBe("Goldman Sachs");
+    expect(rows[0].role).toBe("lead");
   } finally {
     unregister();
   }

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.test.ts
@@ -10,6 +10,7 @@ import {
   extractBeneficialOwnership,
   extractRelatedParty,
   extractSpacSponsors,
+  extractOfferingTerms,
 } from "./sectionExtractors";
 import { fakeS1Model, registerFakeStructuredProvider } from "./testing/fakeStructuredProvider";
 
@@ -92,6 +93,40 @@ describe("section extractors", () => {
     const parties = await extractRelatedParty("We pay rent...", fakeS1Model());
     expect(parties[0].transactions[0].amount).toBe(120000);
   });
+});
+
+it("extractOfferingTerms returns the parsed offering object", async () => {
+  const { unregister } = registerFakeStructuredProvider([
+    {
+      security_type: "Units",
+      shares_offered: null,
+      price: null,
+      price_low: null,
+      price_high: null,
+      gross_proceeds: 200000000,
+      net_proceeds: null,
+      over_allotment_shares: null,
+      units_offered: 20000000,
+      price_per_unit: 10,
+      unit_composition: "one share and one-half warrant",
+      warrant_fraction_per_unit: 0.5,
+      right_fraction_per_unit: null,
+      trust_per_unit: 10.1,
+      over_allotment_units: 3000000,
+      exchange: "NASDAQ",
+      par_value: null,
+      confidence: 0.9,
+      source_span: "each unit",
+      tickers: [{ ticker: "ACQU", exchange: "NASDAQ", security_type: "Units", is_primary: true }],
+    },
+  ]);
+  try {
+    const got = await extractOfferingTerms("THE OFFERING ...", fakeS1Model());
+    expect(got?.units_offered).toBe(20000000);
+    expect(got?.tickers[0].ticker).toBe("ACQU");
+  } finally {
+    unregister();
+  }
 });
 
 it("extractSpacSponsors returns scripted sponsor rows", async () => {

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.ts
@@ -16,6 +16,7 @@ import {
 } from "./sectionSchemas";
 import { SpacSponsorOutputSchema, type SpacSponsorRow } from "./spacSponsorSchema";
 import { OfferingTermsOutputSchema, type OfferingTermsRow } from "./offeringTermsSchema";
+import { UnderwriterOutputSchema, type UnderwriterRowOut } from "./underwriterSchema";
 
 const MAX_TOKENS = 4096;
 
@@ -132,6 +133,22 @@ export async function extractOfferingTerms(
   const obj = await runStructured(model, prompt, OfferingTermsOutputSchema);
   if (obj.confidence === undefined || obj.source_span === undefined) return null;
   return obj as unknown as OfferingTermsRow;
+}
+
+export async function extractUnderwriters(
+  sectionText: string,
+  model: ModelConfig
+): Promise<UnderwriterRowOut[]> {
+  const prompt =
+    "Extract every underwriter named in the following S-1/F-1 Underwriting (or Plan of Distribution) " +
+    "section. For each give legal_name (full legal entity, e.g. 'Goldman Sachs & Co. LLC'), common_name " +
+    "(the bank brand without legal suffix, e.g. 'Goldman Sachs'), role (one of 'lead' for the " +
+    "representative/lead, 'bookrunner' for a book-running manager, 'co-manager', else 'underwriter'; null " +
+    "if unclear), shares_allocated (the number of shares underwritten, or null), over_allotment_shares (or " +
+    "null), a confidence in [0,1], and the verbatim source_span. Return JSON matching the schema.\n\n" +
+    sectionText;
+  const obj = await runStructured(model, prompt, UnderwriterOutputSchema);
+  return (obj.underwriters as UnderwriterRowOut[] | undefined) ?? [];
 }
 
 export async function extractSpacSponsors(

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.ts
@@ -17,6 +17,7 @@ import {
 import { SpacSponsorOutputSchema, type SpacSponsorRow } from "./spacSponsorSchema";
 import { OfferingTermsOutputSchema, type OfferingTermsRow } from "./offeringTermsSchema";
 import { UnderwriterOutputSchema, type UnderwriterRowOut } from "./underwriterSchema";
+import { UseOfProceedsOutputSchema, type UseOfProceedsLineRow } from "./useOfProceedsSchema";
 
 const MAX_TOKENS = 4096;
 
@@ -163,4 +164,17 @@ export async function extractSpacSponsors(
     sectionText;
   const obj = await runStructured(model, prompt, SpacSponsorOutputSchema);
   return (obj.sponsors as SpacSponsorRow[] | undefined) ?? [];
+}
+
+export async function extractUseOfProceeds(
+  sectionText: string,
+  model: ModelConfig
+): Promise<UseOfProceedsLineRow[]> {
+  const prompt =
+    "Extract the use-of-proceeds line items from the following S-1/F-1 Use of Proceeds section. For each " +
+    "stated purpose give purpose, amount (dollars, or null), percent (or null), note (any qualifier, or " +
+    "null), a confidence in [0,1], and the verbatim source_span. Return JSON matching the schema.\n\n" +
+    sectionText;
+  const obj = await runStructured(model, prompt, UseOfProceedsOutputSchema);
+  return (obj.line_items as UseOfProceedsLineRow[] | undefined) ?? [];
 }

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.ts
@@ -15,6 +15,7 @@ import {
   type RelatedPartyRow,
 } from "./sectionSchemas";
 import { SpacSponsorOutputSchema, type SpacSponsorRow } from "./spacSponsorSchema";
+import { OfferingTermsOutputSchema, type OfferingTermsRow } from "./offeringTermsSchema";
 
 const MAX_TOKENS = 4096;
 
@@ -112,6 +113,25 @@ export async function extractRelatedParty(
     sectionText;
   const obj = await runStructured(model, prompt, RelatedPartyOutputSchema);
   return (obj.parties as RelatedPartyRow[] | undefined) ?? [];
+}
+
+export async function extractOfferingTerms(
+  sectionText: string,
+  model: ModelConfig
+): Promise<OfferingTermsRow | null> {
+  const prompt =
+    "Extract the offering terms from the following S-1/F-1 'The Offering' and 'Underwriting' text. " +
+    "For a normal IPO fill security_type, shares_offered, price (or price_low/price_high), gross_proceeds, " +
+    "net_proceeds, over_allotment_shares, exchange, par_value. For a SPAC (units) fill units_offered, " +
+    "price_per_unit, unit_composition (verbatim), warrant_fraction_per_unit, right_fraction_per_unit, " +
+    "trust_per_unit, over_allotment_units. List every distinct ticker symbol in 'tickers' (exact symbol, " +
+    "is_primary true for the common-equity/units symbol, false for warrant/right symbols). Use null for " +
+    "anything not stated. Give a confidence in [0,1] and a verbatim source_span. Return JSON matching the " +
+    "schema.\n\n" +
+    sectionText;
+  const obj = await runStructured(model, prompt, OfferingTermsOutputSchema);
+  if (obj.confidence === undefined || obj.source_span === undefined) return null;
+  return obj as unknown as OfferingTermsRow;
 }
 
 export async function extractSpacSponsors(

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.ts
@@ -131,12 +131,7 @@ export async function extractOfferingTerms(
     "anything not stated. Give a confidence in [0,1] and a verbatim source_span. Return JSON matching the " +
     "schema.\n\n" +
     sectionText;
-  let obj: Record<string, unknown>;
-  try {
-    obj = await runStructured(model, prompt, OfferingTermsOutputSchema);
-  } catch {
-    return null;
-  }
+  const obj = await runStructured(model, prompt, OfferingTermsOutputSchema);
   if (obj.confidence == null || obj.source_span == null) return null;
   return obj as unknown as OfferingTermsRow;
 }

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.ts
@@ -131,8 +131,13 @@ export async function extractOfferingTerms(
     "anything not stated. Give a confidence in [0,1] and a verbatim source_span. Return JSON matching the " +
     "schema.\n\n" +
     sectionText;
-  const obj = await runStructured(model, prompt, OfferingTermsOutputSchema);
-  if (obj.confidence === undefined || obj.source_span === undefined) return null;
+  let obj: Record<string, unknown>;
+  try {
+    obj = await runStructured(model, prompt, OfferingTermsOutputSchema);
+  } catch {
+    return null;
+  }
+  if (obj.confidence == null || obj.source_span == null) return null;
   return obj as unknown as OfferingTermsRow;
 }
 

--- a/src/sec/forms/registration-statements/s1/underwriterSchema.ts
+++ b/src/sec/forms/registration-statements/s1/underwriterSchema.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DataPortSchema } from "workglow";
+
+export const UnderwriterOutputSchema = {
+  type: "object",
+  properties: {
+    underwriters: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          legal_name: { type: "string" },
+          common_name: { type: "string" },
+          role: { type: ["string", "null"], enum: ["lead", "bookrunner", "co-manager", "underwriter", null] },
+          shares_allocated: { type: ["number", "null"] },
+          over_allotment_shares: { type: ["number", "null"] },
+          confidence: { type: "number", minimum: 0, maximum: 1 },
+          source_span: { type: "string" },
+        },
+        required: ["legal_name", "common_name", "confidence", "source_span"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["underwriters"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export interface UnderwriterRowOut {
+  legal_name: string;
+  common_name: string;
+  role: "lead" | "bookrunner" | "co-manager" | "underwriter" | null;
+  shares_allocated: number | null;
+  over_allotment_shares: number | null;
+  confidence: number;
+  source_span: string;
+}

--- a/src/sec/forms/registration-statements/s1/useOfProceedsSchema.ts
+++ b/src/sec/forms/registration-statements/s1/useOfProceedsSchema.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DataPortSchema } from "workglow";
+
+export const UseOfProceedsOutputSchema = {
+  type: "object",
+  properties: {
+    line_items: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          purpose: { type: ["string", "null"] },
+          amount: { type: ["number", "null"] },
+          percent: { type: ["number", "null"] },
+          note: { type: ["string", "null"] },
+          confidence: { type: "number", minimum: 0, maximum: 1 },
+          source_span: { type: "string" },
+        },
+        required: ["confidence", "source_span"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["line_items"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export interface UseOfProceedsLineRow {
+  purpose: string | null;
+  amount: number | null;
+  percent: number | null;
+  note: string | null;
+  confidence: number;
+  source_span: string;
+}

--- a/src/sec/html/parseEdgarHtml.golden.test.ts
+++ b/src/sec/html/parseEdgarHtml.golden.test.ts
@@ -13,7 +13,8 @@ import { DocumentTreeSegmenter } from "../forms/registration-statements/s1/Docum
 import { S1_SECTIONS } from "../forms/registration-statements/s1/DocumentSegmenter";
 import type { S1SectionName } from "../forms/registration-statements/s1/DocumentSegmenter";
 
-const { MANAGEMENT, BENEFICIAL_OWNERSHIP, RELATED_PARTY } = S1_SECTIONS;
+const { MANAGEMENT, BENEFICIAL_OWNERSHIP, RELATED_PARTY, THE_OFFERING, UNDERWRITING, USE_OF_PROCEEDS, THE_SPONSOR } =
+  S1_SECTIONS;
 const dir = join(import.meta.dir, "mock_data", "s1");
 
 /**
@@ -22,14 +23,42 @@ const dir = join(import.meta.dir, "mock_data", "s1");
  * heading detection or the section patterns change.
  */
 const EXPECTED: Record<string, readonly S1SectionName[]> = {
-  // SPACs (SIC 6770) — standard, complete section structure.
-  "s1_1848507_000119312521066104.htm": [MANAGEMENT, BENEFICIAL_OWNERSHIP, RELATED_PARTY],
-  "s1_1849470_000110465921035696.htm": [MANAGEMENT, BENEFICIAL_OWNERSHIP, RELATED_PARTY],
-  "s1_1822912_000121390021001475.htm": [MANAGEMENT, BENEFICIAL_OWNERSHIP, RELATED_PARTY],
+  // SPACs (SIC 6770) — standard, complete section structure (incl. offering sections).
+  "s1_1848507_000119312521066104.htm": [
+    MANAGEMENT,
+    BENEFICIAL_OWNERSHIP,
+    RELATED_PARTY,
+    UNDERWRITING,
+    USE_OF_PROCEEDS,
+  ],
+  "s1_1849470_000110465921035696.htm": [
+    MANAGEMENT,
+    BENEFICIAL_OWNERSHIP,
+    RELATED_PARTY,
+    THE_OFFERING,
+    UNDERWRITING,
+    USE_OF_PROCEEDS,
+  ],
+  "s1_1822912_000121390021001475.htm": [
+    MANAGEMENT,
+    BENEFICIAL_OWNERSHIP,
+    RELATED_PARTY,
+    THE_OFFERING,
+    UNDERWRITING,
+    USE_OF_PROCEEDS,
+  ],
   // Operating companies — varied coverage / edge cases.
-  "s1_2030954_000149315226027129.htm": [BENEFICIAL_OWNERSHIP],
-  "s1_2087989_000143774926019444.htm": [], // atypical trust; 3 stitched tables
-  "s1_1817004_000149315226027137.htm": [], // incorporation-by-reference S-1/A
+  "s1_2030954_000149315226027129.htm": [
+    BENEFICIAL_OWNERSHIP,
+    THE_OFFERING,
+    UNDERWRITING,
+    USE_OF_PROCEEDS,
+  ],
+  // atypical trust (3 stitched tables) — no mgmt/ownership/related-party headings,
+  // but carries the offering sections incl. a focused "The Sponsor".
+  "s1_2087989_000143774926019444.htm": [THE_OFFERING, THE_SPONSOR, UNDERWRITING, USE_OF_PROCEEDS],
+  // incorporation-by-reference S-1/A — offering mechanics present, entities by reference.
+  "s1_1817004_000149315226027137.htm": [THE_OFFERING, UNDERWRITING, USE_OF_PROCEEDS],
 };
 
 const SPAC_FIXTURES = [

--- a/src/storage/canonical/CanonicalAliasSchemas.ts
+++ b/src/storage/canonical/CanonicalAliasSchemas.ts
@@ -102,3 +102,26 @@ export const CANONICAL_SPONSOR_FAMILY_ALIAS_REPOSITORY_TOKEN =
   createServiceToken<CanonicalSponsorFamilyAliasRepositoryStorage>(
     "sec.storage.canonicalSponsorFamilyAliasRepository"
   );
+
+/**
+ * Operator-managed merge of AI-emitted underwriter-family name variants. Same
+ * single-hop semantics as the sponsor-family alias schema.
+ */
+export const CanonicalUnderwriterFamilyAliasSchema = Type.Object({
+  alias_canonical_id: Type.String({ maxLength: 36 }),
+  target_canonical_id: Type.String({ maxLength: 36 }),
+  reason: TypeNullable(Type.String({ maxLength: 1024 })),
+  created_at: Type.String(),
+  created_by: TypeNullable(Type.String({ maxLength: 128 })),
+});
+export type CanonicalUnderwriterFamilyAlias = Static<typeof CanonicalUnderwriterFamilyAliasSchema>;
+export const CanonicalUnderwriterFamilyAliasPrimaryKeyNames = ["alias_canonical_id"] as const;
+export type CanonicalUnderwriterFamilyAliasRepositoryStorage = ITabularStorage<
+  typeof CanonicalUnderwriterFamilyAliasSchema,
+  typeof CanonicalUnderwriterFamilyAliasPrimaryKeyNames,
+  CanonicalUnderwriterFamilyAlias
+>;
+export const CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN =
+  createServiceToken<CanonicalUnderwriterFamilyAliasRepositoryStorage>(
+    "sec.storage.canonicalUnderwriterFamilyAliasRepository"
+  );

--- a/src/storage/canonical/CanonicalFamilyAliasRepo.ts
+++ b/src/storage/canonical/CanonicalFamilyAliasRepo.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ITabularStorage } from "workglow";
+
+/**
+ * Structural shape shared by the sponsor-family and underwriter-family alias
+ * rows. Both schemas are identical, so a single row type drives the base.
+ */
+export interface FamilyAliasRow {
+  readonly alias_canonical_id: string;
+  readonly target_canonical_id: string;
+  readonly reason: string | null;
+  readonly created_at: string;
+  readonly created_by: string | null;
+}
+
+type FamilyAliasStorage = ITabularStorage<any, any, FamilyAliasRow>;
+
+/**
+ * Shared single-hop alias logic for the family canonical tiers (sponsor /
+ * underwriter). Holds `add`/`remove`/`resolve`/`list`/`listByTarget`/
+ * `listOrphans`; subclasses only supply the backing storage instance.
+ */
+export class CanonicalFamilyAliasRepo {
+  protected repo: FamilyAliasStorage;
+
+  constructor(repo: FamilyAliasStorage) {
+    this.repo = repo;
+  }
+
+  async add(
+    alias_canonical_id: string,
+    target_canonical_id: string,
+    reason: string | null,
+    created_by: string | null
+  ): Promise<FamilyAliasRow> {
+    if (alias_canonical_id === target_canonical_id) throw new Error("self-alias is not permitted");
+    const targetAsAlias = await this.repo.get({ alias_canonical_id: target_canonical_id });
+    if (targetAsAlias) {
+      throw new Error(
+        `single-hop invariant violated: target ${target_canonical_id} is itself an alias`
+      );
+    }
+    const fromIsTarget = (await this.repo.query({ target_canonical_id: alias_canonical_id })) ?? [];
+    if (fromIsTarget.length > 0) {
+      throw new Error(
+        `single-hop invariant violated: ${alias_canonical_id} is already a target of an existing alias`
+      );
+    }
+    const row: FamilyAliasRow = {
+      alias_canonical_id,
+      target_canonical_id,
+      reason,
+      created_at: new Date().toISOString(),
+      created_by,
+    };
+    await this.repo.put(row);
+    return row;
+  }
+
+  async remove(alias_canonical_id: string): Promise<void> {
+    await this.repo.delete({ alias_canonical_id });
+  }
+
+  async resolve(canonical_id: string): Promise<string> {
+    const row = await this.repo.get({ alias_canonical_id: canonical_id });
+    return row?.target_canonical_id ?? canonical_id;
+  }
+
+  async list(): Promise<FamilyAliasRow[]> {
+    return (await this.repo.getAll()) ?? [];
+  }
+
+  /** Aliases that redirect into `target_canonical_id` (indexed lookup). */
+  async listByTarget(target_canonical_id: string): Promise<FamilyAliasRow[]> {
+    return (await this.repo.query({ target_canonical_id })) ?? [];
+  }
+
+  async listOrphans(validIds: Set<string>): Promise<FamilyAliasRow[]> {
+    const all = await this.list();
+    return all.filter(
+      (a) => !validIds.has(a.alias_canonical_id) || !validIds.has(a.target_canonical_id)
+    );
+  }
+}

--- a/src/storage/canonical/CanonicalSponsorFamilyAliasRepo.ts
+++ b/src/storage/canonical/CanonicalSponsorFamilyAliasRepo.ts
@@ -7,75 +7,19 @@
 import { globalServiceRegistry } from "workglow";
 import {
   CANONICAL_SPONSOR_FAMILY_ALIAS_REPOSITORY_TOKEN,
-  type CanonicalSponsorFamilyAlias,
   type CanonicalSponsorFamilyAliasRepositoryStorage,
 } from "./CanonicalAliasSchemas";
+import { CanonicalFamilyAliasRepo } from "./CanonicalFamilyAliasRepo";
 
 interface Options {
   repository?: CanonicalSponsorFamilyAliasRepositoryStorage;
 }
 
-export class CanonicalSponsorFamilyAliasRepo {
-  private repo: CanonicalSponsorFamilyAliasRepositoryStorage;
-
+export class CanonicalSponsorFamilyAliasRepo extends CanonicalFamilyAliasRepo {
   constructor(options: Options = {}) {
-    this.repo =
+    super(
       options.repository ??
-      globalServiceRegistry.get(CANONICAL_SPONSOR_FAMILY_ALIAS_REPOSITORY_TOKEN);
-  }
-
-  async add(
-    alias_canonical_id: string,
-    target_canonical_id: string,
-    reason: string | null,
-    created_by: string | null
-  ): Promise<CanonicalSponsorFamilyAlias> {
-    if (alias_canonical_id === target_canonical_id) throw new Error("self-alias is not permitted");
-    const targetAsAlias = await this.repo.get({ alias_canonical_id: target_canonical_id });
-    if (targetAsAlias) {
-      throw new Error(
-        `single-hop invariant violated: target ${target_canonical_id} is itself an alias`
-      );
-    }
-    const fromIsTarget = (await this.repo.query({ target_canonical_id: alias_canonical_id })) ?? [];
-    if (fromIsTarget.length > 0) {
-      throw new Error(
-        `single-hop invariant violated: ${alias_canonical_id} is already a target of an existing alias`
-      );
-    }
-    const row: CanonicalSponsorFamilyAlias = {
-      alias_canonical_id,
-      target_canonical_id,
-      reason,
-      created_at: new Date().toISOString(),
-      created_by,
-    };
-    await this.repo.put(row);
-    return row;
-  }
-
-  async remove(alias_canonical_id: string): Promise<void> {
-    await this.repo.delete({ alias_canonical_id });
-  }
-
-  async resolve(canonical_id: string): Promise<string> {
-    const row = await this.repo.get({ alias_canonical_id: canonical_id });
-    return row?.target_canonical_id ?? canonical_id;
-  }
-
-  async list(): Promise<CanonicalSponsorFamilyAlias[]> {
-    return (await this.repo.getAll()) ?? [];
-  }
-
-  /** Aliases that redirect into `target_canonical_id` (indexed lookup). */
-  async listByTarget(target_canonical_id: string): Promise<CanonicalSponsorFamilyAlias[]> {
-    return (await this.repo.query({ target_canonical_id })) ?? [];
-  }
-
-  async listOrphans(validIds: Set<string>): Promise<CanonicalSponsorFamilyAlias[]> {
-    const all = await this.list();
-    return all.filter(
-      (a) => !validIds.has(a.alias_canonical_id) || !validIds.has(a.target_canonical_id)
+        globalServiceRegistry.get(CANONICAL_SPONSOR_FAMILY_ALIAS_REPOSITORY_TOKEN)
     );
   }
 }

--- a/src/storage/canonical/CanonicalUnderwriterFamilyAliasRepo.test.ts
+++ b/src/storage/canonical/CanonicalUnderwriterFamilyAliasRepo.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { CanonicalUnderwriterFamilyAliasRepo } from "./CanonicalUnderwriterFamilyAliasRepo";
+
+describe("CanonicalUnderwriterFamilyAliasRepo", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+
+  it("resolves an alias to its target and rejects chains", async () => {
+    const repo = new CanonicalUnderwriterFamilyAliasRepo();
+    await repo.add("uw-a", "uw-b", "merge variant", "op");
+    expect(await repo.resolve("uw-a")).toBe("uw-b");
+    expect(await repo.resolve("uw-b")).toBe("uw-b");
+    await expect(repo.add("uw-b", "uw-c", null, null)).rejects.toThrow();
+  });
+
+  it("lists variants by target", async () => {
+    const repo = new CanonicalUnderwriterFamilyAliasRepo();
+    await repo.add("uw-x1", "uw-x", null, null);
+    await repo.add("uw-x2", "uw-x", null, null);
+    const variants = (await repo.listByTarget("uw-x")).map((a) => a.alias_canonical_id).sort();
+    expect(variants).toEqual(["uw-x1", "uw-x2"]);
+  });
+});

--- a/src/storage/canonical/CanonicalUnderwriterFamilyAliasRepo.ts
+++ b/src/storage/canonical/CanonicalUnderwriterFamilyAliasRepo.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN,
+  type CanonicalUnderwriterFamilyAlias,
+  type CanonicalUnderwriterFamilyAliasRepositoryStorage,
+} from "./CanonicalAliasSchemas";
+
+interface Options {
+  repository?: CanonicalUnderwriterFamilyAliasRepositoryStorage;
+}
+
+export class CanonicalUnderwriterFamilyAliasRepo {
+  private repo: CanonicalUnderwriterFamilyAliasRepositoryStorage;
+
+  constructor(options: Options = {}) {
+    this.repo =
+      options.repository ??
+      globalServiceRegistry.get(CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN);
+  }
+
+  async add(
+    alias_canonical_id: string,
+    target_canonical_id: string,
+    reason: string | null,
+    created_by: string | null
+  ): Promise<CanonicalUnderwriterFamilyAlias> {
+    if (alias_canonical_id === target_canonical_id) throw new Error("self-alias is not permitted");
+    const targetAsAlias = await this.repo.get({ alias_canonical_id: target_canonical_id });
+    if (targetAsAlias) {
+      throw new Error(
+        `single-hop invariant violated: target ${target_canonical_id} is itself an alias`
+      );
+    }
+    const fromIsTarget = (await this.repo.query({ target_canonical_id: alias_canonical_id })) ?? [];
+    if (fromIsTarget.length > 0) {
+      throw new Error(
+        `single-hop invariant violated: ${alias_canonical_id} is already a target of an existing alias`
+      );
+    }
+    const row: CanonicalUnderwriterFamilyAlias = {
+      alias_canonical_id,
+      target_canonical_id,
+      reason,
+      created_at: new Date().toISOString(),
+      created_by,
+    };
+    await this.repo.put(row);
+    return row;
+  }
+
+  async remove(alias_canonical_id: string): Promise<void> {
+    await this.repo.delete({ alias_canonical_id });
+  }
+
+  async resolve(canonical_id: string): Promise<string> {
+    const row = await this.repo.get({ alias_canonical_id: canonical_id });
+    return row?.target_canonical_id ?? canonical_id;
+  }
+
+  async list(): Promise<CanonicalUnderwriterFamilyAlias[]> {
+    return (await this.repo.getAll()) ?? [];
+  }
+
+  async listByTarget(target_canonical_id: string): Promise<CanonicalUnderwriterFamilyAlias[]> {
+    return (await this.repo.query({ target_canonical_id })) ?? [];
+  }
+
+  async listOrphans(validIds: Set<string>): Promise<CanonicalUnderwriterFamilyAlias[]> {
+    const all = await this.list();
+    return all.filter(
+      (a) => !validIds.has(a.alias_canonical_id) || !validIds.has(a.target_canonical_id)
+    );
+  }
+}

--- a/src/storage/canonical/CanonicalUnderwriterFamilyAliasRepo.ts
+++ b/src/storage/canonical/CanonicalUnderwriterFamilyAliasRepo.ts
@@ -7,74 +7,19 @@
 import { globalServiceRegistry } from "workglow";
 import {
   CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN,
-  type CanonicalUnderwriterFamilyAlias,
   type CanonicalUnderwriterFamilyAliasRepositoryStorage,
 } from "./CanonicalAliasSchemas";
+import { CanonicalFamilyAliasRepo } from "./CanonicalFamilyAliasRepo";
 
 interface Options {
   repository?: CanonicalUnderwriterFamilyAliasRepositoryStorage;
 }
 
-export class CanonicalUnderwriterFamilyAliasRepo {
-  private repo: CanonicalUnderwriterFamilyAliasRepositoryStorage;
-
+export class CanonicalUnderwriterFamilyAliasRepo extends CanonicalFamilyAliasRepo {
   constructor(options: Options = {}) {
-    this.repo =
+    super(
       options.repository ??
-      globalServiceRegistry.get(CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN);
-  }
-
-  async add(
-    alias_canonical_id: string,
-    target_canonical_id: string,
-    reason: string | null,
-    created_by: string | null
-  ): Promise<CanonicalUnderwriterFamilyAlias> {
-    if (alias_canonical_id === target_canonical_id) throw new Error("self-alias is not permitted");
-    const targetAsAlias = await this.repo.get({ alias_canonical_id: target_canonical_id });
-    if (targetAsAlias) {
-      throw new Error(
-        `single-hop invariant violated: target ${target_canonical_id} is itself an alias`
-      );
-    }
-    const fromIsTarget = (await this.repo.query({ target_canonical_id: alias_canonical_id })) ?? [];
-    if (fromIsTarget.length > 0) {
-      throw new Error(
-        `single-hop invariant violated: ${alias_canonical_id} is already a target of an existing alias`
-      );
-    }
-    const row: CanonicalUnderwriterFamilyAlias = {
-      alias_canonical_id,
-      target_canonical_id,
-      reason,
-      created_at: new Date().toISOString(),
-      created_by,
-    };
-    await this.repo.put(row);
-    return row;
-  }
-
-  async remove(alias_canonical_id: string): Promise<void> {
-    await this.repo.delete({ alias_canonical_id });
-  }
-
-  async resolve(canonical_id: string): Promise<string> {
-    const row = await this.repo.get({ alias_canonical_id: canonical_id });
-    return row?.target_canonical_id ?? canonical_id;
-  }
-
-  async list(): Promise<CanonicalUnderwriterFamilyAlias[]> {
-    return (await this.repo.getAll()) ?? [];
-  }
-
-  async listByTarget(target_canonical_id: string): Promise<CanonicalUnderwriterFamilyAlias[]> {
-    return (await this.repo.query({ target_canonical_id })) ?? [];
-  }
-
-  async listOrphans(validIds: Set<string>): Promise<CanonicalUnderwriterFamilyAlias[]> {
-    const all = await this.list();
-    return all.filter(
-      (a) => !validIds.has(a.alias_canonical_id) || !validIds.has(a.target_canonical_id)
+        globalServiceRegistry.get(CANONICAL_UNDERWRITER_FAMILY_ALIAS_REPOSITORY_TOKEN)
     );
   }
 }

--- a/src/storage/canonical/CanonicalUnderwriterFamilyRepo.test.ts
+++ b/src/storage/canonical/CanonicalUnderwriterFamilyRepo.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { CanonicalUnderwriterFamilyRepo } from "./CanonicalUnderwriterFamilyRepo";
+
+describe("CanonicalUnderwriterFamilyRepo", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+
+  it("creates and finds by resolver version + normalized name", async () => {
+    const repo = new CanonicalUnderwriterFamilyRepo();
+    await repo.create({
+      canonical_underwriter_family_id: "uw-1",
+      resolver_version: "1.0.0",
+      display_name: "Goldman Sachs",
+      normalized_name: "goldman sachs",
+      created_at: new Date().toISOString(),
+    });
+    const found = await repo.findByResolverAndName("1.0.0", "goldman sachs");
+    expect(found?.canonical_underwriter_family_id).toBe("uw-1");
+  });
+});

--- a/src/storage/canonical/CanonicalUnderwriterFamilyRepo.ts
+++ b/src/storage/canonical/CanonicalUnderwriterFamilyRepo.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN,
+  type CanonicalUnderwriterFamily,
+  type CanonicalUnderwriterFamilyRepositoryStorage,
+} from "./CanonicalUnderwriterFamilySchema";
+
+export class CanonicalUnderwriterFamilyRepo {
+  private repo: CanonicalUnderwriterFamilyRepositoryStorage;
+
+  constructor(repo?: CanonicalUnderwriterFamilyRepositoryStorage) {
+    this.repo = repo ?? globalServiceRegistry.get(CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN);
+  }
+
+  async create(row: CanonicalUnderwriterFamily): Promise<CanonicalUnderwriterFamily> {
+    await this.repo.put(row);
+    return row;
+  }
+
+  async getById(
+    canonical_underwriter_family_id: string
+  ): Promise<CanonicalUnderwriterFamily | undefined> {
+    return this.repo.get({ canonical_underwriter_family_id });
+  }
+
+  async findByResolverAndName(
+    resolver_version: string,
+    normalized_name: string
+  ): Promise<CanonicalUnderwriterFamily | undefined> {
+    const matches = await this.repo.query({ resolver_version, normalized_name });
+    return matches?.[0];
+  }
+
+  async listForResolverVersion(resolver_version: string): Promise<CanonicalUnderwriterFamily[]> {
+    return (await this.repo.query({ resolver_version })) ?? [];
+  }
+
+  async deleteForResolverVersion(resolver_version: string): Promise<number> {
+    const rows = (await this.repo.query({ resolver_version })) ?? [];
+    for (const r of rows)
+      await this.repo.delete({
+        canonical_underwriter_family_id: r.canonical_underwriter_family_id,
+      });
+    return rows.length;
+  }
+}

--- a/src/storage/canonical/CanonicalUnderwriterFamilySchema.ts
+++ b/src/storage/canonical/CanonicalUnderwriterFamilySchema.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+import { TypeNullable } from "../../util/TypeBoxUtil";
+
+/**
+ * An underwriter *family* — the bank brand (e.g. "Goldman Sachs") above the
+ * legal-entity company tier. Subsidiaries are members of a family (see
+ * UnderwriterFamilyMembership), not aliases of one another.
+ * Resolver natural key (UNIQUE): (resolver_version, normalized_name).
+ */
+export const CanonicalUnderwriterFamilySchema = Type.Object({
+  canonical_underwriter_family_id: Type.String({ maxLength: 36, description: "UUID v4" }),
+  resolver_version: Type.String({ maxLength: 32 }),
+  display_name: TypeNullable(Type.String({ maxLength: 512 })),
+  normalized_name: Type.String({ maxLength: 512 }),
+  created_at: Type.String(),
+});
+export type CanonicalUnderwriterFamily = Static<typeof CanonicalUnderwriterFamilySchema>;
+
+export const CanonicalUnderwriterFamilyPrimaryKeyNames = [
+  "canonical_underwriter_family_id",
+] as const;
+
+export type CanonicalUnderwriterFamilyRepositoryStorage = ITabularStorage<
+  typeof CanonicalUnderwriterFamilySchema,
+  typeof CanonicalUnderwriterFamilyPrimaryKeyNames,
+  CanonicalUnderwriterFamily
+>;
+
+export const CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN =
+  createServiceToken<CanonicalUnderwriterFamilyRepositoryStorage>(
+    "sec.storage.canonicalUnderwriterFamilyRepository"
+  );

--- a/src/storage/canonical/FamilyMembershipRepo.ts
+++ b/src/storage/canonical/FamilyMembershipRepo.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ITabularStorage } from "workglow";
+
+/**
+ * Structural shape shared by sponsor-family and underwriter-family membership
+ * rows. The family-id column name differs between the two tiers, so it is
+ * addressed dynamically via the `familyIdColumn` constructor argument.
+ */
+export interface FamilyMembershipRow {
+  readonly resolver_version: string;
+  readonly canonical_company_id: string;
+  readonly seen_at: string;
+  readonly [familyIdColumn: string]: string;
+}
+
+type FamilyMembershipStorage = ITabularStorage<any, any, FamilyMembershipRow>;
+
+/**
+ * Shared co-occurrence membership logic for the family canonical tiers. The
+ * family-id column name (`canonical_sponsor_family_id` /
+ * `canonical_underwriter_family_id`) is injected so the same body serves both.
+ */
+export class FamilyMembershipRepo<TRow extends FamilyMembershipRow> {
+  protected repo: ITabularStorage<any, any, TRow>;
+  private readonly familyIdColumn: string;
+
+  constructor(repo: ITabularStorage<any, any, TRow>, familyIdColumn: string) {
+    this.repo = repo;
+    this.familyIdColumn = familyIdColumn;
+  }
+
+  async record(row: TRow): Promise<void> {
+    await this.repo.put(row); // PK upsert -> idempotent
+  }
+
+  async listCompaniesForFamily(
+    resolver_version: string,
+    family_id: string
+  ): Promise<string[]> {
+    const rows =
+      (await this.repo.query({ resolver_version, [this.familyIdColumn]: family_id } as any)) ?? [];
+    return rows.map((r) => r.canonical_company_id);
+  }
+
+  async deleteForResolverVersion(resolver_version: string): Promise<number> {
+    const rows = (await this.repo.query({ resolver_version } as any)) ?? [];
+    for (const r of rows) {
+      await this.repo.delete({
+        resolver_version: r.resolver_version,
+        canonical_company_id: r.canonical_company_id,
+        [this.familyIdColumn]: (r as any)[this.familyIdColumn],
+      } as any);
+    }
+    return rows.length;
+  }
+}

--- a/src/storage/canonical/SponsorFamilyMembershipRepo.ts
+++ b/src/storage/canonical/SponsorFamilyMembershipRepo.ts
@@ -10,36 +10,20 @@ import {
   type SponsorFamilyMembership,
   type SponsorFamilyMembershipRepositoryStorage,
 } from "./SponsorFamilyMembershipSchema";
+import { FamilyMembershipRepo } from "./FamilyMembershipRepo";
 
-export class SponsorFamilyMembershipRepo {
-  private repo: SponsorFamilyMembershipRepositoryStorage;
-
+export class SponsorFamilyMembershipRepo extends FamilyMembershipRepo<SponsorFamilyMembership> {
   constructor(repo?: SponsorFamilyMembershipRepositoryStorage) {
-    this.repo = repo ?? globalServiceRegistry.get(SPONSOR_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN);
-  }
-
-  async record(row: SponsorFamilyMembership): Promise<void> {
-    await this.repo.put(row); // PK upsert -> idempotent
+    super(
+      repo ?? globalServiceRegistry.get(SPONSOR_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN),
+      "canonical_sponsor_family_id"
+    );
   }
 
   async listCompaniesForFamily(
     resolver_version: string,
     canonical_sponsor_family_id: string
   ): Promise<string[]> {
-    const rows =
-      (await this.repo.query({ resolver_version, canonical_sponsor_family_id })) ?? [];
-    return rows.map((r) => r.canonical_company_id);
-  }
-
-  async deleteForResolverVersion(resolver_version: string): Promise<number> {
-    const rows = (await this.repo.query({ resolver_version })) ?? [];
-    for (const r of rows) {
-      await this.repo.delete({
-        resolver_version: r.resolver_version,
-        canonical_company_id: r.canonical_company_id,
-        canonical_sponsor_family_id: r.canonical_sponsor_family_id,
-      });
-    }
-    return rows.length;
+    return super.listCompaniesForFamily(resolver_version, canonical_sponsor_family_id);
   }
 }

--- a/src/storage/canonical/UnderwriterFamilyMembershipRepo.test.ts
+++ b/src/storage/canonical/UnderwriterFamilyMembershipRepo.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { UnderwriterFamilyMembershipRepo } from "./UnderwriterFamilyMembershipRepo";
+
+describe("UnderwriterFamilyMembershipRepo", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+
+  it("records memberships and lists companies for a family", async () => {
+    const repo = new UnderwriterFamilyMembershipRepo();
+    await repo.record({
+      resolver_version: "1.0.0",
+      canonical_company_id: "co-1",
+      canonical_underwriter_family_id: "fam-1",
+      seen_at: new Date().toISOString(),
+    });
+    await repo.record({
+      resolver_version: "1.0.0",
+      canonical_company_id: "co-2",
+      canonical_underwriter_family_id: "fam-1",
+      seen_at: new Date().toISOString(),
+    });
+    const companies = (await repo.listCompaniesForFamily("1.0.0", "fam-1")).sort();
+    expect(companies).toEqual(["co-1", "co-2"]);
+  });
+});

--- a/src/storage/canonical/UnderwriterFamilyMembershipRepo.ts
+++ b/src/storage/canonical/UnderwriterFamilyMembershipRepo.ts
@@ -10,36 +10,20 @@ import {
   type UnderwriterFamilyMembership,
   type UnderwriterFamilyMembershipRepositoryStorage,
 } from "./UnderwriterFamilyMembershipSchema";
+import { FamilyMembershipRepo } from "./FamilyMembershipRepo";
 
-export class UnderwriterFamilyMembershipRepo {
-  private repo: UnderwriterFamilyMembershipRepositoryStorage;
-
+export class UnderwriterFamilyMembershipRepo extends FamilyMembershipRepo<UnderwriterFamilyMembership> {
   constructor(repo?: UnderwriterFamilyMembershipRepositoryStorage) {
-    this.repo = repo ?? globalServiceRegistry.get(UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN);
-  }
-
-  async record(row: UnderwriterFamilyMembership): Promise<void> {
-    await this.repo.put(row); // PK upsert -> idempotent
+    super(
+      repo ?? globalServiceRegistry.get(UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN),
+      "canonical_underwriter_family_id"
+    );
   }
 
   async listCompaniesForFamily(
     resolver_version: string,
     canonical_underwriter_family_id: string
   ): Promise<string[]> {
-    const rows =
-      (await this.repo.query({ resolver_version, canonical_underwriter_family_id })) ?? [];
-    return rows.map((r) => r.canonical_company_id);
-  }
-
-  async deleteForResolverVersion(resolver_version: string): Promise<number> {
-    const rows = (await this.repo.query({ resolver_version })) ?? [];
-    for (const r of rows) {
-      await this.repo.delete({
-        resolver_version: r.resolver_version,
-        canonical_company_id: r.canonical_company_id,
-        canonical_underwriter_family_id: r.canonical_underwriter_family_id,
-      });
-    }
-    return rows.length;
+    return super.listCompaniesForFamily(resolver_version, canonical_underwriter_family_id);
   }
 }

--- a/src/storage/canonical/UnderwriterFamilyMembershipRepo.ts
+++ b/src/storage/canonical/UnderwriterFamilyMembershipRepo.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN,
+  type UnderwriterFamilyMembership,
+  type UnderwriterFamilyMembershipRepositoryStorage,
+} from "./UnderwriterFamilyMembershipSchema";
+
+export class UnderwriterFamilyMembershipRepo {
+  private repo: UnderwriterFamilyMembershipRepositoryStorage;
+
+  constructor(repo?: UnderwriterFamilyMembershipRepositoryStorage) {
+    this.repo = repo ?? globalServiceRegistry.get(UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN);
+  }
+
+  async record(row: UnderwriterFamilyMembership): Promise<void> {
+    await this.repo.put(row); // PK upsert -> idempotent
+  }
+
+  async listCompaniesForFamily(
+    resolver_version: string,
+    canonical_underwriter_family_id: string
+  ): Promise<string[]> {
+    const rows =
+      (await this.repo.query({ resolver_version, canonical_underwriter_family_id })) ?? [];
+    return rows.map((r) => r.canonical_company_id);
+  }
+
+  async deleteForResolverVersion(resolver_version: string): Promise<number> {
+    const rows = (await this.repo.query({ resolver_version })) ?? [];
+    for (const r of rows) {
+      await this.repo.delete({
+        resolver_version: r.resolver_version,
+        canonical_company_id: r.canonical_company_id,
+        canonical_underwriter_family_id: r.canonical_underwriter_family_id,
+      });
+    }
+    return rows.length;
+  }
+}

--- a/src/storage/canonical/UnderwriterFamilyMembershipSchema.ts
+++ b/src/storage/canonical/UnderwriterFamilyMembershipSchema.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+
+/** Co-occurrence: an underwriter canonical company belongs to an underwriter family. */
+export const UnderwriterFamilyMembershipSchema = Type.Object({
+  resolver_version: Type.String({ maxLength: 32 }),
+  canonical_company_id: Type.String({ maxLength: 36 }),
+  canonical_underwriter_family_id: Type.String({ maxLength: 36 }),
+  seen_at: Type.String(),
+});
+export type UnderwriterFamilyMembership = Static<typeof UnderwriterFamilyMembershipSchema>;
+
+export const UnderwriterFamilyMembershipPrimaryKeyNames = [
+  "resolver_version",
+  "canonical_company_id",
+  "canonical_underwriter_family_id",
+] as const;
+
+export type UnderwriterFamilyMembershipRepositoryStorage = ITabularStorage<
+  typeof UnderwriterFamilyMembershipSchema,
+  typeof UnderwriterFamilyMembershipPrimaryKeyNames,
+  UnderwriterFamilyMembership
+>;
+
+export const UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN =
+  createServiceToken<UnderwriterFamilyMembershipRepositoryStorage>(
+    "sec.storage.underwriterFamilyMembershipRepository"
+  );

--- a/src/storage/canonical/UnderwriterLinkRepo.test.ts
+++ b/src/storage/canonical/UnderwriterLinkRepo.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { UnderwriterLinkRepo } from "./UnderwriterLinkRepo";
+
+describe("UnderwriterLinkRepo", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+
+  it("saves links and lists issuer CIKs for a family", async () => {
+    const repo = new UnderwriterLinkRepo();
+    await repo.save({
+      accession_number: "0000000000-26-000001",
+      extractor_id: "S-1",
+      observation_index: 5,
+      issuer_cik: 1018724,
+      underwriter_canonical_company_id: "co-1",
+      underwriter_family_id: "fam-1",
+      role_detail: "lead",
+      shares_allocated: 3000000,
+      over_allotment_shares: 450000,
+      resolver_version: "1.0.0",
+    });
+    expect(await repo.listIssuerCiksForFamily("fam-1")).toEqual([1018724]);
+  });
+
+  it("clears links for an accession", async () => {
+    const repo = new UnderwriterLinkRepo();
+    await repo.save({
+      accession_number: "0000000000-26-000001",
+      extractor_id: "S-1",
+      observation_index: 5,
+      issuer_cik: 1018724,
+      underwriter_canonical_company_id: "co-1",
+      underwriter_family_id: "fam-1",
+      role_detail: "co-manager",
+      shares_allocated: null,
+      over_allotment_shares: null,
+      resolver_version: "1.0.0",
+    });
+    await repo.clear("0000000000-26-000001");
+    expect(await repo.listIssuerCiksForFamily("fam-1")).toEqual([]);
+  });
+});

--- a/src/storage/canonical/UnderwriterLinkRepo.ts
+++ b/src/storage/canonical/UnderwriterLinkRepo.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  UNDERWRITER_LINK_REPOSITORY_TOKEN,
+  type UnderwriterLink,
+  type UnderwriterLinkRepositoryStorage,
+} from "./UnderwriterLinkSchema";
+
+export class UnderwriterLinkRepo {
+  private repo: UnderwriterLinkRepositoryStorage;
+
+  constructor(repo?: UnderwriterLinkRepositoryStorage) {
+    this.repo = repo ?? globalServiceRegistry.get(UNDERWRITER_LINK_REPOSITORY_TOKEN);
+  }
+
+  async save(row: UnderwriterLink): Promise<void> {
+    await this.repo.put(row);
+  }
+
+  async clear(accession_number: string): Promise<void> {
+    const rows = (await this.repo.query({ accession_number })) ?? [];
+    for (const r of rows) {
+      await this.repo.delete({
+        accession_number,
+        extractor_id: r.extractor_id,
+        observation_index: r.observation_index,
+      });
+    }
+  }
+
+  async listIssuerCiksForFamily(underwriter_family_id: string): Promise<number[]> {
+    const rows = (await this.repo.query({ underwriter_family_id })) ?? [];
+    return [...new Set(rows.map((r) => r.issuer_cik))];
+  }
+}

--- a/src/storage/canonical/UnderwriterLinkSchema.ts
+++ b/src/storage/canonical/UnderwriterLinkSchema.ts
@@ -22,7 +22,12 @@ export const UnderwriterLinkSchema = Type.Object({
   issuer_cik: TypeSecCik(),
   underwriter_canonical_company_id: Type.String({ maxLength: 36 }),
   underwriter_family_id: Type.String({ maxLength: 36 }),
-  role_detail: TypeNullable(Type.String({ maxLength: 32 })),
+  // Constrained to UNDERWRITER_ROLES so a typo or free-form value can't be
+  // persisted; the AI extractor already emits only these literals or null.
+  role_detail: Type.Unsafe<UnderwriterRole | null>({
+    type: ["string", "null"],
+    enum: [...UNDERWRITER_ROLES, null],
+  }),
   shares_allocated: TypeNullable(Type.Integer()),
   over_allotment_shares: TypeNullable(Type.Integer()),
   resolver_version: Type.String({ maxLength: 32 }),

--- a/src/storage/canonical/UnderwriterLinkSchema.ts
+++ b/src/storage/canonical/UnderwriterLinkSchema.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
+import { TypeNullable } from "../../util/TypeBoxUtil";
+
+/** Underwriter role detail. Stored as text; values follow this `as const` set. */
+export const UNDERWRITER_ROLES = ["lead", "bookrunner", "co-manager", "underwriter"] as const;
+export type UnderwriterRole = (typeof UNDERWRITER_ROLES)[number];
+
+/** Per-filing fact: a SPAC/IPO issuer (raw CIK) is underwritten by a bank + family. */
+export const UnderwriterLinkSchema = Type.Object({
+  accession_number: Type.String({ maxLength: 25 }),
+  extractor_id: Type.String({ maxLength: 16 }),
+  observation_index: Type.Integer(),
+  issuer_cik: TypeSecCik(),
+  underwriter_canonical_company_id: Type.String({ maxLength: 36 }),
+  underwriter_family_id: Type.String({ maxLength: 36 }),
+  role_detail: TypeNullable(Type.String({ maxLength: 32 })),
+  shares_allocated: TypeNullable(Type.Integer()),
+  over_allotment_shares: TypeNullable(Type.Integer()),
+  resolver_version: Type.String({ maxLength: 32 }),
+});
+export type UnderwriterLink = Static<typeof UnderwriterLinkSchema>;
+
+export const UnderwriterLinkPrimaryKeyNames = [
+  "accession_number",
+  "extractor_id",
+  "observation_index",
+] as const;
+
+export type UnderwriterLinkRepositoryStorage = ITabularStorage<
+  typeof UnderwriterLinkSchema,
+  typeof UnderwriterLinkPrimaryKeyNames,
+  UnderwriterLink
+>;
+
+export const UNDERWRITER_LINK_REPOSITORY_TOKEN =
+  createServiceToken<UnderwriterLinkRepositoryStorage>("sec.storage.underwriterLinkRepository");

--- a/src/storage/offering/IssuerTickerRepo.test.ts
+++ b/src/storage/offering/IssuerTickerRepo.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { IssuerTickerRepo } from "./IssuerTickerRepo";
+
+describe("IssuerTickerRepo", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+
+  it("stores exact symbols and returns a CIK history ordered by filing date", async () => {
+    const repo = new IssuerTickerRepo();
+    const base = {
+      extractor_id: "S-1",
+      cik: 1848507,
+      security_type: null,
+      is_primary: true,
+      confidence: null,
+      source_span: null,
+      created_at: new Date().toISOString(),
+    };
+    await repo.save({
+      ...base,
+      accession_number: "0000000000-26-000002",
+      exchange: "NASDAQ",
+      ticker: "ACQU",
+      filing_date: "2026-01-02",
+    });
+    await repo.save({
+      ...base,
+      accession_number: "0000000000-26-000009",
+      exchange: "NASDAQ",
+      ticker: "ACQ",
+      filing_date: "2026-06-01",
+    });
+    const history = await repo.history(1848507);
+    expect(history.map((t) => t.ticker)).toEqual(["ACQU", "ACQ"]);
+  });
+
+  it("clears all ticker rows for an accession", async () => {
+    const repo = new IssuerTickerRepo();
+    await repo.save({
+      extractor_id: "S-1",
+      accession_number: "0000000000-26-000002",
+      exchange: "NASDAQ",
+      ticker: "ACQU",
+      cik: 1848507,
+      filing_date: "2026-01-02",
+      security_type: "Units",
+      is_primary: true,
+      confidence: null,
+      source_span: null,
+      created_at: new Date().toISOString(),
+    });
+    await repo.clear("0000000000-26-000002");
+    expect(await repo.history(1848507)).toHaveLength(0);
+  });
+});

--- a/src/storage/offering/IssuerTickerRepo.test.ts
+++ b/src/storage/offering/IssuerTickerRepo.test.ts
@@ -58,4 +58,24 @@ describe("IssuerTickerRepo", () => {
     await repo.clear("0000000000-26-000002");
     expect(await repo.history(1848507)).toHaveLength(0);
   });
+
+  it("orders same-filing-date symbols deterministically (primary first, then ticker)", async () => {
+    const repo = new IssuerTickerRepo();
+    const base = {
+      extractor_id: "S-1",
+      accession_number: "0000000000-26-000002",
+      cik: 1848507,
+      filing_date: "2026-01-02",
+      security_type: null,
+      confidence: null,
+      source_span: null,
+      created_at: new Date().toISOString(),
+    };
+    // Insert non-primary symbols first to prove ordering is not insertion order.
+    await repo.save({ ...base, exchange: "NASDAQ", ticker: "ACQW", is_primary: false });
+    await repo.save({ ...base, exchange: "NASDAQ", ticker: "ACQ", is_primary: false });
+    await repo.save({ ...base, exchange: "NASDAQ", ticker: "ACQU", is_primary: true });
+    const history = await repo.history(1848507);
+    expect(history.map((t) => t.ticker)).toEqual(["ACQU", "ACQ", "ACQW"]);
+  });
 });

--- a/src/storage/offering/IssuerTickerRepo.ts
+++ b/src/storage/offering/IssuerTickerRepo.ts
@@ -34,9 +34,19 @@ export class IssuerTickerRepo {
     }
   }
 
-  /** Every symbol the issuer carried, ordered by filing_date (nulls last). */
+  /**
+   * Every symbol the issuer carried, ordered by filing_date (nulls last), then —
+   * for symbols sharing one filing (the common units/share/warrant trio) — the
+   * primary symbol first, then ticker, so the order is deterministic across the
+   * SQLite and in-memory backends.
+   */
   async history(cik: number): Promise<IssuerTicker[]> {
     const rows = (await this.storage.query({ cik })) ?? [];
-    return rows.sort((a, b) => (a.filing_date ?? "~").localeCompare(b.filing_date ?? "~"));
+    return rows.sort((a, b) => {
+      const byDate = (a.filing_date ?? "~").localeCompare(b.filing_date ?? "~");
+      if (byDate !== 0) return byDate;
+      if (a.is_primary !== b.is_primary) return a.is_primary ? -1 : 1;
+      return a.ticker.localeCompare(b.ticker);
+    });
   }
 }

--- a/src/storage/offering/IssuerTickerRepo.ts
+++ b/src/storage/offering/IssuerTickerRepo.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  ISSUER_TICKER_REPOSITORY_TOKEN,
+  type IssuerTicker,
+  type IssuerTickerRepositoryStorage,
+} from "./IssuerTickerSchema";
+
+export class IssuerTickerRepo {
+  private readonly storage: IssuerTickerRepositoryStorage;
+
+  constructor(storage?: IssuerTickerRepositoryStorage) {
+    this.storage = storage ?? globalServiceRegistry.get(ISSUER_TICKER_REPOSITORY_TOKEN);
+  }
+
+  async save(row: IssuerTicker): Promise<void> {
+    await this.storage.put(row);
+  }
+
+  async clear(accession_number: string): Promise<void> {
+    const rows = (await this.storage.query({ accession_number })) ?? [];
+    for (const r of rows) {
+      await this.storage.delete({
+        extractor_id: r.extractor_id,
+        accession_number: r.accession_number,
+        exchange: r.exchange,
+        ticker: r.ticker,
+      });
+    }
+  }
+
+  /** Every symbol the issuer carried, ordered by filing_date (nulls last). */
+  async history(cik: number): Promise<IssuerTicker[]> {
+    const rows = (await this.storage.query({ cik })) ?? [];
+    return rows.sort((a, b) => (a.filing_date ?? "~").localeCompare(b.filing_date ?? "~"));
+  }
+}

--- a/src/storage/offering/IssuerTickerSchema.ts
+++ b/src/storage/offering/IssuerTickerSchema.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
+import { TypeNullable } from "../../util/TypeBoxUtil";
+
+/**
+ * Point-in-time ticker mention read from an immutable filing. Distinct from the
+ * mutable `EntityTicker` current-snapshot table: this is the longitudinal series
+ * keyed by issuer CIK + filing date. `ticker` is stored EXACT (never normalized);
+ * maxLength 16 preserves suffixed symbols like "GSAH.U" / "GSAH WS".
+ */
+export const IssuerTickerSchema = Type.Object({
+  extractor_id: Type.String({ maxLength: 16 }),
+  accession_number: Type.String({ maxLength: 25 }),
+  exchange: Type.String({ maxLength: 32 }),
+  ticker: Type.String({ maxLength: 16 }),
+  cik: TypeNullable(TypeSecCik()),
+  filing_date: TypeNullable(Type.String({ maxLength: 32 })),
+  security_type: TypeNullable(Type.String({ maxLength: 128 })),
+  is_primary: Type.Boolean(),
+  confidence: TypeNullable(Type.Number()),
+  source_span: TypeNullable(Type.String()),
+  created_at: Type.String(),
+});
+export type IssuerTicker = Static<typeof IssuerTickerSchema>;
+
+export const IssuerTickerPrimaryKeyNames = [
+  "extractor_id",
+  "accession_number",
+  "exchange",
+  "ticker",
+] as const;
+
+export type IssuerTickerRepositoryStorage = ITabularStorage<
+  typeof IssuerTickerSchema,
+  typeof IssuerTickerPrimaryKeyNames,
+  IssuerTicker
+>;
+
+export const ISSUER_TICKER_REPOSITORY_TOKEN = createServiceToken<IssuerTickerRepositoryStorage>(
+  "sec.storage.issuerTickerRepository"
+);

--- a/src/storage/offering/OfferingTermsRepo.test.ts
+++ b/src/storage/offering/OfferingTermsRepo.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { OfferingTermsRepo } from "./OfferingTermsRepo";
+
+describe("OfferingTermsRepo", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+
+  it("saves and reads an offering-terms row by natural key", async () => {
+    const repo = new OfferingTermsRepo();
+    await repo.save({
+      extractor_id: "S-1",
+      accession_number: "0000000000-26-000001",
+      cik: 1018724,
+      security_type: "Common Stock",
+      shares_offered: 5000000,
+      price: null,
+      price_low: 14,
+      price_high: 16,
+      gross_proceeds: 75000000,
+      net_proceeds: 69000000,
+      over_allotment_shares: 750000,
+      exchange: "NASDAQ",
+      ticker: "ACME",
+      par_value: 0.0001,
+      confidence: 0.9,
+      source_span: "We are offering 5,000,000 shares",
+      created_at: new Date().toISOString(),
+    });
+    const got = await repo.get("S-1", "0000000000-26-000001");
+    expect(got?.price_high).toBe(16);
+    expect(got?.ticker).toBe("ACME");
+  });
+});

--- a/src/storage/offering/OfferingTermsRepo.ts
+++ b/src/storage/offering/OfferingTermsRepo.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  OFFERING_TERMS_REPOSITORY_TOKEN,
+  type OfferingTerms,
+  type OfferingTermsRepositoryStorage,
+} from "./OfferingTermsSchema";
+
+export class OfferingTermsRepo {
+  private readonly storage: OfferingTermsRepositoryStorage;
+
+  constructor(storage?: OfferingTermsRepositoryStorage) {
+    this.storage = storage ?? globalServiceRegistry.get(OFFERING_TERMS_REPOSITORY_TOKEN);
+  }
+
+  async save(row: OfferingTerms): Promise<void> {
+    await this.storage.put(row);
+  }
+
+  async get(extractor_id: string, accession_number: string): Promise<OfferingTerms | undefined> {
+    return this.storage.get({ extractor_id, accession_number });
+  }
+}

--- a/src/storage/offering/OfferingTermsSchema.ts
+++ b/src/storage/offering/OfferingTermsSchema.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
+import { TypeNullable } from "../../util/TypeBoxUtil";
+
+/** Filing-level common-equity offering terms (one row per non-SPAC filing). */
+export const OfferingTermsSchema = Type.Object({
+  extractor_id: Type.String({ maxLength: 16 }),
+  accession_number: Type.String({ maxLength: 25 }),
+  cik: TypeNullable(TypeSecCik()),
+  security_type: TypeNullable(Type.String({ maxLength: 128 })),
+  shares_offered: TypeNullable(Type.Integer()),
+  price: TypeNullable(Type.Number()),
+  price_low: TypeNullable(Type.Number()),
+  price_high: TypeNullable(Type.Number()),
+  gross_proceeds: TypeNullable(Type.Number()),
+  net_proceeds: TypeNullable(Type.Number()),
+  over_allotment_shares: TypeNullable(Type.Integer()),
+  exchange: TypeNullable(Type.String({ maxLength: 32 })),
+  ticker: TypeNullable(Type.String({ maxLength: 16 })),
+  par_value: TypeNullable(Type.Number()),
+  confidence: TypeNullable(Type.Number()),
+  source_span: TypeNullable(Type.String()),
+  created_at: Type.String(),
+});
+export type OfferingTerms = Static<typeof OfferingTermsSchema>;
+
+export const OfferingTermsPrimaryKeyNames = ["extractor_id", "accession_number"] as const;
+
+export type OfferingTermsRepositoryStorage = ITabularStorage<
+  typeof OfferingTermsSchema,
+  typeof OfferingTermsPrimaryKeyNames,
+  OfferingTerms
+>;
+
+export const OFFERING_TERMS_REPOSITORY_TOKEN = createServiceToken<OfferingTermsRepositoryStorage>(
+  "sec.storage.offeringTermsRepository"
+);

--- a/src/storage/offering/SpacUnitTermsRepo.test.ts
+++ b/src/storage/offering/SpacUnitTermsRepo.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { SpacUnitTermsRepo } from "./SpacUnitTermsRepo";
+
+describe("SpacUnitTermsRepo", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+
+  it("saves and reads SPAC unit terms by natural key", async () => {
+    const repo = new SpacUnitTermsRepo();
+    await repo.save({
+      extractor_id: "S-1",
+      accession_number: "0000000000-26-000002",
+      cik: 1848507,
+      units_offered: 20000000,
+      price_per_unit: 10,
+      unit_composition: "one share and one-half of one redeemable warrant",
+      warrant_fraction_per_unit: 0.5,
+      right_fraction_per_unit: null,
+      trust_per_unit: 10.1,
+      over_allotment_units: 3000000,
+      exchange: "NASDAQ",
+      ticker: "ACQU",
+      gross_proceeds: 200000000,
+      net_proceeds: null,
+      confidence: 0.85,
+      source_span: "each unit consists of one share",
+      created_at: new Date().toISOString(),
+    });
+    const got = await repo.get("S-1", "0000000000-26-000002");
+    expect(got?.warrant_fraction_per_unit).toBe(0.5);
+    expect(got?.trust_per_unit).toBe(10.1);
+  });
+});

--- a/src/storage/offering/SpacUnitTermsRepo.ts
+++ b/src/storage/offering/SpacUnitTermsRepo.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  SPAC_UNIT_TERMS_REPOSITORY_TOKEN,
+  type SpacUnitTerms,
+  type SpacUnitTermsRepositoryStorage,
+} from "./SpacUnitTermsSchema";
+
+export class SpacUnitTermsRepo {
+  private readonly storage: SpacUnitTermsRepositoryStorage;
+
+  constructor(storage?: SpacUnitTermsRepositoryStorage) {
+    this.storage = storage ?? globalServiceRegistry.get(SPAC_UNIT_TERMS_REPOSITORY_TOKEN);
+  }
+
+  async save(row: SpacUnitTerms): Promise<void> {
+    await this.storage.put(row);
+  }
+
+  async get(extractor_id: string, accession_number: string): Promise<SpacUnitTerms | undefined> {
+    return this.storage.get({ extractor_id, accession_number });
+  }
+}

--- a/src/storage/offering/SpacUnitTermsSchema.ts
+++ b/src/storage/offering/SpacUnitTermsSchema.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
+import { TypeNullable } from "../../util/TypeBoxUtil";
+
+/** Filing-level SPAC unit offering terms (one row per SPAC filing). */
+export const SpacUnitTermsSchema = Type.Object({
+  extractor_id: Type.String({ maxLength: 16 }),
+  accession_number: Type.String({ maxLength: 25 }),
+  cik: TypeNullable(TypeSecCik()),
+  units_offered: TypeNullable(Type.Integer()),
+  price_per_unit: TypeNullable(Type.Number()),
+  unit_composition: TypeNullable(Type.String({ maxLength: 1024 })),
+  warrant_fraction_per_unit: TypeNullable(Type.Number()),
+  right_fraction_per_unit: TypeNullable(Type.Number()),
+  trust_per_unit: TypeNullable(Type.Number()),
+  over_allotment_units: TypeNullable(Type.Integer()),
+  exchange: TypeNullable(Type.String({ maxLength: 32 })),
+  ticker: TypeNullable(Type.String({ maxLength: 16 })),
+  gross_proceeds: TypeNullable(Type.Number()),
+  net_proceeds: TypeNullable(Type.Number()),
+  confidence: TypeNullable(Type.Number()),
+  source_span: TypeNullable(Type.String()),
+  created_at: Type.String(),
+});
+export type SpacUnitTerms = Static<typeof SpacUnitTermsSchema>;
+
+export const SpacUnitTermsPrimaryKeyNames = ["extractor_id", "accession_number"] as const;
+
+export type SpacUnitTermsRepositoryStorage = ITabularStorage<
+  typeof SpacUnitTermsSchema,
+  typeof SpacUnitTermsPrimaryKeyNames,
+  SpacUnitTerms
+>;
+
+export const SPAC_UNIT_TERMS_REPOSITORY_TOKEN = createServiceToken<SpacUnitTermsRepositoryStorage>(
+  "sec.storage.spacUnitTermsRepository"
+);

--- a/src/storage/use-of-proceeds/UseOfProceedsRepo.test.ts
+++ b/src/storage/use-of-proceeds/UseOfProceedsRepo.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { UseOfProceedsRepo } from "./UseOfProceedsRepo";
+
+describe("UseOfProceedsRepo", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+
+  it("saves line items and lists them by accession; clear removes them", async () => {
+    const repo = new UseOfProceedsRepo();
+    const row = {
+      extractor_id: "S-1",
+      accession_number: "0000000000-26-000001",
+      line_index: 0,
+      cik: 1018724,
+      purpose: "working capital",
+      amount: 50000000,
+      percent: 60,
+      note: null,
+      confidence: 0.8,
+      source_span: "working capital",
+      created_at: new Date().toISOString(),
+    };
+    await repo.save(row);
+    const got = await repo.queryByAccession("0000000000-26-000001");
+    expect(got[0].purpose).toBe("working capital");
+    await repo.clear("0000000000-26-000001");
+    expect(await repo.queryByAccession("0000000000-26-000001")).toHaveLength(0);
+  });
+});

--- a/src/storage/use-of-proceeds/UseOfProceedsRepo.ts
+++ b/src/storage/use-of-proceeds/UseOfProceedsRepo.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  USE_OF_PROCEEDS_REPOSITORY_TOKEN,
+  type UseOfProceeds,
+  type UseOfProceedsRepositoryStorage,
+} from "./UseOfProceedsSchema";
+
+export class UseOfProceedsRepo {
+  private readonly storage: UseOfProceedsRepositoryStorage;
+
+  constructor(storage?: UseOfProceedsRepositoryStorage) {
+    this.storage = storage ?? globalServiceRegistry.get(USE_OF_PROCEEDS_REPOSITORY_TOKEN);
+  }
+
+  async save(row: UseOfProceeds): Promise<void> {
+    await this.storage.put(row);
+  }
+
+  async queryByAccession(accession_number: string): Promise<UseOfProceeds[]> {
+    return (await this.storage.query({ accession_number })) ?? [];
+  }
+
+  async clear(accession_number: string): Promise<void> {
+    const rows = await this.queryByAccession(accession_number);
+    for (const r of rows) {
+      await this.storage.delete({
+        extractor_id: r.extractor_id,
+        accession_number: r.accession_number,
+        line_index: r.line_index,
+      });
+    }
+  }
+}

--- a/src/storage/use-of-proceeds/UseOfProceedsSchema.ts
+++ b/src/storage/use-of-proceeds/UseOfProceedsSchema.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
+import { TypeNullable } from "../../util/TypeBoxUtil";
+
+/** Narrative-tolerant use-of-proceeds line item (one row per stated purpose). */
+export const UseOfProceedsSchema = Type.Object({
+  extractor_id: Type.String({ maxLength: 16 }),
+  accession_number: Type.String({ maxLength: 25 }),
+  line_index: Type.Integer(),
+  cik: TypeNullable(TypeSecCik()),
+  purpose: TypeNullable(Type.String({ maxLength: 1024 })),
+  amount: TypeNullable(Type.Number()),
+  percent: TypeNullable(Type.Number()),
+  note: TypeNullable(Type.String({ maxLength: 2048 })),
+  confidence: TypeNullable(Type.Number()),
+  source_span: TypeNullable(Type.String()),
+  created_at: Type.String(),
+});
+export type UseOfProceeds = Static<typeof UseOfProceedsSchema>;
+
+export const UseOfProceedsPrimaryKeyNames = [
+  "extractor_id",
+  "accession_number",
+  "line_index",
+] as const;
+
+export type UseOfProceedsRepositoryStorage = ITabularStorage<
+  typeof UseOfProceedsSchema,
+  typeof UseOfProceedsPrimaryKeyNames,
+  UseOfProceeds
+>;
+
+export const USE_OF_PROCEEDS_REPOSITORY_TOKEN = createServiceToken<UseOfProceedsRepositoryStorage>(
+  "sec.storage.useOfProceedsRepository"
+);

--- a/src/storage/versioning/bootstrapComponentVersions.test.ts
+++ b/src/storage/versioning/bootstrapComponentVersions.test.ts
@@ -56,6 +56,13 @@ describe("bootstrapComponentVersions", () => {
     expect(slot?.semver).toBe("1.0.0");
   });
 
+  it("seeds the underwriter-family resolver at 1.0.0", async () => {
+    await bootstrapComponentVersions();
+    const reg = new VersionRegistry(globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN));
+    const slot = await reg.getCurrent("resolver", "underwriter-family");
+    expect(slot?.semver).toBe("1.0.0");
+  });
+
   it("is idempotent: running it twice does not change anything", async () => {
     await bootstrapComponentVersions();
     const reg = new VersionRegistry(

--- a/src/storage/versioning/ceremonies.ts
+++ b/src/storage/versioning/ceremonies.ts
@@ -345,7 +345,7 @@ export async function dropPrevious(args: DropPreviousArgs): Promise<void> {
       await junctionAddr.deleteForResolverVersion(previous.semver);
       await junctionPhone.deleteForResolverVersion(previous.semver);
       await canonRepo.deleteForResolverVersion(previous.semver);
-    } else {
+    } else if (resolverId === "company") {
       const linkRepo = new CompanyIdentityLinkRepo();
       const junctionAddr = new CanonicalCompanyAddressRepo();
       const junctionPhone = new CanonicalCompanyPhoneRepo();
@@ -354,6 +354,17 @@ export async function dropPrevious(args: DropPreviousArgs): Promise<void> {
       await junctionAddr.deleteForResolverVersion(previous.semver);
       await junctionPhone.deleteForResolverVersion(previous.semver);
       await canonRepo.deleteForResolverVersion(previous.semver);
+    } else {
+      // Family-tier resolvers (sponsor-family / underwriter-family) store
+      // canonical + membership + link rows, not identity-links/junctions. Their
+      // version-scoped purge is not yet wired; refuse rather than fall through to
+      // the company branch, which would destructively delete unrelated company
+      // canonical/identity-link data at this semver.
+      throw new Error(
+        `drop-previous is not yet supported for family resolver kind '${resolverId}'. ` +
+          `Purging canonical/membership/link rows by resolver_version is unimplemented; ` +
+          `the previous slot was left intact.`
+      );
     }
   }
 

--- a/src/storage/versioning/componentRegistry.test.ts
+++ b/src/storage/versioning/componentRegistry.test.ts
@@ -14,10 +14,11 @@ describe("componentRegistry", () => {
     }
   });
 
-  it("registers person, company, and sponsor-family resolvers", () => {
+  it("registers person, company, sponsor-family, and underwriter-family resolvers", () => {
     expect(isRegisteredComponent("resolver", "person")).toBe(true);
     expect(isRegisteredComponent("resolver", "company")).toBe(true);
     expect(isRegisteredComponent("resolver", "sponsor-family")).toBe(true);
+    expect(isRegisteredComponent("resolver", "underwriter-family")).toBe(true);
   });
 
   it("rejects unknown ids", () => {
@@ -26,6 +27,7 @@ describe("componentRegistry", () => {
   });
 
   it("listRegisteredComponents returns one entry per extractor and resolver", () => {
-    expect(listRegisteredComponents()).toHaveLength(13);
+    // 10 extractors + 4 resolvers (person, company, sponsor-family, underwriter-family).
+    expect(listRegisteredComponents()).toHaveLength(14);
   });
 });


### PR DESCRIPTION
## Summary

Extends S-1 form extraction to capture offering details (equity terms, SPAC units, tickers) and underwriter information, plus use-of-proceeds narrative. Introduces a new `underwriter-family` resolver tier parallel to the existing sponsor-family canonical structure, and refactors shared family-resolver logic into reusable base classes.

## Key Changes

**New extraction sections:**
- `extractOfferingTerms()` — parses "The Offering" section for equity IPO terms (shares, price, proceeds) or SPAC unit composition
- `extractUnderwriters()` — parses "Underwriting" section for underwriter legal names, roles, and common names
- `extractUseOfProceeds()` — parses "Use of Proceeds" section for narrative line items and amounts
- Routes offering data to `OfferingTermsRepo` (equity) or `SpacUnitTermsRepo` (SPAC units) based on issuer SIC code
- Stores exact ticker symbols in `IssuerTickerRepo` as a point-in-time series keyed by filing date

**Underwriter family canonical tier:**
- New `CanonicalUnderwriterFamilyRepo`, `CanonicalUnderwriterFamilyAliasRepo`, `UnderwriterFamilyMembershipRepo`, and `UnderwriterLinkRepo` mirror the sponsor-family structure
- `UnderwriterFamilyResolver` resolves underwriter legal entities to canonical family IDs
- CLI commands `sec canonical underwriter-family alias|alias-remove|alias-list` and `sec underwriter by-family` for family management and IPO issuer lookup

**Refactored shared logic:**
- Extracted `FamilyResolver` base class with `normalizeFamilyName()` used by both sponsor and underwriter resolvers
- Extracted `CanonicalFamilyAliasRepo` base class for single-hop alias resolution (add/remove/resolve/list/listByTarget/listOrphans)
- Extracted `FamilyMembershipRepo` base class for co-occurrence membership queries
- `SponsorFamilyMembershipRepo` and `SponsorFamilyAliasRepo` now extend these bases

**Section processing refactor:**
- Unified `runSection()` helper consolidates dead-letter ceremony for all seven S-1 sections (entity + derived)
- Applies confidence floor, handles empty/low-confidence/invalid-output cases consistently
- Eliminates repetitive try-catch and dead-letter boilerplate across management, beneficial-ownership, related-party, offering-terms, underwriters, use-of-proceeds, and sponsor sections

**Storage schemas and repos:**
- `OfferingTermsSchema` / `OfferingTermsRepo` — one row per non-SPAC filing with equity terms
- `SpacUnitTermsSchema` / `SpacUnitTermsRepo` — one row per SPAC filing with unit composition
- `IssuerTickerSchema` / `IssuerTickerRepo` — longitudinal ticker series by CIK + filing date
- `UseOfProceedsSchema` / `UseOfProceedsRepo` — narrative line items with amounts
- `UnderwriterLinkSchema` / `UnderwriterLinkRepo` — issuer-to-underwriter-family relationships with roles

**Tests:**
- `Form_S_1.storage.offering.test.ts` — offering terms and ticker persistence for equity and SPAC filings
- `Form_S_1.storage.underwriters.test.ts` — underwriter extraction and family resolution
- `Form_S_1.storage.useofproceeds.test.ts` — use-of-proceeds line item extraction
- `sectionExtractors.test.ts` — unit tests for each new extractor function
- Repo and resolver unit tests for all new canonical/storage classes

**Dependency injection:**
- Registered new repos in `DefaultDI.ts` and `TestingDI.ts`
- Added `underwriter-family` to `RESOLVER_IDS` and component registry
- Updated `setupAllDatabases.ts` to initialize new schemas

https://claude.ai/code/session_01X8jhKh5Tnkz3st8bS1scd6