### PR TITLE
fix(resolver): instance-scope per-key mutex so multi-process race tests test what they claim (HIGH from 24h review)

### DIFF
--- a/src/resolver/CompanyResolver.race.test.ts
+++ b/src/resolver/CompanyResolver.race.test.ts
@@ -173,10 +173,13 @@ async function storageEnforcesCompanyUniqueness(): Promise<boolean> {
 }
 
 // Multi-process race: a separate `sec` invocation has its own
-// CompanyResolver._keyMutexes static, so its mutex map does NOT serialise
-// against ours. We model two processes here with TWO CompanyResolver
-// instances. The storage's UNIQUE index is then the only thing keeping
-// twin canonical rows from being minted.
+// CompanyResolver instance with its own instance-scoped `_keyMutexes`
+// map, so the in-process mutex does NOT serialise across instances. We
+// model that here with TWO CompanyResolver instances sharing the same
+// underlying repos. The storage's UNIQUE index is the real thing
+// keeping twin canonical rows from being minted, and the resolver's
+// UNIQUE-rejection retry path is what makes the loser converge on the
+// winner's canonical id instead of failing.
 describe("CompanyResolver multi-process race (storage-level UNIQUE constraint)", () => {
   beforeEach(async () => {
     // Fail loud if a future workglow regression silently drops UNIQUE
@@ -188,6 +191,29 @@ describe("CompanyResolver multi-process race (storage-level UNIQUE constraint)",
 
   it("twin resolver instances racing the same CIK still collapse to one canonical row", async () => {
     const setup = makeRepos();
+    // Count UNIQUE rejections at the storage layer so we can assert the
+    // constraint actually fired — proving the test exercises the
+    // storage backstop, not just an accidental id match.
+    let uniqueRejections = 0;
+    const originalPut = setup.canonStorage.put.bind(setup.canonStorage);
+    setup.canonStorage.put = async (value) => {
+      try {
+        return await originalPut(value);
+      } catch (err) {
+        if (
+          err !== null &&
+          typeof err === "object" &&
+          typeof (err as { message?: unknown }).message === "string" &&
+          ((err as { message: string }).message).startsWith(
+            "UNIQUE constraint failed"
+          )
+        ) {
+          uniqueRejections += 1;
+        }
+        throw err;
+      }
+    };
+
     const resolverA = new CompanyResolver({
       canonicalCompanyRepo: setup.canonRepo,
       canonicalCompanyAliasRepo: setup.aliasRepo,
@@ -208,6 +234,10 @@ describe("CompanyResolver multi-process race (storage-level UNIQUE constraint)",
     expect(new Set(results).size).toBe(1);
     const rows = await setup.canonStorage.getAll();
     expect(rows.length).toBe(1);
+    // At least one storage-level UNIQUE rejection must have fired —
+    // otherwise the two instances accidentally never raced and the test
+    // doesn't actually exercise the multi-process backstop.
+    expect(uniqueRejections).toBeGreaterThanOrEqual(1);
   });
 
   // No name-race counterpart: the (resolver_version, normalized_name) tuple

--- a/src/resolver/CompanyResolver.ts
+++ b/src/resolver/CompanyResolver.ts
@@ -10,6 +10,7 @@ import type { CanonicalCompanyAliasRepo } from "../storage/canonical/CanonicalCo
 import type { CompanyObservation } from "../storage/observation/CompanyObservationSchema";
 import type { CanonicalCompany } from "../storage/canonical/CanonicalCompanySchema";
 import { AsyncMutex } from "../util/AsyncMutex";
+import { isUniqueConstraintError } from "./isUniqueConstraintError";
 
 interface CompanyResolverOptions {
   canonicalCompanyRepo: CanonicalCompanyRepo;
@@ -45,11 +46,14 @@ function companyKey(
  * the queued caller observes both the canonical row and its alias
  * resolution, so concurrent resolves converge to the same final
  * canonical_company_id even when one races an alias rewrite that happens
- * between the create and the alias lookup. Multi-process callers still
- * need a backend UNIQUE constraint.
+ * between the create and the alias lookup. The mutex map is
+ * instance-scoped: intra-instance contention is serialised via per-key
+ * mutexes; multi-instance / multi-process contention is collapsed at the
+ * storage layer via UNIQUE constraints on (resolver_version, cik) and
+ * (resolver_version, crd_number).
  */
 export class CompanyResolver {
-  private static readonly _keyMutexes = new Map<
+  private readonly _keyMutexes = new Map<
     string,
     { mutex: AsyncMutex; refs: number }
   >();
@@ -63,10 +67,10 @@ export class CompanyResolver {
         `cannot resolve company observation ${obs.observation_id}: no CIK, CRD, or name`
       );
     }
-    let entry = CompanyResolver._keyMutexes.get(k.key);
+    let entry = this._keyMutexes.get(k.key);
     if (entry === undefined) {
       entry = { mutex: new AsyncMutex(), refs: 0 };
-      CompanyResolver._keyMutexes.set(k.key, entry);
+      this._keyMutexes.set(k.key, entry);
     }
     entry.refs += 1;
 
@@ -106,8 +110,29 @@ export class CompanyResolver {
             normalized_name: obs.normalized_name ?? null,
             created_at: new Date().toISOString(),
           };
-          await this.opts.canonicalCompanyRepo.create(fresh);
-          candidateId = freshId;
+          try {
+            await this.opts.canonicalCompanyRepo.create(fresh);
+            candidateId = freshId;
+          } catch (err) {
+            // A concurrent writer in a different process / resolver
+            // instance won the UNIQUE constraint race. Re-query so we
+            // converge on the winner's canonical id instead of failing.
+            if (!isUniqueConstraintError(err)) throw err;
+            let winner: CanonicalCompany | undefined;
+            if (k.kind === "cik" && obs.cik !== null && obs.cik !== undefined) {
+              winner = await this.opts.canonicalCompanyRepo.findByResolverAndCik(
+                this.opts.activeResolverVersion,
+                obs.cik
+              );
+            } else if (k.kind === "crd" && obs.crd_number) {
+              winner = await this.opts.canonicalCompanyRepo.findByResolverAndCrd(
+                this.opts.activeResolverVersion,
+                obs.crd_number
+              );
+            }
+            if (winner === undefined) throw err;
+            candidateId = winner.canonical_company_id;
+          }
         }
         // Resolve the alias INSIDE the mutex so a concurrent caller that
         // queues behind us cannot observe the freshly-minted candidate
@@ -119,9 +144,9 @@ export class CompanyResolver {
     } finally {
       entry.refs -= 1;
       if (entry.refs === 0) {
-        const current = CompanyResolver._keyMutexes.get(k.key);
+        const current = this._keyMutexes.get(k.key);
         if (current === entry) {
-          CompanyResolver._keyMutexes.delete(k.key);
+          this._keyMutexes.delete(k.key);
         }
       }
     }

--- a/src/resolver/PersonResolver.race.test.ts
+++ b/src/resolver/PersonResolver.race.test.ts
@@ -187,13 +187,16 @@ async function storageEnforcesPersonUniqueness(): Promise<boolean> {
   }
 }
 
-// Multi-process race: a separate `sec` invocation gets its own copy of the
-// PersonResolver class, so its `_keyMutexes` static does NOT serialise
-// against ours. We simulate that here with TWO PersonResolver instances
-// sharing the same underlying repos AND patching the static map to a
-// per-instance Map so the in-process mutex no longer collapses concurrent
-// callers. The storage's UNIQUE index is then the only thing keeping
-// twin canonical rows from being minted.
+// Multi-process race: a separate `sec` invocation gets its own
+// PersonResolver instance, so its instance-scoped `_keyMutexes` does NOT
+// serialise against ours. We model that here with TWO PersonResolver
+// instances sharing the same underlying repos: each gets its own mutex
+// map by construction, so the in-process mutex no longer collapses
+// concurrent callers across the two instances. The storage's UNIQUE
+// index is then the real thing keeping twin canonical rows from being
+// minted, and PersonResolver.resolve()'s UNIQUE-rejection retry path is
+// what makes the loser converge on the winner's canonical id instead of
+// failing.
 describe("PersonResolver multi-process race (storage-level UNIQUE constraint)", () => {
   beforeEach(async () => {
     // Fail loud if a future workglow regression silently drops UNIQUE
@@ -205,6 +208,29 @@ describe("PersonResolver multi-process race (storage-level UNIQUE constraint)", 
 
   it("twin resolver instances racing the same CIK still collapse to one canonical row", async () => {
     const setup = makeRepos();
+    // Count UNIQUE rejections at the storage layer so we can assert the
+    // constraint actually fired — proving the test exercises the
+    // storage backstop, not just an accidental id match.
+    let uniqueRejections = 0;
+    const originalPut = setup.canonStorage.put.bind(setup.canonStorage);
+    setup.canonStorage.put = async (value) => {
+      try {
+        return await originalPut(value);
+      } catch (err) {
+        if (
+          err !== null &&
+          typeof err === "object" &&
+          typeof (err as { message?: unknown }).message === "string" &&
+          ((err as { message: string }).message).startsWith(
+            "UNIQUE constraint failed"
+          )
+        ) {
+          uniqueRejections += 1;
+        }
+        throw err;
+      }
+    };
+
     const resolverA = new PersonResolver({
       canonicalPersonRepo: setup.canonRepo,
       canonicalPersonAliasRepo: setup.aliasRepo,
@@ -215,12 +241,6 @@ describe("PersonResolver multi-process race (storage-level UNIQUE constraint)", 
       canonicalPersonAliasRepo: setup.aliasRepo,
       activeResolverVersion: "1.0.0",
     });
-    // Force each resolver instance to use its own mutex map so the
-    // static class-level serialisation does not mask the storage race.
-    // The cast is intentional — we are deliberately violating the
-    // static-on-class invariant to model two processes.
-    (resolverA as unknown as { _ownMutexes?: Map<string, unknown> })._ownMutexes = new Map();
-    (resolverB as unknown as { _ownMutexes?: Map<string, unknown> })._ownMutexes = new Map();
 
     const fanout = 50;
     const results = await Promise.all(
@@ -232,6 +252,10 @@ describe("PersonResolver multi-process race (storage-level UNIQUE constraint)", 
     expect(new Set(results).size).toBe(1);
     const rows = await setup.canonStorage.getAll();
     expect(rows.length).toBe(1);
+    // At least one storage-level UNIQUE rejection must have fired —
+    // otherwise the two instances accidentally never raced and the test
+    // doesn't actually exercise the multi-process backstop.
+    expect(uniqueRejections).toBeGreaterThanOrEqual(1);
   });
 
   // No name-race counterpart: the (resolver_version, normalized_name, ...)

--- a/src/resolver/PersonResolver.ts
+++ b/src/resolver/PersonResolver.ts
@@ -10,6 +10,7 @@ import type { CanonicalPersonAliasRepo } from "../storage/canonical/CanonicalPer
 import type { PersonObservation } from "../storage/observation/PersonObservationSchema";
 import type { CanonicalPerson } from "../storage/canonical/CanonicalPersonSchema";
 import { AsyncMutex } from "../util/AsyncMutex";
+import { isUniqueConstraintError } from "./isUniqueConstraintError";
 
 interface PersonResolverOptions {
   canonicalPersonRepo: CanonicalPersonRepo;
@@ -44,7 +45,7 @@ function personKey(obs: PersonObservation, resolverVersion: string): string {
  * key_kind, key_value) used to race — both observed no canonical row, both
  * minted a fresh UUID, both inserted, yielding two distinct canonical ids
  * for what should have been the same person. We now serialise the
- * find-or-create critical section per key with a process-wide `AsyncMutex`,
+ * find-or-create critical section per key with an `AsyncMutex`,
  * kept alive for as long as any caller still holds or is queued behind it
  * via a simple refcount. Once the count drops to zero the entry is
  * removed from the map so the map stays bounded for long-running
@@ -56,12 +57,16 @@ function personKey(obs: PersonObservation, resolverVersion: string): string {
  * even when one races an alias rewrite that happens between the create
  * and the alias lookup.
  *
- * Multi-process callers (workers, separate `sec` invocations) still need
- * a backend-level UNIQUE constraint to be race-free — single-process
- * mutexes are not visible to other processes.
+ * The mutex map is instance-scoped: intra-instance contention is
+ * serialised via per-key mutexes; multi-instance / multi-process
+ * contention is collapsed at the storage layer via UNIQUE constraints on
+ * (resolver_version, cik). Every production call site constructs one
+ * resolver and reuses it for the duration of its work (a filing
+ * extraction, a CLI batch resolve), so intra-instance serialisation
+ * covers all observations sharing a scope.
  */
 export class PersonResolver {
-  private static readonly _keyMutexes = new Map<
+  private readonly _keyMutexes = new Map<
     string,
     { mutex: AsyncMutex; refs: number }
   >();
@@ -70,10 +75,10 @@ export class PersonResolver {
 
   async resolve(obs: PersonObservation): Promise<string> {
     const key = personKey(obs, this.opts.activeResolverVersion);
-    let entry = PersonResolver._keyMutexes.get(key);
+    let entry = this._keyMutexes.get(key);
     if (entry === undefined) {
       entry = { mutex: new AsyncMutex(), refs: 0 };
-      PersonResolver._keyMutexes.set(key, entry);
+      this._keyMutexes.set(key, entry);
     }
     entry.refs += 1;
 
@@ -120,8 +125,33 @@ export class PersonResolver {
               obs.cik === null ? obs.source_filing_issuer_cik : null,
             created_at: new Date().toISOString(),
           };
-          await this.opts.canonicalPersonRepo.create(fresh);
-          candidateId = freshId;
+          try {
+            await this.opts.canonicalPersonRepo.create(fresh);
+            candidateId = freshId;
+          } catch (err) {
+            // A concurrent writer in a different process / resolver
+            // instance won the UNIQUE constraint race. Re-query so we
+            // converge on the winner's canonical id instead of failing.
+            if (!isUniqueConstraintError(err)) throw err;
+            let winner: CanonicalPerson | undefined;
+            if (obs.cik !== null && obs.cik !== undefined) {
+              winner = await this.opts.canonicalPersonRepo.findByResolverAndCik(
+                this.opts.activeResolverVersion,
+                obs.cik
+              );
+            } else {
+              winner = await this.opts.canonicalPersonRepo.findByResolverAndName(
+                this.opts.activeResolverVersion,
+                obs.normalized_first,
+                obs.normalized_middle,
+                obs.normalized_last,
+                obs.normalized_suffix,
+                obs.source_filing_issuer_cik
+              );
+            }
+            if (winner === undefined) throw err;
+            candidateId = winner.canonical_person_id;
+          }
         }
         // Resolve the alias INSIDE the mutex so a concurrent caller that
         // queues behind us cannot observe the freshly-minted candidate
@@ -135,9 +165,9 @@ export class PersonResolver {
       if (entry.refs === 0) {
         // Same identity check guards against a race where another caller
         // recreated the entry after we decremented but before this line.
-        const current = PersonResolver._keyMutexes.get(key);
+        const current = this._keyMutexes.get(key);
         if (current === entry) {
-          PersonResolver._keyMutexes.delete(key);
+          this._keyMutexes.delete(key);
         }
       }
     }

--- a/src/resolver/isUniqueConstraintError.ts
+++ b/src/resolver/isUniqueConstraintError.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Detects a UNIQUE-index violation thrown by `@workglow/storage` backends.
+ *
+ * All three backends (InMemory, SQLite, Postgres) surface the violation as
+ * a `StorageError` whose message starts with `"UNIQUE constraint failed"`.
+ * We match on the message rather than `instanceof StorageError` so that
+ * future wrappers / re-thrown errors continue to be recognised; the
+ * message prefix is stable across backends.
+ */
+export function isUniqueConstraintError(err: unknown): boolean {
+  if (err === null || typeof err !== "object") return false;
+  const msg = (err as { message?: unknown }).message;
+  return typeof msg === "string" && msg.startsWith("UNIQUE constraint failed");
+}


### PR DESCRIPTION
## Summary

- `PersonResolver._keyMutexes` / `CompanyResolver._keyMutexes` were declared `static`, so the multi-process race tests' twin resolver instances actually collapsed through one shared map. The `_ownMutexes` assignment in the test was dead code (different field name). The tests passed for the wrong reason — the in-process AsyncMutex, not the storage UNIQUE constraint, was the backstop.
- Move the map from `static` to instance. The twin-instance race now reaches `create()` on both sides, the storage UNIQUE constraint on `(resolver_version, cik)` / `(resolver_version, crd_number)` rejects the loser, and the resolver catches the rejection, re-queries, and returns the winner's canonical id — the same convergence semantics multi-process callers need in production.
- Production safety verified: every call site (`buildEntityObserver` per filing; `cli/groups/resolve.ts` once per `sec resolve`; the `Form_*` storage modules and `Form_CFPORTAL` / `Form_144` / `OwnershipDocument` paths) already constructs one resolver per scope and reuses it for all observations in that scope, so instance-scoped serialisation covers the same intra-process workload the static map did.

## Deferred to follow-up PR

H-2 (name-fallback dedupe) is intentionally deferred. It is ~610 LOC of new feature work — a new issuer-scoped fingerprint UNIQUE constraint plus a `sec canonical {person,company} dedupe-by-name` CLI plus a backfill — that warrants its own brainstorming, spec, and review per the 24h review plan's recommendation. The current PR is scoped to the HIGH-severity test-quality fix it identified.

## Test plan

- [x] `bun test src/resolver/PersonResolver.race.test.ts src/resolver/CompanyResolver.race.test.ts` — 11/11 pass; the multi-process race tests now reach the storage UNIQUE backstop instead of being short-circuited by the static map.
- [x] New assertion in both race tests: instrument `canonStorage.put` to count UNIQUE rejections and `expect(uniqueRejections).toBeGreaterThanOrEqual(1)` so a future regression that accidentally re-collapses callers in-process (and therefore stops exercising the storage constraint) fails the test instead of passing trivially.
- [x] `bun test src/resolver` — 43/43 pass (whole resolver test directory).
- [x] `bun test` — 1213/1213 pass across 173 files (no fallout in form storage modules, CLI, or observer paths that construct resolvers).
- [x] `npx tsc --noEmit` — clean.
- [x] Grep audit (`new PersonResolver(` / `new CompanyResolver(`) confirms every production site constructs one resolver per scope; none relied on the static map to coalesce multiple instances within a single `sec` invocation.

---
_Generated by [Claude Code](https://claude.ai/code/session_011VUFicLCb6U83yXwcjwWhZ)_