### PR TITLE
fix(sec): SPAC writer atomicity, redemption LLM input cap, partial-success extractor outcome

### DIFF
--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -200,6 +200,23 @@ export async function setupAllDatabases(): Promise<void> {
     for (const ddl of CURRENT_CANONICAL_VIEW_DDL) {
       db.exec(ddl);
     }
+    backfillExtractorRunsOutcome(db);
   }
   await bootstrapComponentVersions();
+}
+
+/**
+ * One-shot migration: pre-`outcome` extractor_runs rows on a previously-set-up
+ * SQLite database lack the new column. CREATE TABLE IF NOT EXISTS is a no-op
+ * once the table exists, so add the column if missing and seed it from the
+ * existing `success` boolean (partial is unknowable for legacy rows).
+ */
+function backfillExtractorRunsOutcome(db: Sqlite.Database): void {
+  const cols = db.prepare<[], { name: string }>(`PRAGMA table_info(\`extractor_runs\`)`).all();
+  if (cols.length === 0) return; // table not created yet (clean DB)
+  if (cols.some((c) => c.name === "outcome")) return; // already migrated
+  db.exec(`ALTER TABLE \`extractor_runs\` ADD COLUMN outcome TEXT NOT NULL DEFAULT 'failure'`);
+  db.exec(
+    `UPDATE \`extractor_runs\` SET outcome = CASE WHEN success = 1 OR success = 'true' THEN 'success' ELSE 'failure' END`
+  );
 }

--- a/src/sec/forms/miscellaneous-filings/redemption8k.test.ts
+++ b/src/sec/forms/miscellaneous-filings/redemption8k.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../registration-statements/s1/testing/fakeStructuredProvider";
 import { hasRedemptionTriggerItem } from "./spac8kRedemptionTriggers";
 import { processRedemption8K } from "./redemption8k";
+import { ExtractionDeadLetterRepo } from "../../../storage/dead-letter/ExtractionDeadLetterRepo";
 
 const FULL_TXT =
   "<SEC-HEADER>\nACCESSION NUMBER: 0000000000-26-000009\n</SEC-HEADER>\n" +
@@ -183,5 +184,158 @@ describe("processRedemption8K", () => {
     expect(
       await new SpacRedemptionExtractionRepo().getByAccession("0000000000-26-000012")
     ).toBeUndefined();
+  });
+
+  it("drops every exhibit when each exceeds the per-exhibit cap and records OVERSIZED_INPUT", async () => {
+    await seedSpacWithOpenDeal(50);
+    // Build a submission whose primary and EX-99 each exceed the 200k cap.
+    // Each <p> body has > 250k chars of repeated filler.
+    const filler = "A".repeat(260_000);
+    const oversizedTxt =
+      "<SEC-HEADER>\nACCESSION NUMBER: 0000000000-26-OVER01\n</SEC-HEADER>\n" +
+      "<DOCUMENT>\n<TYPE>8-K\n<SEQUENCE>1\n<TEXT>\n" +
+      `<p>${filler}</p>\n` +
+      "</TEXT>\n</DOCUMENT>\n" +
+      "<DOCUMENT>\n<TYPE>EX-99.1\n<SEQUENCE>2\n<TEXT>\n" +
+      `<p>${filler}</p>\n` +
+      "</TEXT>\n</DOCUMENT>\n";
+
+    let modelInvocations = 0;
+    const registration = registerFakeStructuredProvider([
+      {
+        redemption_shares: 1,
+        redemption_amount: 1,
+        price_per_share: 10,
+        confidence: 0.99,
+        source_span: "should never be reached",
+      },
+    ]);
+    cleanup = () => {
+      registration.unregister();
+    };
+    // The fake provider tracks calls via its `calls` array.
+    const baseLen = registration.calls.length;
+
+    await processRedemption8K({
+      cik: 50,
+      accession_number: "0000000000-26-OVER01",
+      filing_date: "2026-03-20",
+      form: "8-K",
+      itemCodes: ["5.07"],
+      fullSubmissionText: oversizedTxt,
+      model: fakeS1Model(),
+    });
+
+    modelInvocations = registration.calls.length - baseLen;
+    expect(modelInvocations).toBe(0);
+
+    expect(
+      await new SpacRedemptionExtractionRepo().getByAccession("0000000000-26-OVER01")
+    ).toBeUndefined();
+
+    const dl = await new ExtractionDeadLetterRepo().get(
+      "redemption",
+      "0000000000-26-OVER01",
+      "redemption"
+    );
+    expect(dl?.reason_code).toBe("OVERSIZED_INPUT");
+  });
+
+  it("proceeds with surviving exhibits when one is dropped and records a partial-oversized dead-letter", async () => {
+    await seedSpacWithOpenDeal(51);
+    // Primary doc is small + has the canonical sentence; EX-99.2 is oversized
+    // and gets dropped. Extraction must still succeed on the survivors.
+    const filler = "B".repeat(260_000);
+    const partialTxt =
+      "<SEC-HEADER>\nACCESSION NUMBER: 0000000000-26-PART01\n</SEC-HEADER>\n" +
+      "<DOCUMENT>\n<TYPE>8-K\n<SEQUENCE>1\n<TEXT>\n" +
+      "<p>Holders of 5,000,000 shares elected to redeem for $50,000,000.</p>\n" +
+      "</TEXT>\n</DOCUMENT>\n" +
+      "<DOCUMENT>\n<TYPE>EX-99.1\n<SEQUENCE>2\n<TEXT>\n" +
+      `<p>${filler}</p>\n` +
+      "</TEXT>\n</DOCUMENT>\n";
+
+    const registration = registerFakeStructuredProvider([
+      {
+        redemption_shares: 5_000_000,
+        redemption_amount: 50_000_000,
+        price_per_share: 10.0,
+        confidence: 0.95,
+        source_span: "5,000,000 shares elected to redeem for $50,000,000",
+      },
+    ]);
+    cleanup = registration.unregister;
+
+    await processRedemption8K({
+      cik: 51,
+      accession_number: "0000000000-26-PART01",
+      filing_date: "2026-03-20",
+      form: "8-K",
+      itemCodes: ["5.07"],
+      fullSubmissionText: partialTxt,
+      model: fakeS1Model(),
+    });
+
+    // Extraction proceeded with the surviving primary doc.
+    const ext = await new SpacRedemptionExtractionRepo().getByAccession("0000000000-26-PART01");
+    expect(ext?.redemption_amount).toBe(50_000_000);
+
+    // Partial-oversized informational dead-letter recorded.
+    const dlRepo = new ExtractionDeadLetterRepo();
+    const partial = await dlRepo.get(
+      "redemption",
+      "0000000000-26-PART01",
+      "redemption-partial-oversized"
+    );
+    expect(partial?.reason_code).toBe("OVERSIZED_INPUT");
+  });
+
+  it("extracts successfully with a moderately large EX-99 (~150 KB)", async () => {
+    await seedSpacWithOpenDeal(52);
+    // 150 KB filler stays under the 200 KB per-exhibit cap; the canonical
+    // sentence still extracts cleanly. Integration baseline that the cap
+    // does not regress reasonable filing sizes.
+    const filler = "C".repeat(150_000);
+    const okTxt =
+      "<SEC-HEADER>\nACCESSION NUMBER: 0000000000-26-OK0001\n</SEC-HEADER>\n" +
+      "<DOCUMENT>\n<TYPE>8-K\n<SEQUENCE>1\n<TEXT>\n" +
+      "<p>Vote results.</p>\n" +
+      "</TEXT>\n</DOCUMENT>\n" +
+      "<DOCUMENT>\n<TYPE>EX-99.1\n<SEQUENCE>2\n<TEXT>\n" +
+      `<p>${filler}</p>\n` +
+      "<p>Holders of 2,500,000 shares elected to redeem for $25,000,000.</p>\n" +
+      "</TEXT>\n</DOCUMENT>\n";
+
+    const registration = registerFakeStructuredProvider([
+      {
+        redemption_shares: 2_500_000,
+        redemption_amount: 25_000_000,
+        price_per_share: 10.0,
+        confidence: 0.95,
+        source_span: "2,500,000 shares elected to redeem for $25,000,000",
+      },
+    ]);
+    cleanup = registration.unregister;
+
+    await processRedemption8K({
+      cik: 52,
+      accession_number: "0000000000-26-OK0001",
+      filing_date: "2026-03-20",
+      form: "8-K",
+      itemCodes: ["5.07"],
+      fullSubmissionText: okTxt,
+      model: fakeS1Model(),
+    });
+
+    const ext = await new SpacRedemptionExtractionRepo().getByAccession("0000000000-26-OK0001");
+    expect(ext?.redemption_amount).toBe(25_000_000);
+
+    // No OVERSIZED_INPUT dead-letter was recorded.
+    const dl = await new ExtractionDeadLetterRepo().get(
+      "redemption",
+      "0000000000-26-OK0001",
+      "redemption-partial-oversized"
+    );
+    expect(dl).toBeUndefined();
   });
 });

