### PR TITLE
fix(forms,portal): undated 1-K/1-Z guard + deterministic stale-replay tie-break (2 HIGH from code review)

### DIFF
--- a/src/sec/forms/exempt-offerings/Form_1_K.storage.test.ts
+++ b/src/sec/forms/exempt-offerings/Form_1_K.storage.test.ts
@@ -268,5 +268,45 @@ describe("Form_1_K storage test", () => {
       });
       expect(history?.price_per_security).toBe(0);
     });
+
+    it("undated stale replay does not regress a dated mutable row", async () => {
+      const mockDataDir = join(__dirname, "mock_data", "form-1-k");
+      const xmlFiles = readdirSync(mockDataDir).filter((file) => file.endsWith(".xml"));
+      const xmlContent = readFileSync(join(mockDataDir, xmlFiles[0]), "utf-8");
+      const form1K = await Form_1_K.parse("1-K", xmlContent);
+      const cik = 990010;
+      const fileNumber = "024-1k-und";
+
+      await processForm1K({
+        cik,
+        file_number: fileNumber,
+        accession_number: "1k-dated-seed",
+        filing_date: "2024-06-15",
+        primary_doc: xmlFiles[0],
+        form1K,
+      });
+
+      const seeded = await regARepo.getOffering(cik, fileNumber);
+      expect(seeded?.as_of).toBe("2024-06-15");
+      const seededTier = seeded?.tier ?? null;
+      const seededIssuerName = seeded?.issuer_name ?? null;
+      const seededSicCode = seeded?.sic_code ?? null;
+
+      // Undated replay (filer error). Any dated row must win.
+      await processForm1K({
+        cik,
+        file_number: fileNumber,
+        accession_number: "1k-undated-replay",
+        filing_date: "",
+        primary_doc: xmlFiles[0],
+        form1K,
+      });
+
+      const after = await regARepo.getOffering(cik, fileNumber);
+      expect(after?.as_of).toBe("2024-06-15");
+      expect(after?.tier ?? null).toBe(seededTier);
+      expect(after?.issuer_name ?? null).toBe(seededIssuerName);
+      expect(after?.sic_code ?? null).toBe(seededSicCode);
+    });
   });
 });

--- a/src/sec/forms/exempt-offerings/Form_1_K.storage.ts
+++ b/src/sec/forms/exempt-offerings/Form_1_K.storage.ts
@@ -247,10 +247,9 @@ export async function processForm1K({
   // out-of-order writes (unknown "" dates apply as-is).
   const existing = await regARepo.getOffering(cik, file_number);
   const isStale =
-    filing_date !== "" &&
     existing?.as_of != null &&
     existing.as_of !== "" &&
-    filing_date < existing.as_of;
+    (filing_date === "" || filing_date < existing.as_of);
 
   if (!isStale) {
     const offering: RegAOffering = {

--- a/src/sec/forms/exempt-offerings/Form_1_Z.storage.test.ts
+++ b/src/sec/forms/exempt-offerings/Form_1_Z.storage.test.ts
@@ -343,5 +343,45 @@ describe("Form_1_Z storage test", () => {
         return;
       }
     });
+
+    it("undated stale replay does not regress a dated mutable row", async () => {
+      const mockDataDir = join(__dirname, "mock_data", "form-1-z");
+      const xmlFiles = readdirSync(mockDataDir).filter((file) => file.endsWith(".xml"));
+      const xmlContent = readFileSync(join(mockDataDir, xmlFiles[0]), "utf-8");
+      const form1Z = await Form_1_Z.parse("1-Z", xmlContent);
+      const cik = 990110;
+      const fileNumber = "024-1z-und";
+
+      await processForm1Z({
+        cik,
+        file_number: fileNumber,
+        accession_number: "1z-dated-seed",
+        filing_date: "2024-09-15",
+        primary_doc: xmlFiles[0],
+        form1Z,
+      });
+
+      const seeded = await regARepo.getOffering(cik, fileNumber);
+      expect(seeded?.as_of).toBe("2024-09-15");
+      const seededTier = seeded?.tier ?? null;
+      const seededIssuerName = seeded?.issuer_name ?? null;
+      const seededSicCode = seeded?.sic_code ?? null;
+
+      // Undated replay (filer error). Any dated row must win.
+      await processForm1Z({
+        cik,
+        file_number: fileNumber,
+        accession_number: "1z-undated-replay",
+        filing_date: "",
+        primary_doc: xmlFiles[0],
+        form1Z,
+      });
+
+      const after = await regARepo.getOffering(cik, fileNumber);
+      expect(after?.as_of).toBe("2024-09-15");
+      expect(after?.tier ?? null).toBe(seededTier);
+      expect(after?.issuer_name ?? null).toBe(seededIssuerName);
+      expect(after?.sic_code ?? null).toBe(seededSicCode);
+    });
   });
 });

