### PR TITLE
fix(xbrl): XbrlFactRepo.replaceForAccession no-ops on 0 rows unless intentionalClear

### DIFF
--- a/src/storage/xbrl/XbrlFactRepo.test.ts
+++ b/src/storage/xbrl/XbrlFactRepo.test.ts
@@ -96,6 +96,74 @@ describe("XbrlFactRepo", () => {
     expect(await new XbrlFactRepo().countByAccession(ACCESSION)).toBe(2);
   });
 
+  it("no-ops (does not delete) when passed 0 rows without intentionalClear", async () => {
+    const repo = new XbrlFactRepo();
+    await repo.replaceForAccession(ACCESSION, rowsFromInline());
+    expect(await repo.countByAccession(ACCESSION)).toBe(2);
+
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (msg: unknown) => {
+      warnings.push(String(msg));
+    };
+    try {
+      await repo.replaceForAccession(ACCESSION, []);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(await repo.countByAccession(ACCESSION)).toBe(2);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(ACCESSION);
+    expect(warnings[0]).toContain("intentionalClear");
+  });
+
+  it("clears prior facts when passed 0 rows with intentionalClear: true", async () => {
+    const repo = new XbrlFactRepo();
+    await repo.replaceForAccession(ACCESSION, rowsFromInline());
+    expect(await repo.countByAccession(ACCESSION)).toBe(2);
+
+    await repo.replaceForAccession(ACCESSION, [], { intentionalClear: true });
+    expect(await repo.countByAccession(ACCESSION)).toBe(0);
+  });
+
+  it("replaces prior facts on non-empty input", async () => {
+    const repo = new XbrlFactRepo();
+    const original = rowsFromInline();
+    await repo.replaceForAccession(ACCESSION, original);
+    expect(await repo.countByAccession(ACCESSION)).toBe(2);
+
+    const replacement: XbrlFactRow[] = [
+      { ...original[0], fact_index: 10, concept: "dei:DocumentType", value_text: "S-1" },
+      {
+        ...original[1],
+        fact_index: 11,
+        concept: "spac:PublicUnitsOfferedGross",
+        value_numeric: 25000000,
+      },
+    ];
+    await repo.replaceForAccession(ACCESSION, replacement);
+
+    const rows = await repo.getByAccession(ACCESSION);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.fact_index).sort((a, b) => a - b)).toEqual([10, 11]);
+  });
+
+  it("clearForAccession removes all facts for accession", async () => {
+    const repo = new XbrlFactRepo();
+    const otherAcc = "0001213900-26-047229";
+
+    await repo.replaceForAccession(ACCESSION, rowsFromInline());
+    const other = rowsFromInline().map((r) => ({ ...r, accession_number: otherAcc }));
+    await repo.replaceForAccession(otherAcc, other);
+    expect(await repo.countByAccession(ACCESSION)).toBe(2);
+    expect(await repo.countByAccession(otherAcc)).toBe(2);
+
+    await repo.clearForAccession(ACCESSION);
+    expect(await repo.countByAccession(ACCESSION)).toBe(0);
+    expect(await repo.countByAccession(otherAcc)).toBe(2);
+  });
+
   it("queries one concept across an issuer's filings", async () => {
     const repo = new XbrlFactRepo();
     await repo.replaceForAccession(ACCESSION, rowsFromInline());

--- a/src/storage/xbrl/XbrlFactRepo.ts
+++ b/src/storage/xbrl/XbrlFactRepo.ts
@@ -33,8 +33,23 @@ export class XbrlFactRepo {
    * abstraction exposes none), so the worst residual case — a failure during the
    * stale-tail delete — leaves a superset of facts, which the next re-extract
    * cleans up, rather than data loss.
+   *
+   * A 0-row input is refused by default: a parser regression, disabled XBRL,
+   * or a degrade path returning `[]` would otherwise wipe every prior fact for
+   * the filing. Callers that genuinely want to purge (an operator forcing a
+   * reset) pass `intentionalClear: true`, or call {@link clearForAccession}.
    */
-  async replaceForAccession(accession_number: string, rows: readonly XbrlFactRow[]): Promise<void> {
+  async replaceForAccession(
+    accession_number: string,
+    rows: readonly XbrlFactRow[],
+    opts: { readonly intentionalClear?: boolean } = {}
+  ): Promise<void> {
+    if (rows.length === 0 && !opts.intentionalClear) {
+      console.warn(
+        `XbrlFactRepo.replaceForAccession: 0 rows for ${accession_number} without intentionalClear — no-op`
+      );
+      return;
+    }
     if (rows.length > 0) await this.storage.putBulk([...rows]);
     const keep = new Set(rows.map((r) => r.fact_index));
     const existing = (await this.storage.query({ accession_number })) ?? [];
@@ -42,6 +57,17 @@ export class XbrlFactRepo {
       if (!keep.has(r.fact_index)) {
         await this.storage.delete({ accession_number, fact_index: r.fact_index });
       }
+    }
+  }
+
+  /**
+   * Unconditionally deletes every fact for the given accession. The explicit
+   * purge path — use when an operator is intentionally resetting a filing.
+   */
+  async clearForAccession(accession_number: string): Promise<void> {
+    const existing = (await this.storage.query({ accession_number })) ?? [];
+    for (const r of existing) {
+      await this.storage.delete({ accession_number, fact_index: r.fact_index });
     }
   }
 


### PR DESCRIPTION
## Summary

`XbrlFactRepo.replaceForAccession` deletes any prior fact for the accession whose `fact_index` is not in the incoming set. When the incoming set is empty, that means *every* prior fact — a legitimate re-extract that yields 0 facts (parser regression, XBRL disabled, or a degrade path returning `[]`) silently wipes the filing.

The sole production caller (`src/sec/forms/registration-statements/s1/xbrlEnrichment.ts`) early-returns `NO_XBRL` before touching the repo, so the wipe is not currently reachable in prod — but the invariant lives in the caller instead of the repo, and one refactor away from re-appearing.

## Fix

Move the invariant into the repo:

- `replaceForAccession(accession_number, rows, opts?)` — refuses a 0-row input with `console.warn` and returns. Callers that genuinely want to purge (an operator forcing a reset) pass `{ intentionalClear: true }`.
- `clearForAccession(accession_number)` — new explicit purge path.

Existing call sites all pass non-empty rows and need no changes; behavior is unchanged for them.

## Tests

Added to `src/storage/xbrl/XbrlFactRepo.test.ts`:

- no-ops (does not delete) when passed 0 rows without `intentionalClear` (spies `console.warn`, seeds 2 facts, asserts 2 remain).
- clears prior facts when passed 0 rows with `intentionalClear: true`.
- replaces prior facts on non-empty input (seeds 2, replaces with 2 different rows, asserts final state).
- `clearForAccession` removes all facts for the target accession only.

## Test plan

- [x] `bun test src/storage/xbrl/` — 8 pass (4 new + 4 existing)
- [x] `bun test src/sec/forms/registration-statements/s1/` — 72 pass
- [x] `bun test src/cli/queries/XbrlQuery.test.ts` — 5 pass
- [x] `npx tsc --noEmit` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01J7p61MWFSPiokZHPKNaNEj)_