--- a/src/sec/forms/miscellaneous-filings/redemption8k.ts
+++ b/src/sec/forms/miscellaneous-filings/redemption8k.ts
@@ -26,8 +26,22 @@ import { SpacRedemptionExtractionRepo } from "../../../storage/spac/SpacRedempti
 import { REDEMPTION_TRIGGER_ITEMS } from "./spac8kRedemptionTriggers";
 
 const EXTRACTOR_ID = "redemption";
-const DEFAULT_EXTRACTOR_VERSION = "1.0.0";
+// v1.1.0: per-exhibit + total input caps. Oversized exhibits are dropped (a
+// truncated span would break source-span verification); a full-drop dead-letters
+// without invoking the model. The dropped-exhibit accounting changes the prompt
+// shape, so confidence calibration drifts — treat as a fresh dev cycle.
+const DEFAULT_EXTRACTOR_VERSION = "1.1.0";
 const REDEMPTION_SECTION = "redemption";
+
+/**
+ * Per-exhibit cap on rendered markdown handed to the model. ~200 KB covers any
+ * realistic vote-results / closing 8-K narrative; anything larger is almost
+ * certainly an EX-99 dump (or an injection vector) that won't fit in context
+ * regardless.
+ */
+const MAX_PER_EXHIBIT_CHARS = 200_000;
+/** Total cap across primary doc + surviving exhibits. */
+const MAX_TOTAL_CHARS = 400_000;
 
 export interface ProcessRedemption8KArgs {
   readonly cik: number;
@@ -79,12 +93,32 @@ export async function processRedemption8K(args: ProcessRedemption8KArgs): Promis
   // events and milestone deals already wrote); a malformed body dead-letters the
   // section so a version bump can retry it, mirroring the merger-proxy path.
   let text: string;
+  let dropped = 0;
+  let droppedChars = 0;
+  let totalDropped = false;
   try {
     const { primaryHtml, exhibitsHtml } = parseEightKSubmission(form, fullSubmissionText);
-    text = [primaryHtml, ...exhibitsHtml]
-      .map((h, i) => renderBody(h, `${form} ${accession_number} #${i}`))
-      .filter((t) => t.length > 0)
-      .join("\n\n");
+    const survivors: string[] = [];
+    [primaryHtml, ...exhibitsHtml].forEach((h, i) => {
+      const rendered = renderBody(h, `${form} ${accession_number} #${i}`);
+      if (rendered.length === 0) return;
+      if (rendered.length > MAX_PER_EXHIBIT_CHARS) {
+        dropped += 1;
+        droppedChars += rendered.length;
+        return;
+      }
+      survivors.push(rendered);
+    });
+    text = survivors.join("\n\n");
+    if (text.length > MAX_TOTAL_CHARS) {
+      // Survivors still too large in aggregate. Drop everything — partial
+      // truncation breaks source-span verification and a doubly-skewed prompt
+      // is worse for calibration than a clean dead-letter.
+      totalDropped = true;
+      dropped += survivors.length;
+      droppedChars += text.length;
+      text = "";
+    }
   } catch (err) {
     await deadLetters.record({
       extractor_id: EXTRACTOR_ID,
@@ -92,6 +126,24 @@ export async function processRedemption8K(args: ProcessRedemption8KArgs): Promis
       section_name: REDEMPTION_SECTION,
       reason_code: "PARSE_ERROR",
       detail: err instanceof Error ? err.message : String(err),
+      failed_extractor_version: extractor_version,
+      source_run_id: null,
+    });
+    return;
+  }
+
+  // Full-drop (every part oversized, or surviving aggregate exceeded the total
+  // cap): record an OVERSIZED_INPUT dead-letter and return without invoking
+  // the model. Surfaces in `sec extractor dead-letters redemption` for triage.
+  if (text === "" && dropped > 0) {
+    await deadLetters.record({
+      extractor_id: EXTRACTOR_ID,
+      accession_number,
+      section_name: REDEMPTION_SECTION,
+      reason_code: "OVERSIZED_INPUT",
+      detail: totalDropped
+        ? `surviving exhibits exceeded ${MAX_TOTAL_CHARS} char total cap (dropped=${dropped}, chars=${droppedChars})`
+        : `every primary/EX-99 exhibit exceeded ${MAX_PER_EXHIBIT_CHARS} char per-exhibit cap (dropped=${dropped}, chars=${droppedChars})`,
       failed_extractor_version: extractor_version,
       source_run_id: null,
     });
@@ -143,5 +195,21 @@ export async function processRedemption8K(args: ProcessRedemption8KArgs): Promis
 
   if (persisted > 0) {
     await new SpacReportWriter().recordRedemption({ cik, accession_number, filing_date, form });
+  }
+
+  // Partial-drop: at least one exhibit was skipped but a non-empty survivor set
+  // ran through extraction. Record an informational dead-letter so operators
+  // can triage filings whose largest exhibit was dropped (mirrors the
+  // "<section>-partial" pattern in sectionRunner.ts).
+  if (dropped > 0 && !totalDropped) {
+    await deadLetters.record({
+      extractor_id: EXTRACTOR_ID,
+      accession_number,
+      section_name: `${REDEMPTION_SECTION}-partial-oversized`,
+      reason_code: "OVERSIZED_INPUT",
+      detail: `dropped ${dropped} exhibit(s) over ${MAX_PER_EXHIBIT_CHARS} char cap (chars=${droppedChars})`,
+      failed_extractor_version: extractor_version,
+      source_run_id: null,
+    });
   }
 }

--- a/src/storage/dead-letter/ExtractionDeadLetterSchema.ts
+++ b/src/storage/dead-letter/ExtractionDeadLetterSchema.ts
@@ -17,6 +17,7 @@ export const DEAD_LETTER_REASON_CODES = [
   "PRIMARY_DOC_UNRESOLVED",
   "FETCH_ERROR",
   "PARSE_ERROR",
+  "OVERSIZED_INPUT",
 ] as const;
 export type DeadLetterReasonCode = (typeof DEAD_LETTER_REASON_CODES)[number];
 

--- a/src/storage/spac/SpacReportWriter.test.ts
+++ b/src/storage/spac/SpacReportWriter.test.ts
@@ -328,4 +328,121 @@ describe("SpacReportWriter", () => {
     expect(row?.target_name).toBe("Acme Target Inc."); // still correlated
     expect(row?.status).toBe("deal_announced"); // no proxy event -> not "proxy"
   });
+
+  it("valid_from is strictly increasing across writes even when the wall clock rewinds", async () => {
+    // First write at "now"; second write with the wall clock rewound 90 days.
+    // A snapshot derived from `new Date()` would emit a valid_from earlier than
+    // the previously-closed row's valid_to and invert the chain.
+    const RealDate = Date;
+    const setNow = (ms: number): void => {
+      class FakeDate extends RealDate {
+        constructor(...args: ConstructorParameters<typeof Date> | []) {
+          if (args.length === 0) super(ms);
+          else super(...(args as ConstructorParameters<typeof Date>));
+        }
+        static now(): number {
+          return ms;
+        }
+      }
+      globalThis.Date = FakeDate as DateConstructor;
+    };
+    const T_LATE = RealDate.parse("2026-06-01T00:00:00.000Z");
+    const T_REWOUND = RealDate.parse("2026-03-01T00:00:00.000Z"); // 90 days earlier
+    try {
+      setNow(T_LATE);
+      await writer.recordRegistration({
+        cik: 30,
+        accession_number: "30-reg",
+        filing_date: "2021-01-10", // forward
+        form: "S-1",
+        primary_document: "s1.htm",
+        spac_name: "Clock Rewind SPAC",
+        spac_sic: 6770,
+      });
+      setNow(T_REWOUND);
+      await writer.recordIpo({
+        cik: 30,
+        accession_number: "30-ipo",
+        filing_date: "2021-02-15", // forward
+        form: "424B4",
+        primary_document: "424.htm",
+        ipo_proceeds: 100_000_000,
+        trust_amount: 100_000_000,
+        spac_tickers: ["CRW.U"],
+      });
+    } finally {
+      globalThis.Date = RealDate;
+    }
+
+    const history = await repo.getHistory(30);
+    expect(history.length).toBe(2);
+    const sorted = [...history].sort((a, b) => a.valid_from.localeCompare(b.valid_from));
+    expect(sorted[0].valid_from < sorted[1].valid_from).toBe(true);
+    expect(sorted[0].valid_to).toBe(sorted[1].valid_from); // contiguous
+    expect(history.filter((h) => h.valid_to == null).length).toBe(1);
+  });
+
+  it("stale-replay history is anchored at existing as_of, not wall clock", async () => {
+    // Seed at "2021-06-01"; then replay a stale write with filing_date older
+    // than the as_of guard. The history row must not be stamped at current
+    // wall clock — that lets stale data sneak into the most recent slot.
+    await writer.recordIpo({
+      cik: 31,
+      accession_number: "31-ipo",
+      filing_date: "2021-06-01",
+      form: "424B4",
+      primary_document: "424.htm",
+      ipo_proceeds: 100_000_000,
+      trust_amount: 100_000_000,
+      spac_tickers: ["STALE.U"],
+    });
+    const after = await repo.getSpac(31);
+    expect(after?.as_of).toBe("2021-06-01");
+
+    // Stale replay: older filing_date than as_of.
+    await writer.recordRegistration({
+      cik: 31,
+      accession_number: "31-reg",
+      filing_date: "2020-12-01", // older
+      form: "S-1",
+      primary_document: "s1.htm",
+      spac_name: "Stale Replay SPAC",
+      spac_sic: 6770,
+    });
+
+    const history = await repo.getHistory(31);
+    // Find the newest history row (the stale-replay snapshot).
+    const sorted = [...history].sort((a, b) => b.valid_from.localeCompare(a.valid_from));
+    const newest = sorted[0];
+    // Anchor must be the existing as_of (2021-06-01), not current wall clock.
+    // We assert it's NOT the current year — a wall-clock anchor would be 2026+.
+    expect(newest.valid_from.startsWith("2021-06")).toBe(true);
+  });
+
+  it("the closed-row chain is never overlapped across many writes", async () => {
+    // Three writes; assert valid_to of each closed row matches valid_from of
+    // the next row, and the chain is strictly increasing.
+    await writer.recordRegistration({
+      cik: 32, accession_number: "32-reg", filing_date: "2021-01-01", form: "S-1",
+      primary_document: "s1.htm", spac_name: "Chain SPAC", spac_sic: 6770,
+    });
+    await writer.recordIpo({
+      cik: 32, accession_number: "32-ipo", filing_date: "2021-02-01", form: "424B4",
+      primary_document: "424.htm", ipo_proceeds: 50_000_000, trust_amount: 50_000_000,
+      spac_tickers: ["CHN.U"],
+    });
+    await writer.recordDealMilestones({
+      cik: 32, accession_number: "32-da", filing_date: "2021-03-01", form: "8-K",
+      primary_document: null,
+      events: [{ event_type: "definitive_agreement", event_date: "2021-03-01" }],
+    });
+
+    const history = await repo.getHistory(32);
+    const sorted = [...history].sort((a, b) => a.valid_from.localeCompare(b.valid_from));
+    for (let i = 0; i + 1 < sorted.length; i++) {
+      expect(sorted[i].valid_to).toBe(sorted[i + 1].valid_from);
+      expect(sorted[i].valid_from < sorted[i + 1].valid_from).toBe(true);
+    }
+    expect(sorted[sorted.length - 1].valid_to).toBeNull();
+  });
 });

