### PR TITLE
fix(forms): restore predefined XML entity decoding without re-opening XXE

### DIFF
--- a/src/sec/forms/Form.entity.test.ts
+++ b/src/sec/forms/Form.entity.test.ts
@@ -6,13 +6,16 @@
 
 import { describe, expect, it } from "bun:test";
 import { Form_8_K } from "./miscellaneous-filings/Form_8_K";
+import { Form_D } from "./exempt-offerings/Form_D";
+import { stripDoctype } from "./Form";
 
 describe("Form XML parser entity expansion hardening", () => {
   /**
    * "Billion laughs" — geometric entity expansion. With expansion enabled the
    * 10-deep nested chain `lol9 -> 10 x lol8 -> ... -> 10^9 x "lol"` produces a
-   * ~1 GB string and pegs CPU. With `processEntities: false` the parser leaves
-   * the `&lolN;` byte sequences literal, so the parse is bounded by input size.
+   * ~1 GB string and pegs CPU. With bounded `processEntities` + DOCTYPE strip,
+   * the filer-declared entities never reach the parser and `&lolN;` byte
+   * sequences remain literal, so the parse is bounded by input size.
    */
   const BILLION_LAUGHS = `<?xml version="1.0"?>
 <!DOCTYPE edgarSubmission [
@@ -43,5 +46,106 @@ describe("Form XML parser entity expansion hardening", () => {
     expect(elapsed).toBeLessThan(50);
     // The parse succeeded and produced an object — no expansion crash, no OOM.
     expect(result).toBeDefined();
+  });
+
+  it("round-trips a predefined ampersand entity in a Form D entityName", async () => {
+    const xml = `<?xml version="1.0"?>
+<edgarSubmission>
+  <schemaVersion>X0708</schemaVersion>
+  <submissionType>D</submissionType>
+  <primaryIssuer>
+    <cik>0000000001</cik>
+    <entityName>Mac Accounting Group &amp;amp; CPAs, LLP</entityName>
+    <issuerAddress>
+      <street1>1 Main St</street1>
+      <city>Anywhere</city>
+      <stateOrCountry>CA</stateOrCountry>
+      <stateOrCountryDescription>CALIFORNIA</stateOrCountryDescription>
+      <zipCode>90001</zipCode>
+    </issuerAddress>
+    <issuerPhoneNumber>5555555555</issuerPhoneNumber>
+  </primaryIssuer>
+</edgarSubmission>`;
+    const result: any = await Form_D.parse("D", xml);
+    // The filer double-encoded an `&` so the body reads `&amp;amp;`. One decode
+    // step (the parser's predefined-entity pass) yields `&amp;`, which is the
+    // intended literal display form for "Mac Accounting Group & CPAs, LLP".
+    expect(result.primaryIssuer.entityName).toBe("Mac Accounting Group &amp; CPAs, LLP");
+  });
+
+  it("strips a DOCTYPE-declared custom entity so it parses as literal text", async () => {
+    const xml = `<?xml version="1.0"?>
+<!DOCTYPE edgarSubmission [
+  <!ENTITY xxe "PWNED">
+]>
+<edgarSubmission>
+  <schemaVersion>X0708</schemaVersion>
+  <submissionType>D</submissionType>
+  <primaryIssuer>
+    <cik>0000000001</cik>
+    <entityName>&xxe;</entityName>
+    <issuerAddress>
+      <street1>1 Main St</street1>
+      <city>Anywhere</city>
+      <stateOrCountry>CA</stateOrCountry>
+      <stateOrCountryDescription>CALIFORNIA</stateOrCountryDescription>
+      <zipCode>90001</zipCode>
+    </issuerAddress>
+    <issuerPhoneNumber>5555555555</issuerPhoneNumber>
+  </primaryIssuer>
+</edgarSubmission>`;
+    const result: any = await Form_D.parse("D", xml);
+    // With DOCTYPE stripped, the parser has no definition for `xxe` — the byte
+    // sequence remains literal rather than expanding to "PWNED".
+    expect(result.primaryIssuer.entityName).not.toBe("PWNED");
+    expect(result.primaryIssuer.entityName).toBe("&xxe;");
+  });
+
+  it("decodes the five predefined XML entities in element text", async () => {
+    // `&apos;` is not legal in a Form D entityName regex, so use the
+    // schemaVersion text channel for full coverage and entityName for the
+    // ampersand/lt/gt subset.
+    const xml = `<?xml version="1.0"?>
+<edgarSubmission>
+  <schemaVersion>A &amp; B &lt; C &gt; D &quot;E&quot; F &apos;G&apos;</schemaVersion>
+  <submissionType>D</submissionType>
+  <primaryIssuer>
+    <cik>0000000001</cik>
+    <entityName>A &amp; B</entityName>
+    <issuerAddress>
+      <street1>1 Main St</street1>
+      <city>Anywhere</city>
+      <stateOrCountry>CA</stateOrCountry>
+      <stateOrCountryDescription>CALIFORNIA</stateOrCountryDescription>
+      <zipCode>90001</zipCode>
+    </issuerAddress>
+    <issuerPhoneNumber>5555555555</issuerPhoneNumber>
+  </primaryIssuer>
+</edgarSubmission>`;
+    const result: any = await Form_D.parse("D", xml);
+    expect(result.schemaVersion).toBe(`A & B < C > D "E" F 'G'`);
+    expect(result.primaryIssuer.entityName).toBe("A & B");
+  });
+});
+
+describe("stripDoctype helper", () => {
+  it("removes a simple DOCTYPE declaration", () => {
+    const out = stripDoctype(`<?xml version="1.0"?>\n<!DOCTYPE foo>\n<foo/>`);
+    expect(out).not.toContain("DOCTYPE");
+    expect(out).toContain("<foo/>");
+  });
+
+  it("removes a DOCTYPE with a bracketed internal subset (including ENTITY decls)", () => {
+    const out = stripDoctype(
+      `<!DOCTYPE foo [ <!ENTITY xxe "PWNED"> <!ENTITY a "b"> ]>\n<foo>&xxe;</foo>`
+    );
+    expect(out).not.toContain("DOCTYPE");
+    expect(out).not.toContain("ENTITY");
+    expect(out).toContain("<foo>&xxe;</foo>");
+  });
+
+  it("leaves XML without a DOCTYPE unchanged", () => {
+    const xml = `<?xml version="1.0"?><foo>bar</foo>`;
+    expect(stripDoctype(xml)).toBe(xml);
   });
 });

--- a/src/sec/forms/Form.ts
+++ b/src/sec/forms/Form.ts
@@ -10,6 +10,36 @@ import { X2jOptions, XMLParser } from "fast-xml-parser";
 import type { TObject } from "typebox";
 import { extractArrayPaths } from "./parse_util";
 
+/**
+ * Strip any leading `<!DOCTYPE ...>` declaration (including a bracketed
+ * internal subset like `<!DOCTYPE name [ <!ENTITY xxe "..."> ]>`).
+ *
+ * The parser still defends in depth via bounded `processEntities`, but
+ * pre-stripping the DOCTYPE eliminates any chance of a filer-declared entity
+ * being expanded — only the five predefined XML entities (`&amp;`, `&lt;`,
+ * `&gt;`, `&quot;`, `&apos;`) remain in play.
+ */
+export function stripDoctype(xml: string): string {
+  // Match `<!DOCTYPE ...>` — either the simple form or the bracketed
+  // internal-subset form. The internal subset is delimited by `[ ... ]` and
+  // can contain `>` inside `<!ENTITY ...>` declarations, so we find the
+  // matching `]` and then the closing `>`. DOCTYPE legally appears between the
+  // XML declaration and the root element; we permit any leading whitespace,
+  // optional `<?xml ...?>` declaration, and additional whitespace before it.
+  return xml.replace(
+    /(^\s*(?:<\?xml[^?]*\?>\s*)?)<!DOCTYPE\b[^[>]*(?:\[[\s\S]*?\][^>]*)?>\s*/i,
+    "$1"
+  );
+}
+
+/**
+ * Thin wrapper around an XMLParser instance that strips any DOCTYPE
+ * declaration before parsing. Returned by {@link Form.getParser}.
+ */
+export interface FormXmlParser {
+  parse(xml: string): any;
+}
+
 export abstract class Form {
   static readonly name: string;
   static readonly description: string;
@@ -22,7 +52,7 @@ export abstract class Form {
   // multiple Form subclasses set `name` to a human-readable description and
   // collisions there would silently return another form's array paths.
   private static _arrayPaths = new WeakMap<Function, string[]>();
-  protected static getParser(schema: TObject): XMLParser {
+  protected static getParser(schema: TObject): FormXmlParser {
     let paths = this._arrayPaths.get(this);
     if (!paths) {
       paths = extractArrayPaths(schema);
@@ -35,19 +65,33 @@ export abstract class Form {
       trimValues: true,
       parseTagValue: false,
       parseAttributeValue: false,
-      // Disable entity expansion. A filer-controlled XML payload that
-      // declares N references each pointing at a node containing N
-      // references explodes geometrically under expansion ("billion laughs"),
-      // and the parser hands us untrusted SGML/XML directly from the filer.
-      // Stays-literal preserves the raw `&entity;` byte sequence — the
-      // downstream consumers either don't read it or HTML-decode their own
-      // entity references explicitly.
-      processEntities: false,
+      // Allow decoding of the five predefined XML entities (`&amp;`, `&lt;`,
+      // `&gt;`, `&quot;`, `&apos;`) so values like
+      // `Mac Accounting Group &amp; CPAs, LLP` round-trip to their intended
+      // form. Filer-controlled XML can declare an entity chain that explodes
+      // geometrically under expansion ("billion laughs"), so the limits below
+      // bound the work the parser will do, and `stripDoctype` removes any
+      // filer-declared entity definitions before parsing as a second line of
+      // defense. Disabling entity processing entirely (`processEntities:
+      // false`) corrupts every value carrying a predefined entity — e.g.
+      // `&amp;` would persist as the literal four-character string.
+      processEntities: {
+        enabled: true,
+        maxEntityCount: 64,
+        maxExpansionDepth: 4,
+        maxExpandedLength: 1_000_000,
+        maxTotalExpansions: 10_000,
+      },
       isArray: (_name, jpath) => {
         return typeof jpath === "string" && paths.includes(jpath);
       },
     };
