### PR TITLE
fix(forms): Form_C name fallback on stale replay + Form 1-A undated guard regression test (2 HIGH from review)

### DIFF
--- a/src/sec/forms/exempt-offerings/Form_1_A.storage.test.ts
+++ b/src/sec/forms/exempt-offerings/Form_1_A.storage.test.ts
@@ -356,5 +356,55 @@ describe("Form_1_A storage test", () => {
       });
       expect(history?.price_per_security).toBe(0);
     });
+
+    // Regression guard: an undated filing must not clobber a dated RegA
+    // mutable row. Filers occasionally submit 1-A variants with no SGML
+    // header date. The mutable row stays anchored at the prior `as_of`;
+    // the per-accession history row still records the undated replay.
+    it("undated stale replay does not regress a dated RegA mutable row", async () => {
+      const mockDataDir = join(__dirname, "mock_data", "form-1-a");
+      const xmlFiles = readdirSync(mockDataDir).filter((file) => file.endsWith(".xml"));
+      const xmlContent = readFileSync(join(mockDataDir, xmlFiles[0]), "utf-8");
+      const form1A = await Form_1_A.parse("1-A", xmlContent);
+      const cik = parseInt(form1A.formData.employeesInfo[0].cik);
+      const fileNumber = "024-stale-und";
+
+      await processForm1A({
+        cik,
+        file_number: fileNumber,
+        accession_number: "test-1a-und-newer",
+        filing_date: "2026-05-01",
+        primary_doc: xmlFiles[0],
+        form1A,
+      });
+
+      const seeded = await regARepo.getOffering(cik, fileNumber);
+      expect(seeded).toBeDefined();
+      expect(seeded?.as_of).toBe("2026-05-01");
+
+      // Undated replay (filer error). Any dated row must win.
+      await processForm1A({
+        cik,
+        file_number: fileNumber,
+        accession_number: "test-1a-und-replay",
+        filing_date: "",
+        primary_doc: xmlFiles[0],
+        form1A,
+      });
+
+      const after = await regARepo.getOffering(cik, fileNumber);
+      expect(after?.as_of).toBe("2026-05-01");
+      expect(after?.tier).toBe(seeded!.tier);
+      expect(after?.status).toBe(seeded!.status);
+      expect(after?.issuer_name).toBe(seeded!.issuer_name);
+
+      // Undated filing still produces a per-accession history row.
+      const replayHistory = await regARepo.getOfferingHistory(
+        cik,
+        fileNumber,
+        "test-1a-und-replay"
+      );
+      expect(replayHistory).toBeDefined();
+    });
   });
 });

--- a/src/sec/forms/exempt-offerings/Form_C.storage.test.ts
+++ b/src/sec/forms/exempt-offerings/Form_C.storage.test.ts
@@ -480,6 +480,64 @@ describe("Form_C storage test", () => {
       expect(after?.filing_date).toBe("2026-05-01");
     });
 
+    // Regression guard: a stale replay with a blank `nameOfIssuer` must
+    // inherit the existing row's name in the history snapshot rather than
+    // writing an empty string. The mutable row also stays unchanged
+    // (skipMutableUpdate suppresses the write entirely on stale replays).
+    it("stale replay with empty nameOfIssuer inherits existing row's name in history snapshot", async () => {
+      const mockDataDir = join(__dirname, "mock_data", "form-c");
+      const xmlFiles = readdirSync(mockDataDir).filter((file) => file.endsWith(".xml"));
+      const xmlContent = readFileSync(join(mockDataDir, xmlFiles[0]), "utf-8");
+      const formC = await Form_C.parse("C", xmlContent);
+      const cik = parseInt(formC.headerData.filerInfo.filer.filerCredentials.filerCik);
+      const fileNumber = "020-stale-name";
+
+      const seededName = formC.formData.issuerInformation.issuerInfo.nameOfIssuer;
+
+      await processFormC({
+        cik,
+        file_number: fileNumber,
+        accession_number: "test-name-newer",
+        filing_date: "2026-05-01",
+        primary_doc: xmlFiles[0],
+        formC,
+      });
+
+      // Mutate the parsed form to simulate a sparser older filing that
+      // dropped `nameOfIssuer`.
+      const issuerInfoRecord = formC.formData.issuerInformation.issuerInfo as Record<
+        string,
+        unknown
+      >;
+      issuerInfoRecord.nameOfIssuer = "";
+
+      await processFormC({
+        cik,
+        file_number: fileNumber,
+        accession_number: "test-name-replay",
+        filing_date: "2026-04-01",
+        primary_doc: xmlFiles[0],
+        formC,
+      });
+
+      const { CrowdfundingTemporalRepo } = await import(
+        "../../../storage/portal/CrowdfundingTemporalRepo"
+      );
+      const temporalRepo = new CrowdfundingTemporalRepo();
+      const history = await temporalRepo.getCrowdfundingHistory(cik, fileNumber);
+
+      const replaySnapshot = history.find(
+        (h) =>
+          h.valid_to !== null && h.valid_to === h.valid_from && h.filing_date === "2026-04-01"
+      );
+      expect(replaySnapshot).toBeDefined();
+      expect(replaySnapshot?.name).toBe(seededName);
+
+      // Mutable row stays unchanged.
+      const mutable = await crowdfundingRepo.getCrowdfunding(cik, fileNumber);
+      expect(mutable?.name).toBe(seededName);
+    });
+
     // Regression guard: `currentEmployees` is schema-typed
     // DECIMAL_TYPE7_2_NONNEGATIVE. The string-decimal migration moved
     // the parse-time `minimum: 0` invariant into storage. A malformed