--- a/src/storage/spac/SpacReportWriter.ts
+++ b/src/storage/spac/SpacReportWriter.ts
@@ -14,6 +14,7 @@ import type { Spac } from "./SpacSchema";
 import type { SpacEvent, SpacEventType } from "./SpacEventSchema";
 import type { SpacHistory } from "./SpacHistorySchema";
 import { CHANGE_LOG_REPOSITORY_TOKEN } from "../change-tracking/ChangeLogSchema";
+import { withSpacCikLock } from "./SpacWriteLock";
 
 interface RecordRegistrationArgs {
   readonly cik: number;
@@ -222,27 +223,59 @@ export class SpacReportWriter {
     changeSource: string,
     patch: SpacRowPatch
   ): Promise<void> {
-    const existing = await this.repo.getSpac(cik);
-    const [deals, events] = await Promise.all([this.repo.getDeals(cik), this.repo.getEvents(cik)]);
-    const next = buildSpacRow({ existing, cik, deals, events, patch, filingDate });
-    await this.repo.saveSpac(next);
-    await this.snapshot(existing, next, changeSource);
+    await withSpacCikLock(cik, this.repo.dealRepository, async () => {
+      const existing = await this.repo.getSpac(cik);
+      const [deals, events] = await Promise.all([
+        this.repo.getDeals(cik),
+        this.repo.getEvents(cik),
+      ]);
+      const next = buildSpacRow({ existing, cik, deals, events, patch, filingDate });
+      await this.repo.saveSpac(next);
+      await this.snapshot(existing, next, changeSource, filingDate);
+    });
   }
 
-  private async snapshot(prev: Spac | undefined, next: Spac, changeSource: string): Promise<void> {
+  private async snapshot(
+    prev: Spac | undefined,
+    next: Spac,
+    changeSource: string,
+    filingDate: string
+  ): Promise<void> {
     const changed = TRACKED_FIELDS.filter((f) => (prev ? prev[f] : null) !== next[f]);
     if (changed.length === 0) return;
 
-    // Close the open history row, then append the new snapshot. Guarantee a
-    // strictly increasing valid_from: two writes for the same CIK in the same
-    // millisecond would otherwise collide on the (cik, valid_from) primary key
-    // and the new snapshot would overwrite the just-closed row, losing history.
+    // Anchor valid_from to the filing's data (not wall-clock updated_at), then
+    // enforce strict monotonicity against every prior history row (closed and
+    // open alike). Wall-clock anchors invert the chain under clock skew or DST
+    // rollback; comparing only the open row lets a same-instant stale replay
+    // back-date past a closed snapshot.
     const history = await this.repo.getHistory(next.cik);
     const open = history.find((h) => h.valid_to == null);
-    let validFrom = next.updated_at;
-    if (open && validFrom <= open.valid_from) {
-      validFrom = new Date(Date.parse(open.valid_from) + 1).toISOString();
-    }
+    const closedTimes = history
+      .filter((h) => h.valid_to != null)
+      .flatMap((h) => [Date.parse(h.valid_from), Date.parse(h.valid_to as string)])
+      .filter((n) => Number.isFinite(n));
+    const maxClosedTo = closedTimes.length > 0 ? Math.max(...closedTimes) : Number.NEGATIVE_INFINITY;
+    const openValidFromMs = open ? Date.parse(open.valid_from) : Number.NEGATIVE_INFINITY;
+
+    const filingDateMs = filingDate === "" ? 0 : Date.parse(`${filingDate}T00:00:00.000Z`);
+    const isStale =
+      prev?.as_of != null &&
+      prev.as_of !== "" &&
+      (filingDate === "" || filingDate < prev.as_of);
+    const anchorMs = isStale
+      ? prev?.as_of != null && prev.as_of !== ""
+        ? Date.parse(`${prev.as_of}T00:00:00.000Z`)
+        : filingDateMs
+      : filingDateMs;
+
+    const validFromMs = Math.max(
+      Number.isFinite(anchorMs) ? anchorMs : 0,
+      Number.isFinite(maxClosedTo) ? maxClosedTo + 1 : Number.NEGATIVE_INFINITY,
+      Number.isFinite(openValidFromMs) ? openValidFromMs + 1 : Number.NEGATIVE_INFINITY
+    );
+    const validFrom = new Date(validFromMs).toISOString();
+
     if (open) {
       await this.repo.saveHistory({ ...open, valid_to: validFrom });
     }

--- a/src/storage/spac/SpacWriteLock.test.ts
+++ b/src/storage/spac/SpacWriteLock.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { SpacRepo } from "./SpacRepo";
+import { SpacReportWriter } from "./SpacReportWriter";
+import { withSpacCikLock } from "./SpacWriteLock";
+
+describe("withSpacCikLock", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+
+  it("serializes per-CIK writers (in-memory backend)", async () => {
+    // Two concurrent callers on the same CIK must not overlap. The slow inner
+    // function records start/end and verifies no observed overlap.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const repo = new SpacRepo();
+
+    async function critical(): Promise<void> {
+      inFlight++;
+      if (inFlight > maxInFlight) maxInFlight = inFlight;
+      await new Promise((r) => setTimeout(r, 20));
+      inFlight--;
+    }
+
+    await Promise.all([
+      withSpacCikLock(100, repo.dealRepository, critical),
+      withSpacCikLock(100, repo.dealRepository, critical),
+      withSpacCikLock(100, repo.dealRepository, critical),
+    ]);
+
+    expect(maxInFlight).toBe(1);
+  });
+
+  it("locks are scoped per CIK — different CIKs do not block each other", async () => {
+    const repo = new SpacRepo();
+    let aStarted = false;
+    let bStarted = false;
+    let bothInFlightAtSomePoint = false;
+
+    await Promise.all([
+      withSpacCikLock(101, repo.dealRepository, async () => {
+        aStarted = true;
+        // Wait briefly so the other lock has a chance to acquire.
+        for (let i = 0; i < 10 && !bStarted; i++) {
+          await new Promise((r) => setTimeout(r, 5));
+        }
+        if (bStarted) bothInFlightAtSomePoint = true;
+      }),
+      withSpacCikLock(102, repo.dealRepository, async () => {
+        bStarted = true;
+        for (let i = 0; i < 10 && !aStarted; i++) {
+          await new Promise((r) => setTimeout(r, 5));
+        }
+      }),
+    ]);
+
+    expect(bothInFlightAtSomePoint).toBe(true);
+  });
+
+  it("three parallel SpacReportWriter rebuilds on the same CIK leave exactly one open history row", async () => {
+    // Without the per-CIK lock, three concurrent writers could each observe
+    // the same set of history rows and each emit a new open row, leaving
+    // multiple valid_to = null rows. Under the lock, exactly one open row
+    // remains after all writers complete.
+    const writer = new SpacReportWriter();
+    const repo = new SpacRepo();
+    await Promise.all([
+      writer.recordRegistration({
+        cik: 200,
+        accession_number: "200-reg-a",
+        filing_date: "2026-01-01",
+        form: "S-1",
+        primary_document: "s1.htm",
+        spac_name: "Parallel SPAC A",
+        spac_sic: 6770,
+      }),
+      writer.recordRegistration({
+        cik: 200,
+        accession_number: "200-reg-b",
+        filing_date: "2026-01-02",
+        form: "S-1/A",
+        primary_document: "s1a.htm",
+        spac_name: "Parallel SPAC B",
+        spac_sic: 6770,
+      }),
+      writer.recordRegistration({
+        cik: 200,
+        accession_number: "200-reg-c",
+        filing_date: "2026-01-03",
+        form: "S-1/A",
+        primary_document: "s1a.htm",
+        spac_name: "Parallel SPAC C",
+        spac_sic: 6770,
+      }),
+    ]);
+
+    const history = await repo.getHistory(200);
+    const open = history.filter((h) => h.valid_to == null);
+    expect(open.length).toBe(1);
+  });
+});

--- a/src/storage/spac/SpacWriteLock.ts
+++ b/src/storage/spac/SpacWriteLock.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { SEC_DB_TYPE } from "../../config/tokens";
+import { getDb } from "../../util/db";
+import { getPgPool } from "../../util/pg";
+import type { SpacDealRepositoryStorage } from "./SpacDealSchema";
+
+/**
+ * Postgres advisory-lock namespace for SPAC CIK locks. Two-key
+ * `pg_advisory_xact_lock(ns, cik)` lets every (cik, this-namespace) pair lock
+ * independently of other features' advisory locks. The literal spells "SPAC"
+ * in ASCII so it's identifiable in `pg_locks`.
+ */
+export const PG_ADVISORY_LOCK_NAMESPACE_SPAC = 0x5350_4143;
+
+/** Per-process keyed mutex used by the in-memory / fallback backend. */
+const inProcessLocks = new Map<number, Promise<void>>();
+
+async function withInProcessLock<T>(cik: number, fn: () => Promise<T>): Promise<T> {
+  const prior = inProcessLocks.get(cik) ?? Promise.resolve();
+  let release!: () => void;
+  const settled = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Tail of the chain: this caller will hold the slot until `release()`; the
+  // next caller chains its `await` onto this settled promise.
+  const tail = prior.then(() => settled);
+  inProcessLocks.set(cik, tail);
+  await prior;
+  try {
+    return await fn();
+  } finally {
+    release();
+    // Only clear when this caller is still the tail — if a later caller has
+    // already chained on, the map entry must keep pointing at their tail.
+    if (inProcessLocks.get(cik) === tail) {
+      inProcessLocks.delete(cik);
+    }
+  }
+}
+
+/**
+ * Run `fn` while holding a per-CIK write lock so that the
+ * `getSpac → buildSpacRow → saveSpac` + history snapshot critical section in
+ * `SpacReportWriter.rebuild` is serialized across concurrent writers.
+ *
+ * Dispatch mirrors `cikNameBulkWriter`:
+ *   - SQLite (`SEC_DB_TYPE=sqlite`): raw `BEGIN IMMEDIATE`/`COMMIT` on the
+ *     shared connection. SQLite is single-writer, so this also serializes
+ *     against any other writer holding the database lock.
+ *   - Postgres (`SEC_DB_TYPE=postgres`): per-transaction advisory lock keyed
+ *     on (`PG_ADVISORY_LOCK_NAMESPACE_SPAC`, `cik`).
+ *   - Anything else (in-memory tests / unregistered): per-process keyed
+ *     mutex on `cik`.
+ *
+ * Caveat: this does not yet handle a nested transaction held by the caller.
+ * On main, `recomputeAndSaveDeals` issues no inner BEGIN, so the SQLite
+ * `BEGIN IMMEDIATE` here is the only transaction in the rebuild stack.
+ */
+export async function withSpacCikLock<T>(
+  cik: number,
+  _dealRepo: SpacDealRepositoryStorage,
+  fn: () => Promise<T>
+): Promise<T> {
+  const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
+    ? globalServiceRegistry.get(SEC_DB_TYPE)
+    : null;
+
+  if (dbType === "sqlite") {
+    const db = getDb();
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = await fn();
+      db.exec("COMMIT");
+      return result;
+    } catch (err) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        // ignore — the original error is what callers care about
+      }
+      throw err;
+    }
+  }
+
+  if (dbType === "postgres") {
+    const pool = getPgPool();
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query("SELECT pg_advisory_xact_lock($1::int, $2::int)", [
+        PG_ADVISORY_LOCK_NAMESPACE_SPAC,
+        cik,
+      ]);
+      const result = await fn();
+      await client.query("COMMIT");
+      return result;
+    } catch (err) {
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        // ignore
+      }
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  return withInProcessLock(cik, fn);
+}

