### PR TITLE
fix(forms,storage): 5 HIGH review findings — stale replay, point-in-time, undated guard, deal sort, Schedule A

### DIFF
--- a/src/commands/issuerDeal.test.ts
+++ b/src/commands/issuerDeal.test.ts
@@ -5,10 +5,34 @@
  */
 
 import { beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry } from "workglow";
 import { resetDependencyInjectionsForTesting } from "../config/TestingDI";
+import { FILING_REPOSITORY_TOKEN, type Filing } from "../storage/filing/FilingSchema";
 import { OfferingTermsRepo } from "../storage/offering/OfferingTermsRepo";
 import { SpacUnitTermsRepo } from "../storage/offering/SpacUnitTermsRepo";
 import { compareIssuerDeal } from "./issuerDeal";
+
+async function seedFiling(cik: number, accession_number: string, filing_date: string) {
+  const repo = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
+  const row: Filing = {
+    cik,
+    accession_number,
+    filing_date,
+    report_date: null,
+    acceptance_date: `${filing_date}T00:00:00.000Z`,
+    form: "S-1",
+    file_number: null,
+    film_number: null,
+    primary_doc: "primary_doc.htm",
+    primary_doc_description: null,
+    size: null,
+    is_xbrl: null,
+    is_inline_xbrl: null,
+    items: null,
+    act: null,
+  };
+  await repo.put(row);
+}
 
 const CIK = 2114227;
 
@@ -75,6 +99,38 @@ describe("compareIssuerDeal", () => {
       delta: null,
     });
     expect(byField.get("ticker")?.delta).toBeNull();