--- a/src/sec/forms/exempt-offerings/Form_C.storage.ts
+++ b/src/sec/forms/exempt-offerings/Form_C.storage.ts
@@ -459,7 +459,7 @@ export async function processFormC({
     cik,
     file_number,
     filing_date: isStale ? filing_date : filing_date || existing?.filing_date || "",
-    name: issuer.nameOfIssuer,
+    name: issuer.nameOfIssuer || existing?.name || issuer.nameOfIssuer,
     legal_status: issuer.legalStatus?.legalStatusForm ?? existing?.legal_status ?? "",
     state_jurisdiction:
       issuer.legalStatus?.jurisdictionOrganization ?? existing?.state_jurisdiction ?? "",


### PR DESCRIPTION
## Summary

Two HIGH findings from code review on the exempt-offerings stale-replay temporal model.

### E1. Form_C `name` fallback on stale-replay snapshot

`src/sec/forms/exempt-offerings/Form_C.storage.ts` — when a stale (older) Form C replay carries an empty `nameOfIssuer` (sparser back-catalog filings can drop the field), the history snapshot now inherits the existing row's name rather than writing an empty string. The trailing `|| issuer.nameOfIssuer` keeps the field non-nullable when both new and existing names are empty, matching the sibling `?? existing?.x ?? ""` pattern used for other fields.

```ts
name: issuer.nameOfIssuer || existing?.name || issuer.nameOfIssuer,
```

Regression test added in `src/sec/forms/exempt-offerings/Form_C.storage.test.ts`: `"stale replay with empty nameOfIssuer inherits existing row's name in history snapshot"` — seeds a dated row, mutates `nameOfIssuer` to `""`, replays as stale, asserts the replay snapshot in `CrowdfundingHistory` carries the original seeded name and the mutable row is unchanged.

### E2. Form 1-A undated stale-replay regression test (no production change)

`src/sec/forms/exempt-offerings/Form_1_A.storage.test.ts` — `Form_1_A.storage` already guards against undated filings clobbering a dated RegA mutable row (`filing_date === ""` is treated as stale when an existing `as_of` is dated). Added a regression test mirroring the Form_C undated stale-replay test so the guard is pinned: `"undated stale replay does not regress a dated RegA mutable row"` asserts the mutable row stays anchored at the prior `2026-05-01` `as_of`, `tier`/`status`/`issuer_name` are preserved, and the per-accession history row still records the undated replay.

## Verification

```sh
$ bun test src/sec/forms/exempt-offerings/Form_C.storage.test.ts
 14 pass
 0 fail
 40 expect() calls

$ bun test src/sec/forms/exempt-offerings/Form_1_A.storage.test.ts
 10 pass
 0 fail
 32 expect() calls
```

Both files pass cleanly. The new tests are the trailing ones in each suite.

## Test plan

- [x] `bun test src/sec/forms/exempt-offerings/Form_C.storage.test.ts` passes
- [x] `bun test src/sec/forms/exempt-offerings/Form_1_A.storage.test.ts` passes
- [x] New E1 test exercises the empty-`nameOfIssuer` stale-replay path and the existing-row fallback
- [x] New E2 test pins the existing undated stale-replay temporal guard for Form 1-A

https://claude.ai/code/session_01YDTm1h7PrFoLbpN9MEZX9k

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDTm1h7PrFoLbpN9MEZX9k)_