--- a/src/storage/spac/SpacWriteLock.ts
+++ b/src/storage/spac/SpacWriteLock.ts
@@ -5,7 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
-import { SEC_DB_TYPE } from "../../config/tokens";
+import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
 import { getDb } from "../../util/db";
 import { getPgPool } from "../../util/pg";
 import type { SpacDealRepositoryStorage } from "./SpacDealSchema";
@@ -64,14 +64,28 @@ async function withInProcessLock<T>(cik: number, fn: () => Promise<T>): Promise<
  */
 export async function withSpacCikLock<T>(
   cik: number,
-  _dealRepo: SpacDealRepositoryStorage,
+  dealRepo: SpacDealRepositoryStorage,
   fn: () => Promise<T>
 ): Promise<T> {
   const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
     ? globalServiceRegistry.get(SEC_DB_TYPE)
     : null;
 
-  if (dbType === "sqlite") {
+  // The dispatch follows the *active* repository class, not the SEC_DB_TYPE
+  // token. Tests stamp SEC_DB_TYPE="sqlite" then back the storages with
+  // InMemoryTabularStorage; trusting the env there would spuriously open a
+  // stray SQLite file via getDb(). The constructor-name check resolves the
+  // ambiguity without requiring callers to pass the backend explicitly.
+  const dealCtor = (dealRepo as { constructor?: { name?: string } })?.constructor?.name ?? "";
+  const isSqliteBacked = dealCtor.includes("Sqlite");
+  const isPostgresBacked = dealCtor.includes("Postgres");
+
+  if (
+    isSqliteBacked &&
+    dbType === "sqlite" &&
+    globalServiceRegistry.has(SEC_DB_FOLDER) &&
+    globalServiceRegistry.has(SEC_DB_NAME)
+  ) {
     const db = getDb();
     db.exec("BEGIN IMMEDIATE");
     try {
@@ -88,7 +102,7 @@ export async function withSpacCikLock<T>(
     }
   }
 
-  if (dbType === "postgres") {
+  if (isPostgresBacked && dbType === "postgres") {
     const pool = getPgPool();
     const client = await pool.connect();
     try {

--- a/src/storage/versioning/ExtractorRunRepo.test.ts
+++ b/src/storage/versioning/ExtractorRunRepo.test.ts
@@ -370,4 +370,87 @@ describe("ExtractorRunRepo with SQLite backend", () => {
     );
     expect(unprocessed.map((f) => f.cik).sort((a, b) => a - b)).toEqual([2000000, 3000000]);
   });
+
+  it("recordRun with outcome=partial sets success=false and partial outcome", async () => {
+    const repo = new ExtractorRunRepo(globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN));
+    await repo.recordRun({
+      cik: FILING.cik,
+      accession_number: FILING.accession_number,
+      form: FILING.form,
+      extractor_id: "S-1",
+      extractor_version: "1.0.0",
+      slot_at_run: "current",
+      success: false, // overridden by outcome
+      outcome: "partial",
+      error: null,
+    });
+    const found = await repo.findRun(FILING.cik, FILING.accession_number, "S-1", "1.0.0");
+    expect(found?.outcome).toBe("partial");
+    expect(found?.success).toBe(false);
+  });
+
+  it("countSuccessfulAtVersion does not count partial runs", async () => {
+    const repo = new ExtractorRunRepo(globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN));
+    await repo.recordRun({
+      cik: 1000000,
+      accession_number: "0001000000-25-000001",
+      form: "S-1",
+      extractor_id: "S-1",
+      extractor_version: "1.0.0",
+      slot_at_run: "current",
+      success: true,
+      outcome: "success",
+      error: null,
+    });
+    await repo.recordRun({
+      cik: 2000000,
+      accession_number: "0002000000-25-000001",
+      form: "S-1",
+      extractor_id: "S-1",
+      extractor_version: "1.0.0",
+      slot_at_run: "current",
+      success: false,
+      outcome: "partial",
+      error: null,
+    });
+    expect(await repo.countSuccessfulAtVersion("S-1", "1.0.0")).toBe(1);
+  });
+
+  it("listFilingsWithoutSuccessfulRun treats partial runs as not-successful", async () => {
+    const repo = new ExtractorRunRepo(globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN));
+    await repo.recordRun({
+      cik: 1000000,
+      accession_number: "0001000000-25-000001",
+      form: "S-1",
+      extractor_id: "S-1",
+      extractor_version: "1.0.0",
+      slot_at_run: "current",
+      success: false,
+      outcome: "partial",
+      error: null,
+    });
+    const unprocessed = await repo.listFilingsWithoutSuccessfulRun(
+      [{ cik: 1000000, accession_number: "0001000000-25-000001" }],
+      "S-1",
+      "1.0.0"
+    );
+    expect(unprocessed.length).toBe(1);
+  });
+
+  it("legacy rows without outcome are inferred from success boolean", async () => {
+    // Default recordRun (no outcome) infers from success: true -> success;
+    // false -> failure. countSuccessfulAtVersion counts the inferred success.
+    const repo = new ExtractorRunRepo(globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN));
+    await repo.recordRun({
+      cik: FILING.cik,
+      accession_number: FILING.accession_number,
+      form: FILING.form,
+      extractor_id: "D",
+      extractor_version: "1.0.0",
+      slot_at_run: "current",
+      success: true,
+      error: null,
+    });
+    expect(await repo.countSuccessfulAtVersion("D", "1.0.0")).toBe(1);
+  });
 });

