### PR TITLE
fix(forms,storage): Crowdfunding history on stale replay + CFPORTAL/A inheritance + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,10 +181,6 @@ sec query reg-a --tier Tier2 --status reporting
 sec query reg-a-summary <cik>      # counts by status/tier + latest aggregate offering
 ```
 
-Known gap: the C-U `progressUpdate` narrative and C/A `natureOfAmendment`
-free-text are parsed but not yet persisted (the crowdfunding tables have no
-text column for them).
-
 Fixtures: `sec fetch fixtures C-U C-AR C-TR` extends the exempt-offering
 mock_data tree (note: the quarterly form.idx endpoint may 403 from cloud
 containers; the committed fixtures were sourced from EDGAR daily indexes).

--- a/src/sec/forms/exempt-offerings/Form_C.storage.ts
+++ b/src/sec/forms/exempt-offerings/Form_C.storage.ts
@@ -443,26 +443,31 @@ export async function processFormC({
     existing.filing_date !== "" &&
     filing_date < existing.filing_date;
 
-  if (!isStale) {
-    const crowdfunding: Crowdfunding = {
-      cik,
-      file_number,
-      filing_date: filing_date || existing?.filing_date || "",
-      name: issuer.nameOfIssuer,
-      legal_status: issuer.legalStatus?.legalStatusForm ?? existing?.legal_status ?? "",
-      state_jurisdiction:
-        issuer.legalStatus?.jurisdictionOrganization ?? existing?.state_jurisdiction ?? "",
-      date_incorporation:
-        issuer.legalStatus?.dateIncorporation ?? existing?.date_incorporation ?? "",
-      url: issuer.issuerWebsite ?? existing?.url ?? "",
-      portal_cik: parsedPortalCik > 0 ? parsedPortalCik : (existing?.portal_cik ?? 0),
-      status: determineStatus(submissionType),
-      progress_update: issuerInfo.progressUpdate ?? existing?.progress_update ?? null,
-      nature_of_amendment: issuerInfo.natureOfAmendment ?? existing?.nature_of_amendment ?? null,
-    };
+  // Always build and write the history snapshot — a stale replay still
+  // belongs in the time series, only the mutable row write is suppressed
+  // (via skipMutableUpdate) so out-of-order processing doesn't regress it.
+  // Falling back to existing fields keeps the snapshot meaningful when the
+  // older filing carried sparser data than the current state.
+  const crowdfunding: Crowdfunding = {
+    cik,
+    file_number,
+    filing_date: filing_date || existing?.filing_date || "",
+    name: issuer.nameOfIssuer,
+    legal_status: issuer.legalStatus?.legalStatusForm ?? existing?.legal_status ?? "",
+    state_jurisdiction:
+      issuer.legalStatus?.jurisdictionOrganization ?? existing?.state_jurisdiction ?? "",
+    date_incorporation:
+      issuer.legalStatus?.dateIncorporation ?? existing?.date_incorporation ?? "",
+    url: issuer.issuerWebsite ?? existing?.url ?? "",
+    portal_cik: parsedPortalCik > 0 ? parsedPortalCik : (existing?.portal_cik ?? 0),
+    status: determineStatus(submissionType),
+    progress_update: issuerInfo.progressUpdate ?? existing?.progress_update ?? null,
+    nature_of_amendment: issuerInfo.natureOfAmendment ?? existing?.nature_of_amendment ?? null,
+  };
 
-    await temporalRepo.saveCrowdfundingWithHistory(crowdfunding, `Form ${submissionType}`);
-  }
+  await temporalRepo.saveCrowdfundingWithHistory(crowdfunding, `Form ${submissionType}`, {
+    skipMutableUpdate: isStale,
+  });
 
   // Issuers: index 0 (issuer), 1+ (co-issuers)
   await processIssuer(cik, formC, ctx, 0);

--- a/src/sec/forms/exempt-offerings/Form_C_postoffering.pipeline.test.ts
+++ b/src/sec/forms/exempt-offerings/Form_C_postoffering.pipeline.test.ts
@@ -7,7 +7,12 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import { resetDependencyInjectionsForTesting } from "../../../config/TestingDI";
 import { setupAllDatabases } from "../../../config/setupAllDatabases";
+import { globalServiceRegistry } from "workglow";
 import { CrowdfundingRepo } from "../../../storage/portal/CrowdfundingRepo";
+import {
+  CROWDFUNDING_HISTORY_REPOSITORY_TOKEN,
+  type CrowdfundingHistory,
+} from "../../../storage/portal/CrowdfundingHistorySchema";
 import { Form_C } from "./Form_C";
 import { determineStatus, processFormC } from "./Form_C.storage";
 import {
@@ -172,5 +177,84 @@ describe("Form C post-offering pipeline (C-U / C-AR / C-TR)", () => {
     const row = await repo.getCrowdfunding(cik, file_number);
     expect(row?.status).toBe("termination");
     expect(row?.filing_date).toBe("2026-01-01");
+  });
+
+  it("writes a CrowdfundingHistory row for an out-of-order older filing without regressing the mutable row", async () => {
+    const repo = new CrowdfundingRepo();
+    const historyRepo = globalServiceRegistry.get(CROWDFUNDING_HISTORY_REPOSITORY_TOKEN);
+    const files = listFixtureFiles("form-c-ar");
+    const xml = readFixture("form-c-ar", files[0]);
+    const parsed = await Form_C.parse("C-AR", xml);
+    const cik = safeCikToInt(parsed.headerData.filerInfo.filer.filerCredentials.filerCik);
+    const file_number = "020-77777";
+
+    // Seed the mutable row at a date newer than the replayed filing.
+    await repo.saveCrowdfunding({
+      cik,
+      file_number,
+      filing_date: "2026-01-01",
+      name: "Current Issuer",
+      legal_status: "Corporation",
+      state_jurisdiction: "DE",
+      date_incorporation: "2020-01-01",
+      url: "https://issuer.example.com",
+      portal_cik: 1725012,
+      status: "termination",
+      progress_update: null,
+      nature_of_amendment: null,
+    });
+
+    await processFormC({
+      cik,
+      file_number,
+      accession_number: accessionFromFixtureName(files[0]),
+      filing_date: "2025-04-28",
+      primary_doc: "primary_doc.xml",
+      formC: parsed,
+    });
+
+    // Mutable row is preserved.
+    const mutable = await repo.getCrowdfunding(cik, file_number);
+    expect(mutable?.status).toBe("termination");
+    expect(mutable?.filing_date).toBe("2026-01-01");
+
+    // History records the older filing as a closed snapshot.
+    const history = (await historyRepo.query({ cik, file_number })) ?? [];
+    const staleRows = history.filter(
+      (h: CrowdfundingHistory) => h.filing_date === "2025-04-28"
+    );
+    expect(staleRows.length).toBeGreaterThan(0);
+    for (const row of staleRows) {
+      expect(row.valid_to).not.toBeNull();
+    }
+  });
+
+  it("writes a CrowdfundingHistory row for a fresh forward filing and leaves the open record open", async () => {
+    const repo = new CrowdfundingRepo();
+    const historyRepo = globalServiceRegistry.get(CROWDFUNDING_HISTORY_REPOSITORY_TOKEN);
+    const files = listFixtureFiles("form-c-ar");
+    const xml = readFixture("form-c-ar", files[0]);
+    const parsed = await Form_C.parse("C-AR", xml);
+    const cik = safeCikToInt(parsed.headerData.filerInfo.filer.filerCredentials.filerCik);
+    const file_number = "020-66666";
+
+    await processFormC({
+      cik,
+      file_number,
+      accession_number: accessionFromFixtureName(files[0]),
+      filing_date: "2025-04-28",
+      primary_doc: "primary_doc.xml",
+      formC: parsed,
+    });
+
+    // Mutable row exists.
+    const mutable = await repo.getCrowdfunding(cik, file_number);
+    expect(mutable).toBeDefined();
+
+    // Exactly one open history row for this fresh filing.
+    const history = (await historyRepo.query({ cik, file_number })) ?? [];
+    expect(history).toHaveLength(1);
+    expect(history[0].filing_date).toBe("2025-04-28");
+    expect(history[0].valid_to).toBeNull();
   });
 });

--- a/src/sec/forms/portal/Form_CFPORTAL.storage.test.ts
+++ b/src/sec/forms/portal/Form_CFPORTAL.storage.test.ts
@@ -135,4 +135,58 @@ describe("Form_CFPORTAL storage", () => {
     });
     expect((await portalRepo.getPortal(cik))?.live).toBe(true);
   });
+
+  it("CFPORTAL/A with absent identifyingInformation fields preserves existing name/brand/url", async () => {
+    const portalRepo = new PortalRepo();
+    const files = fixtureFiles();
+    // Pick the first non-withdrawal fixture that carries identifying info.
+    let seedFile: string | undefined;
+    for (const f of files) {
+      const xml = readFileSync(join(FIXTURE_DIR, f), "utf-8");
+      if (xml.includes("<submissionType>CFPORTAL-W</submissionType>")) continue;
+      const parsedProbe = await Form_CFPORTAL.parse("CFPORTAL", xml);
+      if (parsedProbe.formData?.identifyingInformation?.nameOfPortal) {
+        seedFile = f;
+        break;
+      }
+    }
+    expect(seedFile).toBeDefined();
+
+    const cik = 6666666;
+    const seedXml = readFileSync(join(FIXTURE_DIR, seedFile!), "utf-8");
+    const seedParse = await Form_CFPORTAL.parse("CFPORTAL", seedXml);
+
+    // Seed: register the portal with the full parse.
+    await processFormCFPORTAL({
+      cik,
+      accession_number: "0000000001-24-000010",
+      filing_date: "2024-06-01",
+      formCfportal: seedParse,
+    });
+
+    const seeded = await portalRepo.getPortal(cik);
+    expect(seeded?.name).toBeTruthy();
+    const seededName = seeded?.name;
+    const seededBrand = seeded?.brand;
+    const seededUrl = seeded?.url;
+
+    // Build a follow-up parse that strips identifying fields (simulating an
+    // amendment that only touched other sections).
+    const followUp = await Form_CFPORTAL.parse("CFPORTAL", seedXml);
+    delete (followUp.formData!.identifyingInformation as any).nameOfPortal;
+    delete (followUp.formData!.identifyingInformation as any).otherNamesAndWebsiteUrls;
+
+    await processFormCFPORTAL({
+      cik,
+      accession_number: "0000000001-25-000010",
+      filing_date: "2025-06-01",
+      formCfportal: followUp,
+    });
+
+    const after = await portalRepo.getPortal(cik);
+    expect(after?.name).toBe(seededName ?? null);
+    expect(after?.brand).toBe(seededBrand ?? null);
+    expect(after?.url).toBe(seededUrl ?? null);
+    expect(after?.as_of).toBe("2025-06-01");
+  });
 });

--- a/src/sec/forms/portal/Form_CFPORTAL.storage.ts
+++ b/src/sec/forms/portal/Form_CFPORTAL.storage.ts
@@ -129,14 +129,15 @@ export async function processFormCFPORTAL({
     filing_date < existing.as_of;
 
   if (!isStale) {
-    // Only a withdrawal inherits the registered identity (its formData may be
-    // stripped); a CFPORTAL/A is a full restatement, so an amendment that
-    // drops an alias section genuinely clears brand/url.
+    // Absent fields inherit from the existing portal row — a CFPORTAL/A may
+    // omit identifying info the registered portal still carries. A fresh
+    // CFPORTAL with an absent field stays null (no existing row).
+    const hasName = identifying?.nameOfPortal !== undefined;
     await portalRepo.savePortal({
       cik,
-      name: identifying?.nameOfPortal ?? (isWithdrawal ? (existing?.name ?? null) : null),
-      brand: brand ?? (isWithdrawal ? (existing?.brand ?? null) : null),
-      url: url ?? (isWithdrawal ? (existing?.url ?? null) : null),
+      name: hasName ? (identifying!.nameOfPortal ?? null) : (existing?.name ?? null),
+      brand: brand ?? existing?.brand ?? null,
+      url: url ?? existing?.url ?? null,
       live: !isWithdrawal,
       as_of: filing_date || existing?.as_of || null,
     });

--- a/src/storage/portal/CrowdfundingTemporalRepo.test.ts
+++ b/src/storage/portal/CrowdfundingTemporalRepo.test.ts
@@ -173,6 +173,41 @@ describe("CrowdfundingTemporalRepo", () => {
     expect(statusChange?.new_value).toBe("Inactive");
   });
 
+  test("skipMutableUpdate writes a closed history row, no mutable row, no ChangeLog", async () => {
+    const crowdfunding: Crowdfunding = {
+      cik: 99999,
+      file_number: "020-99999",
+      filing_date: "2025-04-28",
+      name: "Stale Replay Issuer",
+      legal_status: "Corporation",
+      state_jurisdiction: "DE",
+      date_incorporation: "2020-01-01",
+      url: "http://example.com",
+      portal_cik: 12345,
+      status: "annual-report",
+    };
+
+    await temporalRepo.saveCrowdfundingWithHistory(crowdfunding, "STALE_REPLAY", {
+      skipMutableUpdate: true,
+    });
+
+    // No mutable row.
+    const mutable = await temporalRepo.getCrowdfunding(99999, "020-99999");
+    expect(mutable).toBeUndefined();
+
+    // One closed history row (valid_from === valid_to).
+    const history = await temporalRepo.getCrowdfundingHistory(99999, "020-99999");
+    expect(history).toHaveLength(1);
+    expect(history[0].valid_to).not.toBeNull();
+    expect(history[0].valid_to).toBe(history[0].valid_from);
+    expect(history[0].change_source).toBe("STALE_REPLAY");
+    expect(history[0].name).toBe("Stale Replay Issuer");
+
+    // No ChangeLog entry.
+    const changes = await temporalRepo.getCrowdfundingChanges(99999, "020-99999");
+    expect(changes).toHaveLength(0);
+  });
+
   test("should retrieve crowdfunding entity at specific time", async () => {
     const initial: Crowdfunding = {
       cik: 12345,

--- a/src/storage/portal/CrowdfundingTemporalRepo.ts
+++ b/src/storage/portal/CrowdfundingTemporalRepo.ts
@@ -42,18 +42,40 @@ export class CrowdfundingTemporalRepo {
   }
 
   /**
-   * Save a crowdfunding entity with history tracking
+   * Save a crowdfunding entity with history tracking.
+   *
+   * When `options.skipMutableUpdate` is true, append a closed-immediately
+   * `CrowdfundingHistory` snapshot (valid_from === valid_to) capturing what
+   * this filing said and skip both the mutable-row write and ChangeLog
+   * emission — used when replaying an older filing that must not regress
+   * the current state but should still be visible in the time series.
    */
   async saveCrowdfundingWithHistory(
     crowdfunding: Crowdfunding,
     changeSource: string,
+    options?: { skipMutableUpdate?: boolean } | undefined,
     batchId?: string
   ): Promise<void> {
+    const changeDate = new Date().toISOString();
+
+    if (options?.skipMutableUpdate === true) {
+      // Snapshot the older filing as a closed history row; do not touch the
+      // mutable row, do not emit a ChangeLog entry.
+      const history: CrowdfundingHistory = {
+        ...crowdfunding,
+        valid_from: changeDate,
+        valid_to: changeDate,
+        change_source: changeSource,
+        change_date: changeDate,
+      };
+      await this.crowdfundingHistoryRepository.put(history);
+      return;
+    }
+
     const existingCrowdfunding = await this.crowdfundingRepo.getCrowdfunding(
       crowdfunding.cik,
       crowdfunding.file_number
     );
-    const changeDate = new Date().toISOString();
 
     // If entity exists, create history record for the old version
     if (existingCrowdfunding) {


### PR DESCRIPTION
## Summary

Three high-priority fixes to the EDGAR form processors and docs.

### Fix A — Always write CrowdfundingHistory; gate only the mutable update on staleness

A back-catalog replay of an older Form C filing previously skipped *both* the
mutable row update and the history snapshot, so the older filing silently
disappeared from the time series even though it is still real data.

- `src/storage/portal/CrowdfundingTemporalRepo.ts`: add a third positional
  `options: { skipMutableUpdate?: boolean } | undefined` parameter to
  `saveCrowdfundingWithHistory`. When set, append a closed-immediately
  `CrowdfundingHistory` row (`valid_from === valid_to`) and skip the mutable
  write and the `ChangeLog` entry.
- `src/sec/forms/exempt-offerings/Form_C.storage.ts`: remove the
  `if (!isStale)` wrapper. Always build the `crowdfunding` payload (with the
  existing `?? existing?.…` merge fallbacks so the snapshot is meaningful)
  and always call the temporal repo, passing `skipMutableUpdate: isStale`.

### Fix B — CFPORTAL/A field inheritance on absent sections

A `CFPORTAL/A` amendment may omit identifying sections the registered portal
still carries (`nameOfPortal`, `otherNamesAndWebsiteUrls`); the old logic only
inherited those for `CFPORTAL-W` and would null them out on an amendment.

- `src/sec/forms/portal/Form_CFPORTAL.storage.ts`: treat absence (`undefined`
  name; no matching alias entry) as "inherit from existing"; a fresh CFPORTAL
  with no existing row keeps fields null.

### Fix C — Remove stale `CLAUDE.md` "Known gap" paragraph

The crowdfunding tables now persist `progress_update` and `nature_of_amendment`
(see `CrowdfundingSchema` columns and `Form_C.storage.ts` which populates
them), so the "Known gap" note in `CLAUDE.md` is no longer accurate.

## Test plan

- [x] `bun test src/storage/portal/CrowdfundingTemporalRepo.test.ts` — 4/4 pass (includes a new focused unit test that `skipMutableUpdate: true` writes a closed history row, no mutable row, no ChangeLog).
- [x] `bun test src/sec/forms/exempt-offerings/Form_C_postoffering.pipeline.test.ts` — 19/19 pass (includes two new tests: stale older filing writes a closed history row without regressing the mutable row; fresh forward filing leaves the open history record open).
- [x] `bun test src/sec/forms/portal/Form_CFPORTAL.storage.test.ts` — 3/3 pass (includes a new test that a `CFPORTAL/A`-shape parse with `delete`d identifying fields preserves the seeded `name`/`brand`/`url`).
- [x] `bun test src/sec/forms/exempt-offerings` — 162/162 pass.
- [x] `bun test src/sec/forms/portal` — 6/6 pass.
- [x] `bun run build` — clean.

https://claude.ai/code/session_017TXwbp2GD6jvXrELz6msZW

---
_Generated by [Claude Code](https://claude.ai/code/session_017TXwbp2GD6jvXrELz6msZW)_