--- a/src/sec/forms/exempt-offerings/Form_1_Z.storage.ts
+++ b/src/sec/forms/exempt-offerings/Form_1_Z.storage.ts
@@ -335,10 +335,9 @@ export async function processForm1Z({
   // dates apply as-is).
   const existing = await regARepo.getOffering(cik, file_number);
   const isStale =
-    filing_date !== "" &&
     existing?.as_of != null &&
     existing.as_of !== "" &&
-    filing_date < existing.as_of;
+    (filing_date === "" || filing_date < existing.as_of);
 
   if (!isStale) {
     const offering: RegAOffering = {

--- a/src/storage/portal/CrowdfundingTemporalRepo.test.ts
+++ b/src/storage/portal/CrowdfundingTemporalRepo.test.ts
@@ -291,6 +291,89 @@ describe("CrowdfundingTemporalRepo", () => {
     expect(history.some((h) => h.name === "Stale Older Snapshot")).toBe(true);
   });
 
+  // Regression: when multiple closed-immediately stale-replay snapshots
+  // match at the same query instant, `matches[0]` (pre-sort) was
+  // non-deterministic across backends — SQLite usually preserved
+  // insertion order, Postgres did not. The explicit
+  // (change_date desc, valid_from desc) sort in getCrowdfundingAtTime
+  // pins the later-recorded snapshot regardless of how the underlying
+  // store yielded the rows. We simulate the bug condition by stubbing
+  // the history-repo query so multiple closed-immediately rows are
+  // returned for a single instant (the schema PK `(cik, valid_from)`
+  // would otherwise collide on a real put).
+  test("getCrowdfundingAtTime sorts matches deterministically when stale replays share an instant", async () => {
+    const cik = 66666;
+    const fileNumber = "020-66666";
+    const instant = "2024-03-15T10:00:00.000Z";
+
+    const earlier: CrowdfundingHistory = {
+      cik,
+      file_number: fileNumber,
+      filing_date: "2024-01-01",
+      name: "Earlier Snapshot",
+      legal_status: "Corporation",
+      state_jurisdiction: "DE",
+      date_incorporation: "2020-01-01",
+      url: "http://example.com",
+      portal_cik: 33333,
+      status: "annual-report",
+      progress_update: null,
+      nature_of_amendment: null,
+      valid_from: instant,
+      valid_to: instant,
+      change_source: "Form C-AR",
+      change_date: "2024-03-15T10:00:00.000Z",
+    };
+    const later: CrowdfundingHistory = {
+      ...earlier,
+      name: "Later Snapshot",
+      status: "termination",
+      change_source: "Form C-TR",
+      change_date: "2024-03-15T10:00:05.000Z",
+    };
+
+    // Stubbed history-repo query that yields rows in an "adversarial"
+    // order (later first, earlier second). With the deterministic sort
+    // the later row still wins.
+    const stubHistoryRepo = {
+      query: async () => [later, earlier],
+    } as unknown as CrowdfundingHistoryRepositoryStorage;
+    const stubTemporal = new CrowdfundingTemporalRepo({
+      crowdfundingRepo: new CrowdfundingRepo({
+        crowdfundingRepository: mockCrowdfundingRepo as unknown as CrowdfundingRepositoryStorage,
+        crowdfundingOfferingsRepository: {} as any,
+        crowdfundingReportsRepository: {} as any,
+      }),
+      crowdfundingHistoryRepository: stubHistoryRepo,
+      changeLogRepository: mockChangeLogRepo as unknown as ChangeLogRepositoryStorage,
+    });
+
+    const at = await stubTemporal.getCrowdfundingAtTime(cik, fileNumber, new Date(instant));
+    expect(at?.name).toBe("Later Snapshot");
+    expect(at?.status).toBe("termination");
+
+    // Reverse the adversarial order — the result must not change.
+    const stubHistoryRepoReversed = {
+      query: async () => [earlier, later],
+    } as unknown as CrowdfundingHistoryRepositoryStorage;
+    const stubTemporalReversed = new CrowdfundingTemporalRepo({
+      crowdfundingRepo: new CrowdfundingRepo({
+        crowdfundingRepository: mockCrowdfundingRepo as unknown as CrowdfundingRepositoryStorage,
+        crowdfundingOfferingsRepository: {} as any,
+        crowdfundingReportsRepository: {} as any,
+      }),
+      crowdfundingHistoryRepository: stubHistoryRepoReversed,
+      changeLogRepository: mockChangeLogRepo as unknown as ChangeLogRepositoryStorage,
+    });
+    const atReversed = await stubTemporalReversed.getCrowdfundingAtTime(
+      cik,
+      fileNumber,
+      new Date(instant)
+    );
+    expect(atReversed?.name).toBe("Later Snapshot");
+    expect(atReversed?.status).toBe("termination");
+  });
+
   test("should retrieve crowdfunding entity at specific time", async () => {
     const initial: Crowdfunding = {
       cik: 12345,

--- a/src/storage/portal/CrowdfundingTemporalRepo.ts
+++ b/src/storage/portal/CrowdfundingTemporalRepo.ts
@@ -193,6 +193,17 @@ export class CrowdfundingTemporalRepo {
       return isAfterStart && isBeforeEnd;
     });
 
+    // Deterministic tie-break: when multiple closed-immediately stale-replay
+    // snapshots share `valid_from === valid_to` at the same instant, the
+    // backend's natural row order is not portable (SQLite usually preserves
+    // insertion order; Postgres does not). Sort by recency so the most
+    // recently recorded snapshot wins, with `valid_from` as a stable
+    // secondary key. The dominant-row find below still wins precedence.
+    matches.sort((a, b) => {
+      if (a.change_date !== b.change_date) return b.change_date.localeCompare(a.change_date);
+      return b.valid_from.localeCompare(a.valid_from);
+    });
+
     const dominant = matches.find((r) => r.valid_to === null || r.valid_to !== r.valid_from);
     const validRecord = dominant ?? matches[0];
 


### PR DESCRIPTION
## Summary

Addresses 2 HIGH findings from code review on PR #155's neighborhood — both are mutable-row protection gaps that survive an undated or out-of-order replay.

### HIGH-1 — Form_1_K + Form_1_Z get the undated-stale-guard

PR #155 added the undated-stale-guard to Form_C, Form_1_A, and Form_CFPORTAL but missed Form_1_K and Form_1_Z, which write to the same `RegAOffering` mutable row that Form_1_A correctly defends. An undated 1-K or 1-Z replay (filer error with `filing_date === ""`) could clobber the dated current row.

The previous predicate gated the staleness check on `filing_date !== ""`, so undated incoming filings always wrote through. Aligned the predicate with Form_1_A: empty incoming `filing_date` is treated as stale against any dated existing row, while still applying when the existing row is itself undated or absent.

- `src/sec/forms/exempt-offerings/Form_1_K.storage.ts` — predicate aligned with Form_1_A
- `src/sec/forms/exempt-offerings/Form_1_Z.storage.ts` — same edit
- Tests: `Form_1_K.storage.test.ts`, `Form_1_Z.storage.test.ts` — append `undated stale replay does not regress a dated mutable row` regression (mirrors the Form_C pattern from PR #155): seed at a dated `filing_date`, replay at `filing_date: ""`, assert `as_of` / `tier` / `issuer_name` / `sic_code` are unchanged.

No extractor_version bump: the guard only protects the mutable point-in-time `RegAOffering` row. Append-only / history tables are unaffected, so no rows need to be re-routed via a version cycle.

### HIGH-2 — Deterministic tie-break in `getCrowdfundingAtTime`

When two closed-immediately stale-replay snapshots matched the same query instant, `matches[0]` (and therefore the fallback when no dominant row existed) was non-deterministic across backends — SQLite usually preserved insertion order, Postgres did not.

- `src/storage/portal/CrowdfundingTemporalRepo.ts` — sort `matches` by `(change_date desc, valid_from desc)` before the dominant-row find. Dominant-row precedence is preserved via the explicit `find`.
- Test: `src/storage/portal/CrowdfundingTemporalRepo.test.ts` — append a regression that stubs the history-repo query to yield two closed-immediately rows at the same instant in adversarial order, asserts the later-change_date row wins, and re-runs with the order reversed to confirm storage iteration order is no longer load-bearing.

## Test plan

- [x] `bun test src/sec/forms/exempt-offerings/Form_1_K.storage.test.ts` (8 pass)
- [x] `bun test src/sec/forms/exempt-offerings/Form_1_Z.storage.test.ts` (9 pass)
- [x] `bun test src/storage/portal/CrowdfundingTemporalRepo.test.ts` (7 pass)
- [x] `bunx tsc --noEmit` (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_01W1jTfnsRppCiLTof7ifSxV)_