--- a/src/storage/versioning/ExtractorRunRepo.ts
+++ b/src/storage/versioning/ExtractorRunRepo.ts
@@ -4,8 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ExtractorRun, ExtractorRunRepositoryStorage } from "./ExtractorRunSchema";
+import type {
+  ExtractorRun,
+  ExtractorRunOutcome,
+  ExtractorRunRepositoryStorage,
+} from "./ExtractorRunSchema";
 import { semverMajorMinorPrefix } from "./semver";
+
+/**
+ * Pre-`outcome` rows (success / failure boolean only) are inferred to
+ * outcome=success when success=true, outcome=failure otherwise. Partial is
+ * unknowable for legacy rows — the boolean alone can't distinguish a
+ * fully-successful run from one whose sections silently dead-lettered.
+ */
+function inferOutcome(row: ExtractorRun): ExtractorRunOutcome {
+  if (row.outcome) return row.outcome;
+  return row.success ? "success" : "failure";
+}
 
 export interface FilingKey {
   readonly cik: number;
@@ -25,9 +40,15 @@ export interface FilingKey {
 export class ExtractorRunRepo {
   constructor(private readonly storage: ExtractorRunRepositoryStorage) {}
 
-  async recordRun(row: Omit<ExtractorRun, "ran_at">): Promise<void> {
+  async recordRun(row: Omit<ExtractorRun, "ran_at" | "outcome"> & {
+    outcome?: ExtractorRunOutcome;
+  }): Promise<void> {
+    const outcome: ExtractorRunOutcome = row.outcome ?? (row.success ? "success" : "failure");
     await this.storage.put({
       ...row,
+      // success stays as the back-compat boolean mirror of outcome === "success".
+      success: outcome === "success",
+      outcome,
       ran_at: new Date().toISOString(),
     } as ExtractorRun);
   }
@@ -54,21 +75,24 @@ export class ExtractorRunRepo {
     extractor_version: string
   ): Promise<boolean> {
     const row = await this.findRun(cik, accession_number, extractor_id, extractor_version);
-    return row?.success === true;
+    return row !== undefined && inferOutcome(row) === "success";
   }
 
   /**
    * Counts successful runs for a specific (extractor_id, extractor_version).
    * Used by the major-promote coverage gate. Exact-match (not major.minor
    * prefix) because the gate measures actual production at the new version.
+   * Partial runs do NOT count — coverage measures fully-successful production.
    */
   async countSuccessfulAtVersion(extractor_id: string, extractor_version: string): Promise<number> {
-    const rows = await this.storage.query({
+    const rows = (await this.storage.query({
       extractor_id,
       extractor_version,
       success: true,
-    });
-    return rows?.length ?? 0;
+    })) ?? [];
+    // success=true narrows the storage scan; inferOutcome is the source of truth
+    // (legacy rows lack outcome and fall back to success).
+    return rows.filter((r) => inferOutcome(r) === "success").length;
   }
 
   /**
@@ -142,6 +166,9 @@ export class ExtractorRunRepo {
     const successfulKeys = new Set(
       (successful ?? [])
         .filter((r) => r.extractor_version.startsWith(prefix))
+        // Partial rows have success=true but outcome="partial"; they are NOT
+        // "successful enough" — retry-dead-letters should still pick them up.
+        .filter((r) => inferOutcome(r) === "success")
         .map((r) => `${r.cik}::${r.accession_number}`)
     );
     return filings.filter((f) => !successfulKeys.has(`${f.cik}::${f.accession_number}`));

--- a/src/storage/versioning/ExtractorRunSchema.ts
+++ b/src/storage/versioning/ExtractorRunSchema.ts
@@ -9,6 +9,9 @@ import type { ITabularStorage } from "workglow";
 import { createServiceToken } from "workglow";
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 
+export const EXTRACTOR_RUN_OUTCOMES = ["success", "partial", "failure"] as const;
+export type ExtractorRunOutcome = (typeof EXTRACTOR_RUN_OUTCOMES)[number];
+
 export const ExtractorRunSchema = Type.Object({
   cik: TypeSecCik({ description: "Central Index Key" }),
   accession_number: Type.String({
@@ -35,8 +38,15 @@ export const ExtractorRunSchema = Type.Object({
     description: "ISO 8601 timestamp",
   }),
   success: Type.Boolean({
-    description: "Whether the extractor completed without error",
+    description: "Whether the extractor completed without error (mirrors outcome === 'success')",
   }),
+  outcome: Type.Union(
+    [Type.Literal("success"), Type.Literal("partial"), Type.Literal("failure")],
+    {
+      description:
+        "Tri-state run result: success (every section persisted), partial (parse+store ran but at least one section dead-lettered), failure (filing-level failure).",
+    }
+  ),
   error: Type.Union(
     [Type.String({ maxLength: 4096 }), Type.Null()],
     { description: "Error message if success=false, else null" }

--- a/src/task/forms/ProcessAccessionDocFormTask.s1.test.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.s1.test.ts
@@ -110,7 +110,7 @@ describe("ProcessAccessionDocFormTask (S-1 end-to-end)", () => {
     resetDependencyInjectionsForTesting();
   });
 
-  it("dispatches an S-1 filing to processFormS1 and records a successful run", async () => {
+  it("dispatches an S-1 filing to processFormS1 and records a partial run when some sections dead-letter", async () => {
     const { unregister } = registerFakeStructuredProvider([
       // management
       {
@@ -144,7 +144,10 @@ describe("ProcessAccessionDocFormTask (S-1 end-to-end)", () => {
     const runRepo = new ExtractorRunRepo(globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN));
     const run = await runRepo.findRun(CIK, ACCESSION, "S-1", "1.0.0");
     expect(run).toBeDefined();
-    expect(run?.success).toBe(true);
+    // ownership / related-party returned empty arrays so they dead-letter
+    // MODEL_EMPTY; the run is therefore "partial" rather than fully successful.
+    expect(run?.outcome).toBe("partial");
+    expect(run?.success).toBe(false);
 
     const companies = await new CompanyObservationRepo().listAll();
     expect(companies.some((c) => c.cik === CIK)).toBe(true);

--- a/src/task/forms/ProcessAccessionDocFormTask.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.ts
@@ -241,6 +241,7 @@ export class ProcessAccessionDocFormTask extends Task<
           extractor_version: extractorVersion,
           slot_at_run: slotAtRun,
           success: false,
+          outcome: "failure",
           error: message.slice(0, 4096),
         });
       } catch (recordErr) {
@@ -411,6 +412,23 @@ export class ProcessAccessionDocFormTask extends Task<
           dlErr
         );
       }
+      // Detect partial-success: parse+store ran end-to-end, but at least one
+      // section dead-lettered. A pending section-level entry (section_name !== "")
+      // for this filing means coverage-as-success would be a lie. Filing-level
+      // (section_name === "") entries were already markResolved above.
+      let outcome: "success" | "partial" = "success";
+      try {
+        const pending = await deadLetters.listPending(extractorId);
+        const hasPendingSection = pending.some(
+          (r) => r.accession_number === accessionNumber && r.section_name !== ""
+        );
+        if (hasPendingSection) outcome = "partial";
+      } catch (dlErr) {
+        console.error(
+          `Failed to query pending dead-letters for ${accessionNumber}@${extractorId}:`,
+          dlErr
+        );
+      }
       try {
         await runRepo.recordRun({
           cik: cik!,
@@ -419,7 +437,8 @@ export class ProcessAccessionDocFormTask extends Task<
           extractor_id: extractorId,
           extractor_version: extractorVersion,
           slot_at_run: slotAtRun,
-          success: true,
+          success: outcome === "success",
+          outcome,
           error: null,
         });
       } catch (recordErr) {


### PR DESCRIPTION
## Summary

Three correctness/security fixes stacked as separate commits.

### 1. SPAC writer atomicity + monotonic history chain
`SpacReportWriter.snapshot()` derived `valid_from` from wall-clock `next.updated_at` and only de-collided against the currently-open history row, so clock skew or a stale-replay could invert the chain or back-date a history snapshot. `rebuild()` and `snapshot()` also read-modify-write without any lock, so two concurrent writers on the same CIK could leave two `valid_to == null` rows.

- Anchor `valid_from` to the filing data (`filingDate` for non-stale writes, the existing row's `as_of` for stale replays) with strict monotonicity enforced against the max of all prior closed/open `valid_to` values.
- New `withSpacCikLock` wraps the rebuild critical section — SQLite `BEGIN IMMEDIATE`, Postgres `pg_advisory_xact_lock` keyed on CIK, in-memory keyed mutex fallback. Backend dispatch checks the active repo class so in-memory test backends never reach `getDb()`.
- New `SpacWriteLock.test.ts` asserts exactly one open history row after 3 parallel writers on the same CIK.

### 2. Cap redemption AI input bytes
`processRedemption8K` joined the primary doc + every EX-99 exhibit markdown unconditionally into `runStructured`, with `MAX_TOKENS=4096` bounding only the model's completion. A multi-megabyte EX-99 ran up token bills and widened the prompt-injection surface proportional to filing size.

- Per-exhibit cap (200k chars) + total cap (400k chars). Oversized exhibits are dropped (not truncated — partial spans break source-span verification).
- Full-drop records an `OVERSIZED_INPUT` dead-letter without invoking the model.
- Partial-drop records an informational `<section>-partial-oversized` dead-letter so operators can triage filings whose largest exhibit was skipped.
- Bump `redemption` extractor `1.0.0` → `1.1.0` (prompt shape changed → confidence calibration drifts → fresh dev cycle, matching the S-1/424 precedent in PR #165).
- Add `OVERSIZED_INPUT` to `DEAD_LETTER_REASON_CODES`.

### 3. Partial-success outcome on `extractor_runs`
`makeRunSection` catches `MODEL_INVALID_OUTPUT` / `LOW_CONFIDENCE_ALL` / `UNVERIFIED_SOURCE_SPAN`, writes a dead-letter, and returns without throwing. `ProcessAccessionDocFormTask` then recorded a `success` row even when every section dead-lettered, so `sec version coverage` counted those as covered and `drop-previous` purged the dead-letter rows operators needed for triage.

- Add tri-state `outcome` column (`success` / `partial` / `failure`) to `extractor_runs`. `success` boolean kept as `outcome === "success"` for back-compat.
- After successful parse+store, `ProcessAccessionDocFormTask` queries pending section-level dead-letters for the filing and writes `outcome = "partial"` when any exist.
- `countSuccessfulAtVersion` and `listFilingsWithoutSuccessfulRun` count only `outcome = "success"`; partial rows stay eligible for `retry-dead-letters`.
- Legacy rows backfill `outcome` from the existing `success` boolean (partial breakdown is unknowable for them); SQLite `setupAllDatabases` gets a one-shot `ADD COLUMN` migration for pre-existing databases.

## PR #169 merge-order note

`withSpacCikLock` does NOT yet handle a nested transaction held by the caller. On `main` today, `recomputeAndSaveDeals` issues no inner `BEGIN`, so the SQLite `BEGIN IMMEDIATE` here is the only transaction in the rebuild stack. PR #169 (`SpacDealReplace.ts`) introduces its own transaction in `recomputeSpacDeals`.

If this PR lands first, PR #169 should rebase its transaction to either skip `BEGIN` when an outer lock holds it, or detect the active transaction and use `SAVEPOINT` instead. If PR #169 lands first, this PR's SQLite path may need a similar guard.

## Test plan

- [x] `bun run build` — clean
- [x] `bun test src/storage/spac/` — all pass
- [x] `bun test src/sec/forms/miscellaneous-filings/` — all pass (incl. new oversized tests)
- [x] `bun test src/task/forms/` — all pass
- [x] `bun test src/storage/versioning/` — all pass (incl. new partial-outcome tests)
- [x] `bun test src/cli/queries/` — VersionCoverage tests still pass
- [x] Full `bun test` — 1386 pass / pre-existing FetchDailyIndexTask / FetchQuarterlyIndexTask network timeouts unrelated to this PR

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3e3m8cMRy5stFhDzGmZrF)_