### PR TITLE
fix(resolver): flip stale lowercase test literal + JSDoc to UPPER

### DIFF
--- a/src/resolver/SponsorFamilyResolver.ts
+++ b/src/resolver/SponsorFamilyResolver.ts
@@ -18,10 +18,10 @@ interface SponsorFamilyResolverOptions {
 /**
  * The single source of truth for the sponsor-family natural key. Delegates to
  * {@link normalizeFamilyName} (punctuation/whitespace canonicalization plus the
- * suffix handling that helper applies, then lower-casing for case-insensitive
- * matching). Every caller that looks up a family by name (resolver, CLI query,
- * alias commands) MUST use this so keys line up. Returns "" when the name
- * normalizes to nothing.
+ * suffix handling that helper applies, then UPPER-casing for case-insensitive
+ * matching against `canonical_sponsor_family.normalized_name`). Every caller
+ * that looks up a family by name (resolver, CLI query, alias commands) MUST
+ * use this so keys line up. Returns "" when the name normalizes to nothing.
  */
 export function normalizeSponsorFamilyName(name: string): string {
   return normalizeFamilyName(name);

--- a/src/sec/forms/registration-statements/Form_S_1.storage.underwriters.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.underwriters.test.ts
@@ -64,7 +64,7 @@ describe("processFormS1 underwriters", () => {
     const companies = await new CompanyObservationRepo().listAll();
     expect(companies.some((c) => c.name === "Goldman Sachs & Co. LLC")).toBe(true);
 
-    const family = await new CanonicalUnderwriterFamilyRepo().findByResolverAndName("1.0.0", "goldman sachs");
+    const family = await new CanonicalUnderwriterFamilyRepo().findByResolverAndName("1.0.0", "GOLDMAN SACHS");
     expect(family).toBeDefined();
     const members = await new UnderwriterFamilyMembershipRepo().listCompaniesForFamily(
       "1.0.0",


### PR DESCRIPTION
## Summary

Two follow-up fixes to #129, which pinned `FamilyResolver` normalization to UPPER:

- **Critical:** `Form_S_1.storage.underwriters.test.ts:67` still called `findByResolverAndName("1.0.0", "goldman sachs")`. Under the UPPER normalization it returns `undefined`, and the next line dereferences `family!.canonical_underwriter_family_id` and crashes. Flipped the literal to `"GOLDMAN SACHS"` to match the three other test files already updated in #129.
- **High:** `SponsorFamilyResolver.normalizeSponsorFamilyName`'s JSDoc still described "*then lower-casing for case-insensitive matching*". The function delegates to `normalizeFamilyName`, which now UPPER-cases. Updated the doc to describe UPPER-casing and the `canonical_sponsor_family.normalized_name` column it matches against. `UnderwriterFamilyResolver` was checked and has no equivalent stale doc.

## Test plan

- [x] `bun test src/sec/forms/registration-statements/Form_S_1.storage.underwriters.test.ts src/resolver/SponsorFamilyResolver.test.ts src/resolver/UnderwriterFamilyResolver.test.ts src/resolver/FamilyResolver.test.ts` — 11 pass / 0 fail
- [x] `bun run build-types` — clean
- [x] `grep -i 'lower-cas\|lowercas\|lower case' src/resolver/` — no remaining stale refs

https://claude.ai/code/session_0198SNs3pRmADdpeWrGZv9UB

---
_Generated by [Claude Code](https://claude.ai/code/session_0198SNs3pRmADdpeWrGZv9UB)_