+  });
+
+  // Regression: re-extracting an older amendment after the newer one used
+  // to make the older row "win" because the offerings table was sorted by
+  // created_at. The latest-by-filing-date filing must always be reported as
+  // "registered".
+  it("orders by filing_date, not extract created_at (re-extracted older amendment loses)", async () => {
+    const repo = new SpacUnitTermsRepo();
+    // Newer amendment: extracted earlier.
+    const newerAccession = "0000000000-26-000900";
+    await seedFiling(CIK, newerAccession, "2026-04-15");
+    await repo.save(
+      spacRow("S-1", newerAccession, {
+        units_offered: 30000000,
+        created_at: "2026-04-15T00:00:00.000Z",
+      })
+    );
+
+    // Older amendment: re-extracted LATER (so its created_at is newer).
+    const olderAccession = "0000000000-26-000800";
+    await seedFiling(CIK, olderAccession, "2026-04-01");
+    await repo.save(
+      spacRow("S-1", olderAccession, {
+        units_offered: 25000000,
+        created_at: "2026-05-01T00:00:00.000Z",
+      })
+    );
+
+    const result = (await compareIssuerDeal(CIK))!;
+    // Latest by filing_date wins as "registered", not latest by created_at.
+    expect(result.registered_accession).toBe(newerAccession);
+    expect(result.fields.find((f) => f.field === "units_offered")?.registered).toBe(30000000);
   });
 
   it("uses the latest registration extract when amendments exist", async () => {

--- a/src/commands/issuerDeal.ts
+++ b/src/commands/issuerDeal.ts
@@ -5,6 +5,8 @@
  */
 
 import { Command } from "commander";
+import { globalServiceRegistry } from "workglow";
+import { FILING_REPOSITORY_TOKEN } from "../storage/filing/FilingSchema";
 import type { OfferingTerms } from "../storage/offering/OfferingTermsSchema";
 import { OfferingTermsRepo } from "../storage/offering/OfferingTermsRepo";
 import type { SpacUnitTerms } from "../storage/offering/SpacUnitTermsSchema";
@@ -43,6 +45,37 @@ function latestFor<T extends { extractor_id: string }>(
   extractor_id: string
 ): T | null {
   return rows.find((r) => r.extractor_id === extractor_id) ?? null;
+}
+
+/**
+ * Re-sort offering rows by the underlying filing's filing_date (DESC), with
+ * accession_number and created_at as tie-breakers. `listByCik` orders by
+ * extract recency (`created_at`), which inverts the desired result when an
+ * older amendment is re-extracted after a newer one (re-extraction bumps
+ * `created_at` but not filing_date). The offering-terms tables don't carry
+ * filing_date, so we look it up from the filings table by accession_number.
+ */
+async function sortByFilingDate<T extends { accession_number: string; created_at: string }>(
+  cik: number,
+  rows: readonly T[]
+): Promise<T[]> {
+  if (rows.length === 0) return [];
+  const filingRepo = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
+  const accessionToFilingDate = new Map<string, string>();
+  for (const row of rows) {
+    if (accessionToFilingDate.has(row.accession_number)) continue;
+    const filing = await filingRepo.get({ cik, accession_number: row.accession_number });
+    accessionToFilingDate.set(row.accession_number, filing?.filing_date ?? "");
+  }
+  return [...rows].sort((a, b) => {
+    const fdA = accessionToFilingDate.get(a.accession_number) ?? "";
+    const fdB = accessionToFilingDate.get(b.accession_number) ?? "";
+    return (
+      fdB.localeCompare(fdA) ||
+      b.accession_number.localeCompare(a.accession_number) ||
+      b.created_at.localeCompare(a.created_at)
+    );
+  });
 }
 
 function spacFields(reg: SpacUnitTerms | null, fin: SpacUnitTerms | null): DealField[] {
@@ -87,8 +120,8 @@ function equityFields(reg: OfferingTerms | null, fin: OfferingTerms | null): Dea
  * terms exist for the CIK, the table containing the priced row wins.
  */
 export async function compareIssuerDeal(cik: number): Promise<DealComparison | null> {
-  const spacRows = await new SpacUnitTermsRepo().listByCik(cik);
-  const equityRows = await new OfferingTermsRepo().listByCik(cik);
+  const spacRows = await sortByFilingDate(cik, await new SpacUnitTermsRepo().listByCik(cik));
+  const equityRows = await sortByFilingDate(cik, await new OfferingTermsRepo().listByCik(cik));
 
   const spacReg = latestFor(spacRows, "S-1");
   const spacFin = latestFor(spacRows, "424");

--- a/src/sec/forms/exempt-offerings/Form_1_A.storage.ts
+++ b/src/sec/forms/exempt-offerings/Form_1_A.storage.ts
@@ -428,13 +428,16 @@ export async function processForm1A({
   const existing = await regARepo.getOffering(cik, file_number);
 
   // Mutable row = latest filing by filing date; skip stale out-of-order
-  // writes (unknown "" dates can't be ordered and apply as-is). The history
-  // row below is per-accession and always recorded.
+  // writes. An undated incoming filing ("") cannot be ordered against a
+  // dated existing row and is treated as stale, so a filer error with no
+  // SGML date in the header does not clobber a known-dated mutable row.
+  // (When the existing row is also undated or absent, an undated filing
+  // still applies — there's nothing to regress.) The history row below is
+  // per-accession and always recorded.
   const isStale =
-    filing_date !== "" &&
     existing?.as_of != null &&
     existing.as_of !== "" &&
-    filing_date < existing.as_of;
+    (filing_date === "" || filing_date < existing.as_of);
 
   if (!isStale) {
     const offering: RegAOffering = {

--- a/src/sec/forms/exempt-offerings/Form_C.storage.test.ts
+++ b/src/sec/forms/exempt-offerings/Form_C.storage.test.ts
@@ -444,6 +444,42 @@ describe("Form_C storage test", () => {
       expect(mutable?.filing_date).toBe("2026-05-01");
     });
 
+    // Regression guard: an undated filing must not clobber the dated current
+    // row. Filers occasionally submit with no date in the SGML header.
+    it("undated stale replay does not regress a dated mutable row", async () => {
+      const mockDataDir = join(__dirname, "mock_data", "form-c");
+      const xmlFiles = readdirSync(mockDataDir).filter((file) => file.endsWith(".xml"));
+      const xmlContent = readFileSync(join(mockDataDir, xmlFiles[0]), "utf-8");
+      const formC = await Form_C.parse("C", xmlContent);
+      const cik = parseInt(formC.headerData.filerInfo.filer.filerCredentials.filerCik);
+      const fileNumber = "020-stale-und";
+
+      await processFormC({
+        cik,
+        file_number: fileNumber,
+        accession_number: "test-und-newer",
+        filing_date: "2026-05-01",
+        primary_doc: xmlFiles[0],
+        formC,
+      });
+
+      const seeded = await crowdfundingRepo.getCrowdfunding(cik, fileNumber);
+      expect(seeded?.filing_date).toBe("2026-05-01");
+
+      // Undated replay (filer error). Any dated row must win.
+      await processFormC({
+        cik,
+        file_number: fileNumber,
+        accession_number: "test-und-replay",
+        filing_date: "",
+        primary_doc: xmlFiles[0],
+        formC,
+      });
+
+      const after = await crowdfundingRepo.getCrowdfunding(cik, fileNumber);
+      expect(after?.filing_date).toBe("2026-05-01");
+    });
+
     // Regression guard: `currentEmployees` is schema-typed
     // DECIMAL_TYPE7_2_NONNEGATIVE. The string-decimal migration moved
     // the parse-time `minimum: 0` invariant into storage. A malformed

--- a/src/sec/forms/exempt-offerings/Form_C.storage.test.ts
+++ b/src/sec/forms/exempt-offerings/Form_C.storage.test.ts
@@ -389,6 +389,61 @@ describe("Form_C storage test", () => {
       }
     });
 
+    // Regression guard: a stale (older) replay must snapshot its OWN
+    // filing_date into CrowdfundingHistory, not the dated existing row's.
+    // Otherwise the time series reads back the wrong date for the replay.
+    it("stale replay snapshots its own filing_date in history (not the existing row's)", async () => {
+      const mockDataDir = join(__dirname, "mock_data", "form-c");
+      const xmlFiles = readdirSync(mockDataDir).filter((file) => file.endsWith(".xml"));
+      const xmlContent = readFileSync(join(mockDataDir, xmlFiles[0]), "utf-8");
+      const formC = await Form_C.parse("C", xmlContent);
+      const cik = parseInt(formC.headerData.filerInfo.filer.filerCredentials.filerCik);
+      const fileNumber = "020-stale-fd";
+
+      // Seed: a dated current row from a newer filing.
+      await processFormC({
+        cik,
+        file_number: fileNumber,
+        accession_number: "test-stale-newer",
+        filing_date: "2026-05-01",
+        primary_doc: xmlFiles[0],
+        formC,
+      });
+
+      const { CrowdfundingTemporalRepo } = await import(
+        "../../../storage/portal/CrowdfundingTemporalRepo"
+      );
+      const temporalRepo = new CrowdfundingTemporalRepo();
+      const beforeHistory = await temporalRepo.getCrowdfundingHistory(cik, fileNumber);
+      const seedHistoryCount = beforeHistory.length;
+
+      // Replay an OLDER filing (different accession). The mutable row stays
+      // anchored at 2026-05-01; the history snapshot must carry 2026-04-01.
+      await processFormC({
+        cik,
+        file_number: fileNumber,
+        accession_number: "test-stale-older",
+        filing_date: "2026-04-01",
+        primary_doc: xmlFiles[0],
+        formC,
+      });
+
+      const afterHistory = await temporalRepo.getCrowdfundingHistory(cik, fileNumber);
+      expect(afterHistory.length).toBe(seedHistoryCount + 1);
+
+      // The most recently appended row (closed-immediately, change_source
+      // starts with "Form ") is the stale-replay snapshot.
+      const replaySnapshot = afterHistory.find(
+        (h) => h.valid_to !== null && h.valid_to === h.valid_from
+      );
+      expect(replaySnapshot).toBeDefined();
+      expect(replaySnapshot?.filing_date).toBe("2026-04-01");
+
+      // Mutable row stays anchored at the newer filing_date.
+      const mutable = await crowdfundingRepo.getCrowdfunding(cik, fileNumber);
+      expect(mutable?.filing_date).toBe("2026-05-01");
+    });
+
     // Regression guard: `currentEmployees` is schema-typed
     // DECIMAL_TYPE7_2_NONNEGATIVE. The string-decimal migration moved
     // the parse-time `minimum: 0` invariant into storage. A malformed

--- a/src/sec/forms/exempt-offerings/Form_C.storage.ts
+++ b/src/sec/forms/exempt-offerings/Form_C.storage.ts
@@ -447,11 +447,15 @@ export async function processFormC({
   // belongs in the time series, only the mutable row write is suppressed
   // (via skipMutableUpdate) so out-of-order processing doesn't regress it.
   // Falling back to existing fields keeps the snapshot meaningful when the
-  // older filing carried sparser data than the current state.
+  // older filing carried sparser data than the current state. The
+  // filing_date is exempt from that fallback: when stale, the snapshot must
+  // record this replay's own filing_date so the time series reflects when
+  // each filing was actually made. The schema requires a string, so unknown
+  // dates are stored as "" rather than inheriting the existing row's date.
   const crowdfunding: Crowdfunding = {
     cik,
     file_number,
-    filing_date: filing_date || existing?.filing_date || "",
+    filing_date: isStale ? filing_date : filing_date || existing?.filing_date || "",
     name: issuer.nameOfIssuer,
     legal_status: issuer.legalStatus?.legalStatusForm ?? existing?.legal_status ?? "",
     state_jurisdiction:

--- a/src/sec/forms/exempt-offerings/Form_C.storage.ts
+++ b/src/sec/forms/exempt-offerings/Form_C.storage.ts
@@ -434,14 +434,17 @@ export async function processFormC({
 
   // The mutable row reflects the latest filing by *filing date*, not by
   // processing order: a back-catalog replay of an older filing must not
-  // regress it. Unknown dates ("") can't be ordered and apply as-is. The
-  // per-filing tables (offerings, disclosure reports, observations) below
-  // are keyed by filing/accession and always record the older filing too.
+  // regress it. An undated incoming filing ("") cannot be ordered against
+  // a dated existing row and is treated as stale, so a filer error with no
+  // SGML date in the header does not clobber a known-dated mutable row.
+  // (When the existing row is also undated or absent, an undated filing
+  // still applies — there's nothing to regress.) The per-filing tables
+  // (offerings, disclosure reports, observations) below are keyed by
+  // filing/accession and always record the older filing too.
   const isStale =
-    filing_date !== "" &&
     existing?.filing_date !== undefined &&
     existing.filing_date !== "" &&
-    filing_date < existing.filing_date;
+    (filing_date === "" || filing_date < existing.filing_date);
 
   // Always build and write the history snapshot — a stale replay still
   // belongs in the time series, only the mutable row write is suppressed

--- a/src/sec/forms/portal/Form_CFPORTAL.storage.test.ts
+++ b/src/sec/forms/portal/Form_CFPORTAL.storage.test.ts
@@ -136,6 +136,111 @@ describe("Form_CFPORTAL storage", () => {
     expect((await portalRepo.getPortal(cik))?.live).toBe(true);
   });
 
+  // Regression: a person whose name happens to include a company-ending
+  // word ("Holdings LLC") was routed to observeCompany when entityType was
+  // absent — contaminating the canonical company pool. With no CIK/CRD
+  // identifier, the heuristic now prefers person.
+  it("Schedule A: missing entityType + no CIK/CRD routes the owner to observePerson", async () => {
+    const personObs = new PersonObservationRepo();
+    const companyObs = new CompanyObservationRepo();
+
+    const cik = 5555555;
+    const accession = "0000000001-26-000099";
+
+    // Synthetic CFPORTAL parse with one Schedule A owner whose entityType
+    // is absent and who carries no CIK/CRD.
+    const synthetic: any = {
+      headerData: {
+        submissionType: "CFPORTAL",
+        filerInfo: {
+          filer: {
+            filerCredentials: {
+              filerCik: String(cik),
+            },
+          },
+        },
+      },
+      formData: {
+        identifyingInformation: {
+          nameOfPortal: "Test Portal LLC",
+        },
+        scheduleA: {
+          entityOrNaturalPerson: [
+            {
+              fullLegalName: "John Smith Holdings LLC",
+              // entityType intentionally absent
+              titleStatus: "Director",
+              ownershipCode: "A",
+              controlPerson: "Y",
+              // cikNumber / crdNumber absent
+            },
+          ],
+        },
+      },
+    };
+
+    await processFormCFPORTAL({
+      cik,
+      accession_number: accession,
+      filing_date: "2026-06-01",
+      formCfportal: synthetic,
+    });
+
+    const persons = await personObs.listByAccession(accession);
+    const companies = await companyObs.listByAccession(accession);
+
+    // The owner (index 100) must be a person, not a company.
+    expect(persons.some((o) => o.observation_index === 100)).toBe(true);
+    expect(companies.some((o) => o.observation_index === 100)).toBe(false);
+  });
+
+  // Companion to the above: when a CIK is present, the company-ending
+  // heuristic still routes to observeCompany (companies typically carry an
+  // identifier).
+  it("Schedule A: missing entityType + a CIK still routes a company-ending name to observeCompany", async () => {
+    const personObs = new PersonObservationRepo();
+    const companyObs = new CompanyObservationRepo();
+
+    const cik = 5555556;
+    const accession = "0000000001-26-000100";
+
+    const synthetic: any = {
+      headerData: {
+        submissionType: "CFPORTAL",
+        filerInfo: {
+          filer: {
+            filerCredentials: { filerCik: String(cik) },
+          },
+        },
+      },
+      formData: {
+        identifyingInformation: { nameOfPortal: "Test Portal LLC" },
+        scheduleA: {
+          entityOrNaturalPerson: [
+            {
+              fullLegalName: "Acme Holdings LLC",
+              titleStatus: "Member",
+              cikNumber: "1234567",
+            },
+          ],
+        },
+      },
+    };
+
+    await processFormCFPORTAL({
+      cik,
+      accession_number: accession,
+      filing_date: "2026-06-01",
+      formCfportal: synthetic,
+    });
+
+    const persons = await personObs.listByAccession(accession);
+    const companies = await companyObs.listByAccession(accession);
+
+    expect(companies.some((o) => o.observation_index === 100)).toBe(true);
+    expect(persons.some((o) => o.observation_index === 100)).toBe(false);
+  });
+
   it("CFPORTAL/A with absent identifyingInformation fields preserves existing name/brand/url", async () => {
     const portalRepo = new PortalRepo();
     const files = fixtureFiles();

--- a/src/sec/forms/portal/Form_CFPORTAL.storage.ts
+++ b/src/sec/forms/portal/Form_CFPORTAL.storage.ts
@@ -119,14 +119,17 @@ export async function processFormCFPORTAL({
 
   // The mutable row reflects the latest filing by *filing date*, not by
   // processing order — a back-catalog replay of the original registration
-  // must not resurrect a withdrawn portal. Unknown dates ("") can't be
-  // ordered and apply as-is. Observations below are keyed by accession and
-  // always record the older filing too.
+  // must not resurrect a withdrawn portal. An undated incoming filing ("")
+  // cannot be ordered against a dated existing row and is treated as
+  // stale, so a filer error with no SGML date in the header does not
+  // clobber a known-dated mutable row. (When the existing row is also
+  // undated or absent, an undated filing still applies — there's nothing
+  // to regress.) Observations below are keyed by accession and always
+  // record the older filing too.
   const isStale =
-    filing_date !== "" &&
     existing?.as_of != null &&
     existing.as_of !== "" &&
-    filing_date < existing.as_of;
+    (filing_date === "" || filing_date < existing.as_of);
 
   if (!isStale) {
     // Absent fields inherit from the existing portal row — a CFPORTAL/A may

--- a/src/sec/forms/portal/Form_CFPORTAL.storage.ts
+++ b/src/sec/forms/portal/Form_CFPORTAL.storage.ts
@@ -204,11 +204,19 @@ export async function processFormCFPORTAL({
       ownershipCode: owner.ownershipCode ?? null,
       controlPerson: owner.controlPerson ?? null,
     });
-    // entityType is optional in the schema; when absent, fall back to the
-    // same company-ending heuristic Form C uses for signature names.
+    // entityType is optional in the schema. When absent and neither CIK nor
+    // CRD is provided, prefer person: natural persons rarely carry CIK/CRD
+    // on Schedule A, and "John Smith Holdings LLC" otherwise trips the
+    // company-ending heuristic and contaminates the canonical company pool.
+    // When at least one identifier is present we keep the hasCompanyEnding
+    // tiebreaker.
+    const ownerCikRaw = parseCikSafely(owner.cikNumber);
+    const ownerCrdNormalized = crdOrNull(owner.crdNumber);
+    const hasAnyIdentifier = ownerCikRaw > 0 || ownerCrdNormalized !== null;
     const isNaturalPerson =
       owner.entityType === "NP" ||
-      (owner.entityType === undefined && !hasCompanyEnding(owner.fullLegalName));
+      (owner.entityType === undefined &&
+        (!hasAnyIdentifier || !hasCompanyEnding(owner.fullLegalName)));
     if (isNaturalPerson) {
       const name = splitScheduleAName(owner.fullLegalName);
       await observer.observePerson({
@@ -225,14 +233,13 @@ export async function processFormCFPORTAL({
         source_context,
       });
     } else {
-      const ownerCik = parseCikSafely(owner.cikNumber);
       await observer.observeCompany({
         accession_number,
         extractor_id: EXTRACTOR_ID,
         extractor_version: EXTRACTOR_VERSION,
         observation_index: index,
-        cik: ownerCik > 0 ? ownerCik : null,
-        crd_number: crdOrNull(owner.crdNumber),
+        cik: ownerCikRaw > 0 ? ownerCikRaw : null,
+        crd_number: ownerCrdNormalized,
         name: owner.fullLegalName,
         source_context,
       });

--- a/src/storage/portal/CrowdfundingTemporalRepo.test.ts
+++ b/src/storage/portal/CrowdfundingTemporalRepo.test.ts
@@ -208,6 +208,89 @@ describe("CrowdfundingTemporalRepo", () => {
     expect(changes).toHaveLength(0);
   });
 
+  // Regression: closed-immediately (stale-replay) history rows must be
+  // visible to getCrowdfundingAtTime. Approach: half-open intervals stay
+  // [valid_from, valid_to) for normal rows, but rows where valid_from ===
+  // valid_to are matched at the single instant valid_from. When a dominant
+  // (open or non-closed-immediately) row also matches the same instant the
+  // dominant row wins.
+  test("getCrowdfundingAtTime surfaces a stale-replay snapshot at its instant", async () => {
+    const stale: Crowdfunding = {
+      cik: 88888,
+      file_number: "020-88888",
+      filing_date: "2024-01-01",
+      name: "Stale Replay Snapshot",
+      legal_status: "Corporation",
+      state_jurisdiction: "DE",
+      date_incorporation: "2020-01-01",
+      url: "http://example.com",
+      portal_cik: 11111,
+      status: "annual-report",
+    };
+
+    await temporalRepo.saveCrowdfundingWithHistory(stale, "Form C-AR", {
+      skipMutableUpdate: true,
+    });
+
+    const history = await temporalRepo.getCrowdfundingHistory(88888, "020-88888");
+    expect(history).toHaveLength(1);
+    expect(history[0].valid_to).toBe(history[0].valid_from);
+
+    // The snapshot's instant: getCrowdfundingAtTime must surface it (was
+    // invisible under strict `>` on valid_to).
+    const at = await temporalRepo.getCrowdfundingAtTime(
+      88888,
+      "020-88888",
+      new Date(history[0].valid_from)
+    );
+    expect(at?.name).toBe("Stale Replay Snapshot");
+  });
+
+  test("getCrowdfundingAtTime prefers dominant row when both match the same instant", async () => {
+    // Seed an open dominant row, then write a stale-replay snapshot whose
+    // valid_from happens to fall inside the dominant row's interval. The
+    // dominant row should win at the snapshot's instant.
+    const dominant: Crowdfunding = {
+      cik: 77777,
+      file_number: "020-77777",
+      filing_date: "2024-01-01",
+      name: "Dominant Open Row",
+      legal_status: "Corporation",
+      state_jurisdiction: "DE",
+      date_incorporation: "2020-01-01",
+      url: "http://example.com",
+      portal_cik: 22222,
+      status: "active",
+    };
+    await temporalRepo.saveCrowdfundingWithHistory(dominant, "Form C");
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const replay: Crowdfunding = {
+      ...dominant,
+      name: "Stale Older Snapshot",
+      status: "annual-report",
+    };
+    await temporalRepo.saveCrowdfundingWithHistory(replay, "Form C-AR", {
+      skipMutableUpdate: true,
+    });
+
+    const history = await temporalRepo.getCrowdfundingHistory(77777, "020-77777");
+    const closedImmediate = history.find((h) => h.valid_to !== null && h.valid_to === h.valid_from);
+    expect(closedImmediate).toBeDefined();
+
+    const at = await temporalRepo.getCrowdfundingAtTime(
+      77777,
+      "020-77777",
+      new Date(closedImmediate!.valid_from)
+    );
+    // Dominant row wins at the overlap instant.
+    expect(at?.name).toBe("Dominant Open Row");
+
+    // Stale-replay snapshot still discoverable via history listing.
+    expect(history.some((h) => h.name === "Stale Older Snapshot")).toBe(true);
+  });
+
   test("should retrieve crowdfunding entity at specific time", async () => {
     const initial: Crowdfunding = {
       cik: 12345,

--- a/src/storage/portal/CrowdfundingTemporalRepo.ts
+++ b/src/storage/portal/CrowdfundingTemporalRepo.ts
@@ -173,13 +173,28 @@ export class CrowdfundingTemporalRepo {
       return undefined;
     }
 
-    // Find the record that was valid at the given timestamp
+    // Find the record(s) valid at the given timestamp. A normal interval is
+    // [valid_from, valid_to) — strict on the right so a row that closes at
+    // `t` does not also match at `t`. A stale-replay snapshot is
+    // closed-immediately (valid_from === valid_to): without a half-open
+    // exception it would match at no timestamp, leaving the row write-only.
+    // For those rows we widen to a single-point match at valid_from. If a
+    // dominant (non-closed-immediately) row also matches at the same
+    // instant, prefer the dominant row — the stale-replay snapshot stays
+    // discoverable via getCrowdfundingHistory.
     const timestampStr = timestamp.toISOString();
-    const validRecord = history.find((record) => {
+    const matches = history.filter((record) => {
       const isAfterStart = record.valid_from <= timestampStr;
-      const isBeforeEnd = !record.valid_to || record.valid_to > timestampStr;
+      const isClosedImmediately =
+        record.valid_to !== null && record.valid_to === record.valid_from;
+      const isBeforeEnd = isClosedImmediately
+        ? record.valid_to! >= timestampStr
+        : !record.valid_to || record.valid_to > timestampStr;
       return isAfterStart && isBeforeEnd;
     });
+
+    const dominant = matches.find((r) => r.valid_to === null || r.valid_to !== r.valid_from);
+    const validRecord = dominant ?? matches[0];
 
     if (validRecord) {
       const { change_source, change_date, valid_from, valid_to, ...crowdfunding } = validRecord;


### PR DESCRIPTION
## Summary

Fixes 5 HIGH-priority review findings across the temporal-guard and observation paths. Each finding is its own commit with a regression test.

### 1. Form C stale-replay history snapshot adopts existing `filing_date`
`src/sec/forms/exempt-offerings/Form_C.storage.ts`

The Crowdfunding row built for `saveCrowdfundingWithHistory({ skipMutableUpdate: true })` fell back to `existing?.filing_date` for `filing_date`. The history snapshot therefore carried the dominant row's date, not the replay's — the time series misrepresented when each filing was actually made. Fix: when stale, the snapshot records the replay's own `filing_date` verbatim (empty string preserved when unknown rather than inheriting the existing row's date). The mutable-row merge path is unchanged.

### 2. Closed-immediately history rows invisible to point-in-time queries
`src/storage/portal/CrowdfundingTemporalRepo.ts`

The point-in-time predicate used a strict `[valid_from, valid_to)` interval — but stale-replay snapshots write `valid_from === valid_to`, so they matched at no timestamp and were effectively write-only.

**Approach: option (a)** — kept `[valid_from, valid_to)` for normal rows and added a single-point match when `valid_from === valid_to`. Option (a) was safe because no production path other than stale-replay produces closed-immediately rows. When a dominant (open or non-closed-immediately) row also matches the same instant, the dominant row wins, so a stale-replay snapshot never shadows live state — it stays discoverable via `getCrowdfundingHistory`.

### 3. Undated filings clobber dated current state
`src/sec/forms/exempt-offerings/Form_C.storage.ts`, `src/sec/forms/exempt-offerings/Form_1_A.storage.ts`, `src/sec/forms/portal/Form_CFPORTAL.storage.ts`

The temporal-guard predicate `filing_date !== "" && ... && filing_date < existing.as_of` treated empty incoming `filing_date` as "apply-as-is", letting a filer error with no SGML date nullify known-dated mutable fields.

**Approach:** flipped the predicate to treat empty incoming `filing_date` as stale when the existing row carries a dated `as_of` / `filing_date`. When the existing row is also undated or absent, an undated filing still applies. No shared helper exists; updated identically across the three required call sites (Form_1_K and Form_1_Z were left alone as out of scope).

### 4. `compareIssuerDeal` sorts by `created_at` not filing date
`src/commands/issuerDeal.ts`

`SpacUnitTermsRepo.listByCik` and `OfferingTermsRepo.listByCik` ordered by `created_at DESC`. Re-extracting an older S-1 amendment after a newer one inverted the result because re-extraction bumps `created_at` without affecting the underlying filing's `filing_date` — the command then reported a stale amendment as "registered".

`filing_date` is not a column on the offering-terms tables, so the fix joins through the filings table by `accession_number` inside `compareIssuerDeal` and re-sorts by `(filing_date DESC, accession_number DESC, created_at DESC)`. `listByCik` keeps its `created_at`-based order for callers that want extract recency (no other callers in tree).

### 5. CFPORTAL Schedule A misroutes persons as companies
`src/sec/forms/portal/Form_CFPORTAL.storage.ts`

When `entityType` was absent, the code used `hasCompanyEnding(name)` to decide person vs company. "John Smith Holdings LLC" tripped the heuristic and contaminated the canonical company pool. Fix: when `entityType` is absent AND both `cikNumber` and `crdNumber` are absent, prefer person. `hasCompanyEnding` is retained as a tiebreaker only when at least one identifier is present.

## Test coverage

- `CrowdfundingTemporalRepo.test.ts` — two new tests (snapshot visible at its instant; dominant row wins at overlap)
- `Form_C.storage.test.ts` — two new tests (stale replay snapshots its own filing_date; undated replay does not regress)
- `Form_CFPORTAL.storage.test.ts` — two new tests (person preferred without identifier; company still wins with a CIK)
- `issuerDeal.test.ts` — one new test (older amendment re-extracted last still loses to newer by filing_date)

## Test plan

- [x] `bun test src/storage/portal/CrowdfundingTemporalRepo.test.ts` — 6 pass
- [x] `bun test src/sec/forms/exempt-offerings/Form_C.storage.test.ts` — 13 pass
- [x] `bun test src/sec/forms/portal/Form_CFPORTAL.storage.test.ts` — 5 pass
- [x] `bun test src/commands/issuerDeal.test.ts` — 5 pass
- [x] Broader sanity: `bun test src/storage/portal/ src/sec/forms/exempt-offerings/ src/sec/forms/portal/ src/sec/forms/registration-statements/ src/commands/ src/storage/offering/` — 284 pass / 0 fail
- [x] `bunx tsc --noEmit` clean

https://claude.ai/code/session_012goPYgXU4i7BF2k8aDatKP

---
_Generated by [Claude Code](https://claude.ai/code/session_012goPYgXU4i7BF2k8aDatKP)_