-    return new XMLParser(options);
+    const parser = new XMLParser(options);
+    return {
+      parse(xml: string): any {
+        return parser.parse(stripDoctype(xml));
+      },
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

PR #165 disabled entity processing entirely (`processEntities: false`) to defang billion-laughs payloads. That also **silently corrupted every XML form value carrying one of the five predefined XML entities** — e.g. a filer name like `Mac Accounting Group &amp; CPAs, LLP` was persisting as the literal four-character string `&amp;` instead of the intended `&`. Any field containing `&amp;`, `&lt;`, `&gt;`, `&quot;`, or `&apos;` was affected.

This restores the standard predefined-entity decode (so all five round-trip normally) while keeping XXE / billion-laughs defenses in place.

## Fix

Two layers of defense replace the heavy-handed `processEntities: false`:

1. **Bounded `processEntities` config.** `fast-xml-parser` 5.8.0+ supports
   `{ enabled, maxEntityCount, maxExpansionDepth, maxExpandedLength, maxTotalExpansions }`.
   A filer-declared chain bombs out at the configured limit instead of expanding geometrically.

2. **DOCTYPE strip.** A new `stripDoctype(xml)` pass removes any leading `<!DOCTYPE name [ ... ]>` block before parsing — including the bracketed internal subset where `<!ENTITY ...>` declarations live — so filer-declared custom entities never reach the parser at all.

`getParser()` now returns a thin wrapper exposing `parse(xml)` that runs `stripDoctype()` before delegating to the underlying `XMLParser`, so every existing callsite (Form_D, Form_C, Form_1_A, Form_1_K, Form_1_Z, Form_8_K, Form_3/4/5, Form_144, Form_CFPORTAL) picks up the fix without code changes.

## Test plan

- [x] Existing billion-laughs DOCTYPE test still parses in under 50 ms (no expansion).
- [x] `Mac Accounting Group &amp;amp; CPAs, LLP` in a Form D `<entityName>` round-trips through one decode step to `Mac Accounting Group &amp; CPAs, LLP`.
- [x] `<!DOCTYPE foo [ <!ENTITY xxe "PWNED"> ]>` is stripped, so `&xxe;` in the body parses as the literal `&xxe;` (NOT `PWNED`).
- [x] All five predefined entities (`&amp; &lt; &gt; &quot; &apos;`) decode to `& < > " '`.
- [x] `bun test src/sec/forms/` — 423 tests pass across 56 files.
- [x] `bun run build` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERWJJbFgDbPokzJCBsFMdE)_