### PR TITLE
fix(sec): gate SQLite SPAC lock through in-process mutex + auto-resolve oversized dead-letter

### DIFF
--- a/src/sec/forms/miscellaneous-filings/redemption8k.test.ts
+++ b/src/sec/forms/miscellaneous-filings/redemption8k.test.ts
@@ -280,7 +280,8 @@ describe("processRedemption8K", () => {
     const ext = await new SpacRedemptionExtractionRepo().getByAccession("0000000000-26-PART01");
     expect(ext?.redemption_amount).toBe(50_000_000);
 
-    // Partial-oversized informational dead-letter recorded.
+    // Partial-oversized informational dead-letter recorded — and auto-resolved
+    // (no retry recovers a deterministic-cap drop).
     const dlRepo = new ExtractionDeadLetterRepo();
     const partial = await dlRepo.get(
       "redemption",
@@ -288,6 +289,86 @@ describe("processRedemption8K", () => {
       "redemption-partial-oversized"
     );
     expect(partial?.reason_code).toBe("OVERSIZED_INPUT");
+    expect(partial?.status).toBe("resolved");
+  });
+
+  it("auto-resolves the partial-oversized dead-letter across replays — never appears in listEligible", async () => {
+    await seedSpacWithOpenDeal(53);
+    // Same shape as the partial-oversized test: small primary doc with the
+    // canonical sentence + an EX-99 over the cap that gets dropped.
+    const filler = "D".repeat(260_000);
+    const partialTxt =
+      "<SEC-HEADER>\nACCESSION NUMBER: 0000000000-26-RES001\n</SEC-HEADER>\n" +
+      "<DOCUMENT>\n<TYPE>8-K\n<SEQUENCE>1\n<TEXT>\n" +
+      "<p>Holders of 7,500,000 shares elected to redeem for $75,000,000.</p>\n" +
+      "</TEXT>\n</DOCUMENT>\n" +
+      "<DOCUMENT>\n<TYPE>EX-99.1\n<SEQUENCE>2\n<TEXT>\n" +
+      `<p>${filler}</p>\n` +
+      "</TEXT>\n</DOCUMENT>\n";
+    const registration = registerFakeStructuredProvider([
+      {
+        redemption_shares: 7_500_000,
+        redemption_amount: 75_000_000,
+        price_per_share: 10.0,
+        confidence: 0.95,
+        source_span: "7,500,000 shares elected to redeem for $75,000,000",
+      },
+      // Second-run replay produces the same row.
+      {
+        redemption_shares: 7_500_000,
+        redemption_amount: 75_000_000,
+        price_per_share: 10.0,
+        confidence: 0.95,
+        source_span: "7,500,000 shares elected to redeem for $75,000,000",
+      },
+    ]);
+    cleanup = registration.unregister;
+
+    const dlRepo = new ExtractionDeadLetterRepo();
+    const sectionKey = "redemption-partial-oversized";
+
+    // Run #1: record + auto-resolve.
+    await processRedemption8K({
+      cik: 53,
+      accession_number: "0000000000-26-RES001",
+      filing_date: "2026-03-20",
+      form: "8-K",
+      itemCodes: ["5.07"],
+      fullSubmissionText: partialTxt,
+      model: fakeS1Model(),
+    });
+
+    let entry = await dlRepo.get("redemption", "0000000000-26-RES001", sectionKey);
+    expect(entry?.status).toBe("resolved");
+    expect(entry?.attempts).toBe(1);
+
+    // The current extractor version must be derivable; we use the version on the
+    // recorded entry itself as the source of truth.
+    const currentVersion = entry!.failed_extractor_version;
+    let eligible = await dlRepo.listEligible("redemption", currentVersion);
+    expect(
+      eligible.filter((e) => e.section_name === sectionKey && e.accession_number === "0000000000-26-RES001")
+    ).toHaveLength(0);
+
+    // Run #2: idempotent — the entry stays resolved, attempts increments (audit
+    // trail), and listEligible still excludes it.
+    await processRedemption8K({
+      cik: 53,
+      accession_number: "0000000000-26-RES001",
+      filing_date: "2026-03-20",
+      form: "8-K",
+      itemCodes: ["5.07"],
+      fullSubmissionText: partialTxt,
+      model: fakeS1Model(),
+    });
+
+    entry = await dlRepo.get("redemption", "0000000000-26-RES001", sectionKey);
+    expect(entry?.status).toBe("resolved");
+    expect(entry?.attempts).toBe(2);
+    eligible = await dlRepo.listEligible("redemption", currentVersion);
+    expect(
+      eligible.filter((e) => e.section_name === sectionKey && e.accession_number === "0000000000-26-RES001")
+    ).toHaveLength(0);
   });
 
   it("extracts successfully with a moderately large EX-99 (~150 KB)", async () => {

--- a/src/sec/forms/miscellaneous-filings/redemption8k.ts
+++ b/src/sec/forms/miscellaneous-filings/redemption8k.ts
@@ -200,16 +200,21 @@ export async function processRedemption8K(args: ProcessRedemption8KArgs): Promis
   // Partial-drop: at least one exhibit was skipped but a non-empty survivor set
   // ran through extraction. Record an informational dead-letter so operators
   // can triage filings whose largest exhibit was dropped (mirrors the
-  // "<section>-partial" pattern in sectionRunner.ts).
+  // "<section>-partial" pattern in sectionRunner.ts), then immediately mark
+  // it resolved: this is informational, auto-resolved (no retry recovers a
+  // deterministic-cap drop); the attempts counter preserves the audit trail
+  // across replays.
   if (dropped > 0 && !totalDropped) {
+    const partialSection = `${REDEMPTION_SECTION}-partial-oversized`;
     await deadLetters.record({
       extractor_id: EXTRACTOR_ID,
       accession_number,
-      section_name: `${REDEMPTION_SECTION}-partial-oversized`,
+      section_name: partialSection,
       reason_code: "OVERSIZED_INPUT",
       detail: `dropped ${dropped} exhibit(s) over ${MAX_PER_EXHIBIT_CHARS} char cap (chars=${droppedChars})`,
       failed_extractor_version: extractor_version,
       source_run_id: null,
     });
+    await deadLetters.markResolved(EXTRACTOR_ID, accession_number, partialSection);
   }
 }

--- a/src/storage/spac/SpacWriteLock.test.ts
+++ b/src/storage/spac/SpacWriteLock.test.ts
@@ -4,9 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { globalServiceRegistry, Sqlite } from "workglow";
+import { DefaultDI } from "../../config/DefaultDI";
 import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
 import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
+import { closeDb } from "../../util/db";
 import { SpacRepo } from "./SpacRepo";
 import { SpacReportWriter } from "./SpacReportWriter";
 import { withSpacCikLock } from "./SpacWriteLock";
@@ -64,6 +71,66 @@ describe("withSpacCikLock", () => {
     ]);
 
     expect(bothInFlightAtSomePoint).toBe(true);
+  });
+
+  it("five parallel writers across distinct CIKs serialize on the singleton SQLite conn", async () => {
+    // The SQLite branch issues `BEGIN IMMEDIATE` on the shared
+    // `better-sqlite3` connection. Without the process-wide gate added by
+    // SQLITE_GLOBAL_LOCK_KEY, distinct-CIK writers that race past the
+    // per-CIK in-memory mutex would all hit BEGIN on the same conn and
+    // throw "cannot start a transaction within a transaction".
+    closeDb();
+    resetDependencyInjectionsForTesting();
+    if (typeof Sqlite.init === "function") {
+      await Sqlite.init();
+    }
+    const tmpDir = mkdtempSync(join(tmpdir(), "sec-spac-lock-sqlite-"));
+    try {
+      globalServiceRegistry.registerInstance(SEC_DB_TYPE, "sqlite");
+      globalServiceRegistry.registerInstance(SEC_DB_FOLDER, tmpDir);
+      globalServiceRegistry.registerInstance(SEC_DB_NAME, "spac_lock_sqlite");
+      DefaultDI();
+      await setupAllDatabases();
+
+      const repo = new SpacRepo();
+      const writer = new SpacReportWriter(repo);
+      const ciks = [100, 200, 300, 400, 500];
+
+      // Capture any rejection — the regression we're guarding against shows
+      // up as a "transaction within a transaction" throw from better-sqlite3.
+      const results = await Promise.allSettled(
+        ciks.map((cik) =>
+          writer.recordRegistration({
+            cik,
+            accession_number: `${cik}-reg`,
+            filing_date: "2026-01-01",
+            form: "S-1",
+            primary_document: "s1.htm",
+            spac_name: `SPAC ${cik}`,
+            spac_sic: 6770,
+          })
+        )
+      );
+
+      const rejections = results.filter((r) => r.status === "rejected");
+      // Surface the actual error texts for easier triage if this regresses.
+      const errors = rejections.map((r) =>
+        String((r as PromiseRejectedResult).reason?.message ?? r)
+      );
+      expect(errors).toEqual([]);
+      expect(
+        errors.some((e) => /transaction within a transaction/i.test(e))
+      ).toBe(false);
+      expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+    } finally {
+      closeDb();
+      rmSync(tmpDir, { recursive: true, force: true });
+      globalServiceRegistry.registerInstance(
+        SEC_DB_TYPE,
+        "memory" as unknown as "sqlite" | "postgres"
+      );
+      resetDependencyInjectionsForTesting();
+    }
   });
 
   it("three parallel SpacReportWriter rebuilds on the same CIK leave exactly one open history row", async () => {

--- a/src/storage/spac/SpacWriteLock.ts
+++ b/src/storage/spac/SpacWriteLock.ts
@@ -45,6 +45,15 @@ async function withInProcessLock<T>(cik: number, fn: () => Promise<T>): Promise<
 }
 
 /**
+ * Sentinel key for the process-wide SQLite serialization gate. All SPAC
+ * writes share this slot regardless of CIK because `getDb()` returns the
+ * singleton `better-sqlite3` connection — nesting a second `BEGIN IMMEDIATE`
+ * on the same conn throws "cannot start a transaction within a transaction",
+ * so even distinct-CIK writers have to queue at the connection.
+ */
+const SQLITE_GLOBAL_LOCK_KEY = 0;
+
+/**
  * Run `fn` while holding a per-CIK write lock so that the
  * `getSpac → buildSpacRow → saveSpac` + history snapshot critical section in
  * `SpacReportWriter.rebuild` is serialized across concurrent writers.
@@ -52,7 +61,11 @@ async function withInProcessLock<T>(cik: number, fn: () => Promise<T>): Promise<
  * Dispatch mirrors `cikNameBulkWriter`:
  *   - SQLite (`SEC_DB_TYPE=sqlite`): raw `BEGIN IMMEDIATE`/`COMMIT` on the
  *     shared connection. SQLite is single-writer, so this also serializes
- *     against any other writer holding the database lock.
+ *     against any other writer holding the database lock. The branch is
+ *     gated by a process-wide mutex (`SQLITE_GLOBAL_LOCK_KEY`) because the
+ *     singleton `better-sqlite3` connection cannot nest a second
+ *     `BEGIN IMMEDIATE` — distinct CIKs concurrently entering this branch
+ *     would otherwise throw "cannot start a transaction within a transaction".
  *   - Postgres (`SEC_DB_TYPE=postgres`): per-transaction advisory lock keyed
  *     on (`PG_ADVISORY_LOCK_NAMESPACE_SPAC`, `cik`).
  *   - Anything else (in-memory tests / unregistered): per-process keyed
@@ -86,20 +99,22 @@ export async function withSpacCikLock<T>(
     globalServiceRegistry.has(SEC_DB_FOLDER) &&
     globalServiceRegistry.has(SEC_DB_NAME)
   ) {
-    const db = getDb();
-    db.exec("BEGIN IMMEDIATE");
-    try {
-      const result = await fn();
-      db.exec("COMMIT");
-      return result;
-    } catch (err) {
+    return withInProcessLock(SQLITE_GLOBAL_LOCK_KEY, async () => {
+      const db = getDb();
+      db.exec("BEGIN IMMEDIATE");
       try {
-        db.exec("ROLLBACK");
-      } catch {
-        // ignore — the original error is what callers care about
+        const result = await fn();
+        db.exec("COMMIT");
+        return result;
+      } catch (err) {
+        try {
+          db.exec("ROLLBACK");
+        } catch {
+          // ignore — the original error is what callers care about
+        }
+        throw err;
       }
-      throw err;
-    }
+    });
   }
 
   if (isPostgresBacked && dbType === "postgres") {


### PR DESCRIPTION
Two follow-ups on PR #170.

## Fix 1 (CRITICAL): SQLite `withSpacCikLock` singleton-connection crash

The SQLite branch in `withSpacCikLock` issues `BEGIN IMMEDIATE` on the singleton `better-sqlite3` connection returned by `getDb()`. The existing per-CIK keyed mutex (`withInProcessLock`) only serializes writers on the **same** CIK — distinct CIKs race past the mutex and hit BEGIN concurrently, and SQLite throws `"cannot start a transaction within a transaction"`.

Wrapping the SQLite branch body in a process-wide gate keyed by a sentinel value (`SQLITE_GLOBAL_LOCK_KEY = 0`) forces every SPAC writer to queue at the connection regardless of CIK. The connection-level SQLite database lock is single-writer anyway, so this matches the backend's actual concurrency model. Postgres + in-memory fallback are unchanged.

New test: five parallel `recordRegistration` calls across CIKs `[100, 200, 300, 400, 500]` under a real SQLite backend all resolve fulfilled, with zero throws containing `"transaction within a transaction"`. Reverting only the wrap causes the second concurrent BEGIN to throw — the fix is essential.

## Fix 2 (HIGH): auto-resolve the `redemption-partial-oversized` dead-letter

`processRedemption8K` records a `redemption-partial-oversized` entry whenever at least one exhibit was dropped over the per-exhibit cap but a non-empty survivor set still ran through extraction. The entry is purely informational — the drop is deterministic (the cap doesn't move between runs) so **no retry recovers the dropped exhibit**, and yet today the entry sits in `pending` forever, polluting `sec extractor dead-letters redemption` with rows no version bump can clear.

Adding `markResolved` immediately after `record` lands the entry in `resolved` so `listEligible` / `listPending` exclude it. The `attempts` counter still increments on each replay (audit trail intact), so operators retain visibility into how often the cap fired for a given accession.

## Test plan

- [x] `bun test src/storage/spac/` — 49 tests across 10 files, 0 fail (new SQLite parallel-writer test included).
- [x] `bun test src/sec/forms/miscellaneous-filings/` — 49 tests across 4 files, 0 fail (existing partial-oversized test extended + a new dual-run idempotency test).
- [x] `bun run build` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERWJJbFgDbPokzJCBsFMdE)_