### PR TITLE
fix(canonical): serialize junction observation_count with KeyedMutex + add removeObservation

### DIFF
--- a/src/resolver/EntityObserver.concurrency.test.ts
+++ b/src/resolver/EntityObserver.concurrency.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @copyright
+ * Copyright 2026 Steven Roussey
+ * All Rights Reserved
+ */
+
+import { describe, expect, it, beforeEach } from "bun:test";
+import { InMemoryTabularStorage } from "workglow";
+import { EntityObserver, type PersonClaim } from "./EntityObserver";
+import { PersonObservationRepo } from "../storage/observation/PersonObservationRepo";
+import {
+  PersonObservationSchema,
+  PersonObservationPrimaryKeyNames,
+  type PersonObservation,
+} from "../storage/observation/PersonObservationSchema";
+import { CanonicalPersonRepo } from "../storage/canonical/CanonicalPersonRepo";
+import {
+  CanonicalPersonSchema,
+  CanonicalPersonPrimaryKeyNames,
+  type CanonicalPerson,
+} from "../storage/canonical/CanonicalPersonSchema";
+import { CanonicalPersonAliasRepo } from "../storage/canonical/CanonicalPersonAliasRepo";
+import {
+  CanonicalPersonAliasSchema,
+  CanonicalPersonAliasPrimaryKeyNames,
+  type CanonicalPersonAlias,
+} from "../storage/canonical/CanonicalAliasSchemas";
+import { PersonIdentityLinkRepo } from "../storage/canonical/PersonIdentityLinkRepo";
+import {
+  PersonIdentityLinkSchema,
+  PersonIdentityLinkPrimaryKeyNames,
+  type PersonIdentityLink,
+} from "../storage/canonical/PersonIdentityLinkSchema";
+import { CanonicalPersonAddressRepo } from "../storage/canonical/CanonicalPersonAddressRepo";
+import {
+  CanonicalPersonAddressSchema,
+  CanonicalPersonAddressPrimaryKeyNames,
+  type CanonicalPersonAddress,
+} from "../storage/canonical/CanonicalJunctionSchemas";
+import { PersonResolver } from "./PersonResolver";
+
+function makePersonRepos() {
+  const personObsStorage = new InMemoryTabularStorage<
+    typeof PersonObservationSchema,
+    typeof PersonObservationPrimaryKeyNames,
+    PersonObservation
+  >(PersonObservationSchema, PersonObservationPrimaryKeyNames, [
+    ["accession_number", "extractor_id", "observation_index"],
+  ]);
+  const canonStorage = new InMemoryTabularStorage<
+    typeof CanonicalPersonSchema,
+    typeof CanonicalPersonPrimaryKeyNames,
+    CanonicalPerson
+  >(CanonicalPersonSchema, CanonicalPersonPrimaryKeyNames, [
+    ["resolver_version", "cik"],
+    ["resolver_version", "normalized_last"],
+  ]);
+  const aliasStorage = new InMemoryTabularStorage<
+    typeof CanonicalPersonAliasSchema,
+    typeof CanonicalPersonAliasPrimaryKeyNames,
+    CanonicalPersonAlias
+  >(CanonicalPersonAliasSchema, CanonicalPersonAliasPrimaryKeyNames, []);
+  const identityLinkStorage = new InMemoryTabularStorage<
+    typeof PersonIdentityLinkSchema,
+    typeof PersonIdentityLinkPrimaryKeyNames,
+    PersonIdentityLink
+  >(PersonIdentityLinkSchema, PersonIdentityLinkPrimaryKeyNames, []);
+  const addressJunctionStorage = new InMemoryTabularStorage<
+    typeof CanonicalPersonAddressSchema,
+    typeof CanonicalPersonAddressPrimaryKeyNames,
+    CanonicalPersonAddress
+  >(CanonicalPersonAddressSchema, CanonicalPersonAddressPrimaryKeyNames, []);
+
+  const personObsRepo = new PersonObservationRepo({
+    personObservationRepository: personObsStorage,
+  });
+  const canonRepo = new CanonicalPersonRepo({ canonicalPersonRepository: canonStorage });
+  const aliasRepo = new CanonicalPersonAliasRepo({
+    canonicalPersonAliasRepository: aliasStorage,
+  });
+  const identityLinkRepo = new PersonIdentityLinkRepo({
+    personIdentityLinkRepository: identityLinkStorage,
+  });
+  const addressRepo = new CanonicalPersonAddressRepo({
+    canonicalPersonAddressRepository: addressJunctionStorage,
+  });
+  const resolver = new PersonResolver({
+    canonicalPersonRepo: canonRepo,
+    canonicalPersonAliasRepo: aliasRepo,
+    activeResolverVersion: "1.0.0",
+  });
+
+  return {
+    personObsRepo,
+    identityLinkRepo,
+    addressRepo,
+    addressJunctionStorage,
+    resolver,
+  };
+}
+
+describe("EntityObserver concurrency", () => {
+  let setup: ReturnType<typeof makePersonRepos>;
+  let observer: EntityObserver;
+
+  beforeEach(() => {
+    setup = makePersonRepos();
+    observer = new EntityObserver({
+      personObservationRepo: setup.personObsRepo,
+      companyObservationRepo: undefined as any,
+      personIdentityLinkRepo: setup.identityLinkRepo,
+      companyIdentityLinkRepo: undefined as any,
+      personResolver: setup.resolver,
+      companyResolver: undefined as any,
+      canonicalPersonAddressRepo: setup.addressRepo,
+      canonicalPersonPhoneRepo: undefined as any,
+      canonicalCompanyAddressRepo: undefined as any,
+      canonicalCompanyPhoneRepo: undefined as any,
+      activeResolverPersonVersion: "1.0.0",
+      activeResolverCompanyVersion: "1.0.0",
+    });
+  });
+
+  it("two concurrent observePerson calls for the same canonical + same address produce observation_count === 2", async () => {
+    // Two claims for the same CIK -> same canonical person, at distinct
+    // observation indices (distinct observation rows) but the same address.
+    const base: Omit<PersonClaim, "observation_index"> = {
+      accession_number: "0001-25-000001",
+      extractor_id: "D",
+      extractor_version: "1.0.0",
+      cik: 1234,
+      first_name: "Jane",
+      last_name: "Smith",
+      address_id: "addr-hash-abc123",
+    };
+    const [a, b] = await Promise.all([
+      observer.observePerson({ ...base, observation_index: 0 }),
+      observer.observePerson({ ...base, observation_index: 1 }),
+    ]);
+    expect(a.canonical_person_id).toBe(b.canonical_person_id);
+
+    const addresses = await setup.addressRepo.listForCanonical(a.canonical_person_id, "1.0.0");
+    expect(addresses).toHaveLength(1);
+    expect(addresses[0].observation_count).toBe(2);
+  });
+});

--- a/src/storage/canonical/CanonicalCompanyAddressRepo.concurrency.test.ts
+++ b/src/storage/canonical/CanonicalCompanyAddressRepo.concurrency.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @copyright
+ * Copyright 2026 Steven Roussey
+ * All Rights Reserved
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryTabularStorage } from "workglow";
+import { CanonicalCompanyAddressRepo } from "./CanonicalCompanyAddressRepo";
+import {
+  CanonicalCompanyAddressPrimaryKeyNames,
+  CanonicalCompanyAddressSchema,
+  type CanonicalCompanyAddress,
+} from "./CanonicalJunctionSchemas";
+
+function makeStorage() {
+  return new InMemoryTabularStorage<
+    typeof CanonicalCompanyAddressSchema,
+    typeof CanonicalCompanyAddressPrimaryKeyNames,
+    CanonicalCompanyAddress
+  >(CanonicalCompanyAddressSchema, CanonicalCompanyAddressPrimaryKeyNames, [
+    ["canonical_company_id", "resolver_version"],
+    ["resolver_version"],
+  ]);
+}
+
+describe("CanonicalCompanyAddressRepo concurrency", () => {
+  let storage: ReturnType<typeof makeStorage>;
+  let repo: CanonicalCompanyAddressRepo;
+
+  beforeEach(() => {
+    storage = makeStorage();
+    repo = new CanonicalCompanyAddressRepo({ canonicalCompanyAddressRepository: storage });
+  });
+
+  it("keeps observation_count consistent under 100 concurrent recordObservation calls for the same PK", async () => {
+    const pk = {
+      canonical_company_id: "uuid-1",
+      address_hash_id: "addr-x",
+      resolver_version: "1.0.0",
+    };
+    await Promise.all(
+      Array.from({ length: 100 }, () =>
+        repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" })
+      )
+    );
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(100);
+  });
+
+  it("keeps observation_count consistent under mixed record+remove concurrent calls", async () => {
+    const pk = {
+      canonical_company_id: "uuid-1",
+      address_hash_id: "addr-x",
+      resolver_version: "1.0.0",
+    };
+    for (let i = 0; i < 50; i++) {
+      await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    }
+    const ops: Array<Promise<unknown>> = [];
+    for (let i = 0; i < 50; i++) {
+      ops.push(repo.recordObservation({ ...pk, seen_at: "2026-01-02T00:00:00.000Z" }));
+      ops.push(repo.removeObservation(pk));
+    }
+    await Promise.all(ops);
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(50);
+  });
+
+  it("does not serialize different PKs", async () => {
+    const N = 8;
+    let entered = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const originalPut = storage.put.bind(storage);
+    storage.put = async (row: CanonicalCompanyAddress) => {
+      entered++;
+      if (entered === N) release();
+      await gate;
+      return originalPut(row);
+    };
+    const results = Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        repo.recordObservation({
+          canonical_company_id: `uuid-${i}`,
+          address_hash_id: "addr-x",
+          resolver_version: "1.0.0",
+          seen_at: "2026-01-01T00:00:00.000Z",
+        })
+      )
+    );
+    const deadline = Date.now() + 1000;
+    while (entered < N && Date.now() < deadline) {
+      await new Promise((r) => setImmediate(r));
+    }
+    expect(entered).toBe(N);
+    await results;
+  });
+});

--- a/src/storage/canonical/CanonicalCompanyAddressRepo.removeObservation.test.ts
+++ b/src/storage/canonical/CanonicalCompanyAddressRepo.removeObservation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @copyright
+ * Copyright 2026 Steven Roussey
+ * All Rights Reserved
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryTabularStorage } from "workglow";
+import { CanonicalCompanyAddressRepo } from "./CanonicalCompanyAddressRepo";
+import {
+  CanonicalCompanyAddressPrimaryKeyNames,
+  CanonicalCompanyAddressSchema,
+  type CanonicalCompanyAddress,
+} from "./CanonicalJunctionSchemas";
+
+describe("CanonicalCompanyAddressRepo.removeObservation", () => {
+  let storage: InMemoryTabularStorage<
+    typeof CanonicalCompanyAddressSchema,
+    typeof CanonicalCompanyAddressPrimaryKeyNames,
+    CanonicalCompanyAddress
+  >;
+  let repo: CanonicalCompanyAddressRepo;
+  const pk = {
+    canonical_company_id: "uuid-1",
+    address_hash_id: "addr-x",
+    resolver_version: "1.0.0",
+  };
+
+  beforeEach(() => {
+    storage = new InMemoryTabularStorage<
+      typeof CanonicalCompanyAddressSchema,
+      typeof CanonicalCompanyAddressPrimaryKeyNames,
+      CanonicalCompanyAddress
+    >(CanonicalCompanyAddressSchema, CanonicalCompanyAddressPrimaryKeyNames, [
+      ["canonical_company_id", "resolver_version"],
+      ["resolver_version"],
+    ]);
+    repo = new CanonicalCompanyAddressRepo({ canonicalCompanyAddressRepository: storage });
+  });
+
+  it("decrements observation_count when > 1", async () => {
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-02T00:00:00.000Z" });
+    await repo.removeObservation(pk);
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(1);
+  });
+
+  it("deletes the row when observation_count === 1", async () => {
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    await repo.removeObservation(pk);
+    const row = await storage.get(pk);
+    expect(row).toBeUndefined();
+  });
+
+  it("is a no-op when the row does not exist", async () => {
+    await expect(repo.removeObservation(pk)).resolves.toBeUndefined();
+    const row = await storage.get(pk);
+    expect(row).toBeUndefined();
+  });
+});

--- a/src/storage/canonical/CanonicalCompanyAddressRepo.ts
+++ b/src/storage/canonical/CanonicalCompanyAddressRepo.ts
@@ -5,6 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
+import { KeyedMutex } from "../../util/KeyedMutex";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
   type CanonicalCompanyAddress,
@@ -22,6 +23,17 @@ interface RecordCompanyAddressArgs {
   seen_at: string;
 }
 
+/** Per-composite-PK read-modify-write lock for `observation_count`; see CanonicalPersonAddressRepo. */
+const junctionLocks = new KeyedMutex<string>();
+
+function junctionKey(pk: {
+  canonical_company_id: string;
+  address_hash_id: string;
+  resolver_version: string;
+}): string {
+  return `${pk.canonical_company_id}\x00${pk.address_hash_id}\x00${pk.resolver_version}`;
+}
+
 export class CanonicalCompanyAddressRepo {
   private repo: CanonicalCompanyAddressRepositoryStorage;
 
@@ -37,24 +49,26 @@ export class CanonicalCompanyAddressRepo {
       address_hash_id: args.address_hash_id,
       resolver_version: args.resolver_version,
     };
-    const existing = await this.repo.get(pk);
-    if (existing) {
-      const updated: CanonicalCompanyAddress = {
-        ...existing,
-        observation_count: existing.observation_count + 1,
+    return junctionLocks.lock(junctionKey(pk), async () => {
+      const existing = await this.repo.get(pk);
+      if (existing) {
+        const updated: CanonicalCompanyAddress = {
+          ...existing,
+          observation_count: existing.observation_count + 1,
+          last_seen_at: args.seen_at,
+        };
+        await this.repo.put(updated);
+        return updated;
+      }
+      const fresh: CanonicalCompanyAddress = {
+        ...pk,
+        observation_count: 1,
+        first_seen_at: args.seen_at,
         last_seen_at: args.seen_at,
       };
-      await this.repo.put(updated);
-      return updated;
-    }
-    const fresh: CanonicalCompanyAddress = {
-      ...pk,
-      observation_count: 1,
-      first_seen_at: args.seen_at,
-      last_seen_at: args.seen_at,
-    };
-    await this.repo.put(fresh);
-    return fresh;
+      await this.repo.put(fresh);
+      return fresh;
+    });
   }
 
   /** Remove one observation's contribution; see CanonicalPersonAddressRepo.removeObservation. */
@@ -63,13 +77,15 @@ export class CanonicalCompanyAddressRepo {
     address_hash_id: string;
     resolver_version: string;
   }): Promise<void> {
-    const existing = await this.repo.get(pk);
-    if (!existing) return;
-    if (existing.observation_count <= 1) {
-      await this.repo.delete(pk);
-      return;
-    }
-    await this.repo.put({ ...existing, observation_count: existing.observation_count - 1 });
+    await junctionLocks.lock(junctionKey(pk), async () => {
+      const existing = await this.repo.get(pk);
+      if (!existing) return;
+      if (existing.observation_count <= 1) {
+        await this.repo.delete(pk);
+        return;
+      }
+      await this.repo.put({ ...existing, observation_count: existing.observation_count - 1 });
+    });
   }
 
   async listForCanonical(

--- a/src/storage/canonical/CanonicalCompanyPhoneRepo.concurrency.test.ts
+++ b/src/storage/canonical/CanonicalCompanyPhoneRepo.concurrency.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @copyright
+ * Copyright 2026 Steven Roussey
+ * All Rights Reserved
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryTabularStorage } from "workglow";
+import { CanonicalCompanyPhoneRepo } from "./CanonicalCompanyPhoneRepo";
+import {
+  CanonicalCompanyPhonePrimaryKeyNames,
+  CanonicalCompanyPhoneSchema,
+  type CanonicalCompanyPhone,
+} from "./CanonicalJunctionSchemas";
+
+function makeStorage() {
+  return new InMemoryTabularStorage<
+    typeof CanonicalCompanyPhoneSchema,
+    typeof CanonicalCompanyPhonePrimaryKeyNames,
+    CanonicalCompanyPhone
+  >(CanonicalCompanyPhoneSchema, CanonicalCompanyPhonePrimaryKeyNames, [
+    ["canonical_company_id", "resolver_version"],
+    ["resolver_version"],
+  ]);
+}
+
+describe("CanonicalCompanyPhoneRepo concurrency", () => {
+  let storage: ReturnType<typeof makeStorage>;
+  let repo: CanonicalCompanyPhoneRepo;
+
+  beforeEach(() => {
+    storage = makeStorage();
+    repo = new CanonicalCompanyPhoneRepo({ canonicalCompanyPhoneRepository: storage });
+  });
+
+  it("keeps observation_count consistent under 100 concurrent recordObservation calls for the same PK", async () => {
+    const pk = {
+      canonical_company_id: "uuid-1",
+      international_number: "+14155551234",
+      resolver_version: "1.0.0",
+    };
+    await Promise.all(
+      Array.from({ length: 100 }, () =>
+        repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" })
+      )
+    );
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(100);
+  });
+
+  it("keeps observation_count consistent under mixed record+remove concurrent calls", async () => {
+    const pk = {
+      canonical_company_id: "uuid-1",
+      international_number: "+14155551234",
+      resolver_version: "1.0.0",
+    };
+    for (let i = 0; i < 50; i++) {
+      await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    }
+    const ops: Array<Promise<unknown>> = [];
+    for (let i = 0; i < 50; i++) {
+      ops.push(repo.recordObservation({ ...pk, seen_at: "2026-01-02T00:00:00.000Z" }));
+      ops.push(repo.removeObservation(pk));
+    }
+    await Promise.all(ops);
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(50);
+  });
+
+  it("does not serialize different PKs", async () => {
+    const N = 8;
+    let entered = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const originalPut = storage.put.bind(storage);
+    storage.put = async (row: CanonicalCompanyPhone) => {
+      entered++;
+      if (entered === N) release();
+      await gate;
+      return originalPut(row);
+    };
+    const results = Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        repo.recordObservation({
+          canonical_company_id: `uuid-${i}`,
+          international_number: "+14155551234",
+          resolver_version: "1.0.0",
+          seen_at: "2026-01-01T00:00:00.000Z",
+        })
+      )
+    );
+    const deadline = Date.now() + 1000;
+    while (entered < N && Date.now() < deadline) {
+      await new Promise((r) => setImmediate(r));
+    }
+    expect(entered).toBe(N);
+    await results;
+  });
+});

--- a/src/storage/canonical/CanonicalCompanyPhoneRepo.removeObservation.test.ts
+++ b/src/storage/canonical/CanonicalCompanyPhoneRepo.removeObservation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @copyright
+ * Copyright 2026 Steven Roussey
+ * All Rights Reserved
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryTabularStorage } from "workglow";
+import { CanonicalCompanyPhoneRepo } from "./CanonicalCompanyPhoneRepo";
+import {
+  CanonicalCompanyPhonePrimaryKeyNames,
+  CanonicalCompanyPhoneSchema,
+  type CanonicalCompanyPhone,
+} from "./CanonicalJunctionSchemas";
+
+describe("CanonicalCompanyPhoneRepo.removeObservation", () => {
+  let storage: InMemoryTabularStorage<
+    typeof CanonicalCompanyPhoneSchema,
+    typeof CanonicalCompanyPhonePrimaryKeyNames,
+    CanonicalCompanyPhone
+  >;
+  let repo: CanonicalCompanyPhoneRepo;
+  const pk = {
+    canonical_company_id: "uuid-1",
+    international_number: "+14155551234",
+    resolver_version: "1.0.0",
+  };
+
+  beforeEach(() => {
+    storage = new InMemoryTabularStorage<
+      typeof CanonicalCompanyPhoneSchema,
+      typeof CanonicalCompanyPhonePrimaryKeyNames,
+      CanonicalCompanyPhone
+    >(CanonicalCompanyPhoneSchema, CanonicalCompanyPhonePrimaryKeyNames, [
+      ["canonical_company_id", "resolver_version"],
+      ["resolver_version"],
+    ]);
+    repo = new CanonicalCompanyPhoneRepo({ canonicalCompanyPhoneRepository: storage });
+  });
+
+  it("decrements observation_count when > 1", async () => {
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-02T00:00:00.000Z" });
+    await repo.removeObservation(pk);
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(1);
+  });
+
+  it("deletes the row when observation_count === 1", async () => {
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    await repo.removeObservation(pk);
+    const row = await storage.get(pk);
+    expect(row).toBeUndefined();
+  });
+
+  it("is a no-op when the row does not exist", async () => {
+    await expect(repo.removeObservation(pk)).resolves.toBeUndefined();
+    const row = await storage.get(pk);
+    expect(row).toBeUndefined();
+  });
+});

--- a/src/storage/canonical/CanonicalCompanyPhoneRepo.ts
+++ b/src/storage/canonical/CanonicalCompanyPhoneRepo.ts
@@ -5,6 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
+import { KeyedMutex } from "../../util/KeyedMutex";
 import {
   CANONICAL_COMPANY_PHONE_REPOSITORY_TOKEN,
   type CanonicalCompanyPhone,
@@ -22,6 +23,17 @@ interface RecordCompanyPhoneArgs {
   seen_at: string;
 }
 
+/** Per-composite-PK read-modify-write lock for `observation_count`; see CanonicalPersonAddressRepo. */
+const junctionLocks = new KeyedMutex<string>();
+
+function junctionKey(pk: {
+  canonical_company_id: string;
+  international_number: string;
+  resolver_version: string;
+}): string {
+  return `${pk.canonical_company_id}\x00${pk.international_number}\x00${pk.resolver_version}`;
+}
+
 export class CanonicalCompanyPhoneRepo {
   private repo: CanonicalCompanyPhoneRepositoryStorage;
 
@@ -37,24 +49,26 @@ export class CanonicalCompanyPhoneRepo {
       international_number: args.international_number,
       resolver_version: args.resolver_version,
     };
-    const existing = await this.repo.get(pk);
-    if (existing) {
-      const updated: CanonicalCompanyPhone = {
-        ...existing,
-        observation_count: existing.observation_count + 1,
+    return junctionLocks.lock(junctionKey(pk), async () => {
+      const existing = await this.repo.get(pk);
+      if (existing) {
+        const updated: CanonicalCompanyPhone = {
+          ...existing,
+          observation_count: existing.observation_count + 1,
+          last_seen_at: args.seen_at,
+        };
+        await this.repo.put(updated);
+        return updated;
+      }
+      const fresh: CanonicalCompanyPhone = {
+        ...pk,
+        observation_count: 1,
+        first_seen_at: args.seen_at,
         last_seen_at: args.seen_at,
       };
-      await this.repo.put(updated);
-      return updated;
-    }
-    const fresh: CanonicalCompanyPhone = {
-      ...pk,
-      observation_count: 1,
-      first_seen_at: args.seen_at,
-      last_seen_at: args.seen_at,
-    };
-    await this.repo.put(fresh);
-    return fresh;
+      await this.repo.put(fresh);
+      return fresh;
+    });
   }
 
   /** Remove one observation's contribution; see CanonicalPersonAddressRepo.removeObservation. */
@@ -63,13 +77,15 @@ export class CanonicalCompanyPhoneRepo {
     international_number: string;
     resolver_version: string;
   }): Promise<void> {
-    const existing = await this.repo.get(pk);
-    if (!existing) return;
-    if (existing.observation_count <= 1) {
-      await this.repo.delete(pk);
-      return;
-    }
-    await this.repo.put({ ...existing, observation_count: existing.observation_count - 1 });
+    await junctionLocks.lock(junctionKey(pk), async () => {
+      const existing = await this.repo.get(pk);
+      if (!existing) return;
+      if (existing.observation_count <= 1) {
+        await this.repo.delete(pk);
+        return;
+      }
+      await this.repo.put({ ...existing, observation_count: existing.observation_count - 1 });
+    });
   }
 
   async listForCanonical(

--- a/src/storage/canonical/CanonicalPersonAddressRepo.concurrency.test.ts
+++ b/src/storage/canonical/CanonicalPersonAddressRepo.concurrency.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @copyright
+ * Copyright 2026 Steven Roussey
+ * All Rights Reserved
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryTabularStorage } from "workglow";
+import { CanonicalPersonAddressRepo } from "./CanonicalPersonAddressRepo";
+import {
+  CanonicalPersonAddressPrimaryKeyNames,
+  CanonicalPersonAddressSchema,
+  type CanonicalPersonAddress,
+} from "./CanonicalJunctionSchemas";
+
+function makeStorage() {
+  return new InMemoryTabularStorage<
+    typeof CanonicalPersonAddressSchema,
+    typeof CanonicalPersonAddressPrimaryKeyNames,
+    CanonicalPersonAddress
+  >(CanonicalPersonAddressSchema, CanonicalPersonAddressPrimaryKeyNames, [
+    ["canonical_person_id", "resolver_version"],
+    ["resolver_version"],
+  ]);
+}
+
+describe("CanonicalPersonAddressRepo concurrency", () => {
+  let storage: ReturnType<typeof makeStorage>;
+  let repo: CanonicalPersonAddressRepo;
+
+  beforeEach(() => {
+    storage = makeStorage();
+    repo = new CanonicalPersonAddressRepo({ canonicalPersonAddressRepository: storage });
+  });
+
+  it("keeps observation_count consistent under 100 concurrent recordObservation calls for the same PK", async () => {
+    const pk = {
+      canonical_person_id: "uuid-1",
+      address_hash_id: "addr-x",
+      resolver_version: "1.0.0",
+    };
+    await Promise.all(
+      Array.from({ length: 100 }, (_, i) =>
+        repo.recordObservation({
+          ...pk,
+          seen_at: `2026-01-01T00:00:${String(i).padStart(2, "0")}.000Z`,
+        })
+      )
+    );
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(100);
+  });
+
+  it("keeps observation_count consistent under mixed record+remove concurrent calls", async () => {
+    const pk = {
+      canonical_person_id: "uuid-1",
+      address_hash_id: "addr-x",
+      resolver_version: "1.0.0",
+    };
+    // Seed to 50 so the 50 removes and 50 records net to a row of count 50.
+    for (let i = 0; i < 50; i++) {
+      await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    }
+    // Interleave 50 records + 50 removes concurrently.
+    const ops: Array<Promise<unknown>> = [];
+    for (let i = 0; i < 50; i++) {
+      ops.push(repo.recordObservation({ ...pk, seen_at: "2026-01-02T00:00:00.000Z" }));
+      ops.push(repo.removeObservation(pk));
+    }
+    await Promise.all(ops);
+    const row = await storage.get(pk);
+    // Net change: +50 -50 = 0; starting at 50 -> final 50.
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(50);
+  });
+
+  it("does not serialize different PKs", async () => {
+    // Distinct PKs must not block each other. Wrap storage.put with a barrier
+    // so all put calls stall until every one has arrived.
+    const N = 8;
+    let entered = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const originalPut = storage.put.bind(storage);
+    storage.put = async (row: CanonicalPersonAddress) => {
+      entered++;
+      if (entered === N) release();
+      await gate;
+      return originalPut(row);
+    };
+    const results = Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        repo.recordObservation({
+          canonical_person_id: `uuid-${i}`,
+          address_hash_id: "addr-x",
+          resolver_version: "1.0.0",
+          seen_at: "2026-01-01T00:00:00.000Z",
+        })
+      )
+    );
+    // If different PKs were serialized, only the first put would enter the barrier.
+    // Poll macrotasks until all concurrent puts arrive (or a reasonable timeout).
+    const deadline = Date.now() + 1000;
+    while (entered < N && Date.now() < deadline) {
+      await new Promise((r) => setImmediate(r));
+    }
+    expect(entered).toBe(N);
+    await results;
+  });
+});

--- a/src/storage/canonical/CanonicalPersonAddressRepo.removeObservation.test.ts
+++ b/src/storage/canonical/CanonicalPersonAddressRepo.removeObservation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @copyright
+ * Copyright 2026 Steven Roussey
+ * All Rights Reserved
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryTabularStorage } from "workglow";
+import { CanonicalPersonAddressRepo } from "./CanonicalPersonAddressRepo";
+import {
+  CanonicalPersonAddressPrimaryKeyNames,
+  CanonicalPersonAddressSchema,
+  type CanonicalPersonAddress,
+} from "./CanonicalJunctionSchemas";
+
+describe("CanonicalPersonAddressRepo.removeObservation", () => {
+  let storage: InMemoryTabularStorage<
+    typeof CanonicalPersonAddressSchema,
+    typeof CanonicalPersonAddressPrimaryKeyNames,
+    CanonicalPersonAddress
+  >;
+  let repo: CanonicalPersonAddressRepo;
+  const pk = {
+    canonical_person_id: "uuid-1",
+    address_hash_id: "addr-x",
+    resolver_version: "1.0.0",
+  };
+
+  beforeEach(() => {
+    storage = new InMemoryTabularStorage<
+      typeof CanonicalPersonAddressSchema,
+      typeof CanonicalPersonAddressPrimaryKeyNames,
+      CanonicalPersonAddress
+    >(CanonicalPersonAddressSchema, CanonicalPersonAddressPrimaryKeyNames, [
+      ["canonical_person_id", "resolver_version"],
+      ["resolver_version"],
+    ]);
+    repo = new CanonicalPersonAddressRepo({ canonicalPersonAddressRepository: storage });
+  });
+
+  it("decrements observation_count when > 1", async () => {
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-02T00:00:00.000Z" });
+    await repo.removeObservation(pk);
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(1);
+  });
+
+  it("deletes the row when observation_count === 1", async () => {
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    await repo.removeObservation(pk);
+    const row = await storage.get(pk);
+    expect(row).toBeUndefined();
+  });
+
+  it("is a no-op when the row does not exist", async () => {
+    await expect(repo.removeObservation(pk)).resolves.toBeUndefined();
+    const row = await storage.get(pk);
+    expect(row).toBeUndefined();
+  });
+});

--- a/src/storage/canonical/CanonicalPersonAddressRepo.ts
+++ b/src/storage/canonical/CanonicalPersonAddressRepo.ts
@@ -5,6 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
+import { KeyedMutex } from "../../util/KeyedMutex";
 import {
   CANONICAL_PERSON_ADDRESS_REPOSITORY_TOKEN,
   type CanonicalPersonAddress,
@@ -22,6 +23,23 @@ interface RecordPersonAddressArgs {
   seen_at: string;
 }
 
+/**
+ * Serialises the read-modify-write of the mutable `observation_count` per
+ * composite PK `(canonical_person_id, address_hash_id, resolver_version)`.
+ * Module-scoped because every caller builds a fresh {@link CanonicalPersonAddressRepo};
+ * different composite keys still run concurrently. The `\x00` separator never
+ * occurs in the string PK components, so distinct keys can't collide.
+ */
+const junctionLocks = new KeyedMutex<string>();
+
+function junctionKey(pk: {
+  canonical_person_id: string;
+  address_hash_id: string;
+  resolver_version: string;
+}): string {
+  return `${pk.canonical_person_id}\x00${pk.address_hash_id}\x00${pk.resolver_version}`;
+}
+
 export class CanonicalPersonAddressRepo {
   private repo: CanonicalPersonAddressRepositoryStorage;
 
@@ -37,24 +55,26 @@ export class CanonicalPersonAddressRepo {
       address_hash_id: args.address_hash_id,
       resolver_version: args.resolver_version,
     };
-    const existing = await this.repo.get(pk);
-    if (existing) {
-      const updated: CanonicalPersonAddress = {
-        ...existing,
-        observation_count: existing.observation_count + 1,
+    return junctionLocks.lock(junctionKey(pk), async () => {
+      const existing = await this.repo.get(pk);
+      if (existing) {
+        const updated: CanonicalPersonAddress = {
+          ...existing,
+          observation_count: existing.observation_count + 1,
+          last_seen_at: args.seen_at,
+        };
+        await this.repo.put(updated);
+        return updated;
+      }
+      const fresh: CanonicalPersonAddress = {
+        ...pk,
+        observation_count: 1,
+        first_seen_at: args.seen_at,
         last_seen_at: args.seen_at,
       };
-      await this.repo.put(updated);
-      return updated;
-    }
-    const fresh: CanonicalPersonAddress = {
-      ...pk,
-      observation_count: 1,
-      first_seen_at: args.seen_at,
-      last_seen_at: args.seen_at,
-    };
-    await this.repo.put(fresh);
-    return fresh;
+      await this.repo.put(fresh);
+      return fresh;
+    });
   }
 
   /**
@@ -68,13 +88,15 @@ export class CanonicalPersonAddressRepo {
     address_hash_id: string;
     resolver_version: string;
   }): Promise<void> {
-    const existing = await this.repo.get(pk);
-    if (!existing) return;
-    if (existing.observation_count <= 1) {
-      await this.repo.delete(pk);
-      return;
-    }
-    await this.repo.put({ ...existing, observation_count: existing.observation_count - 1 });
+    await junctionLocks.lock(junctionKey(pk), async () => {
+      const existing = await this.repo.get(pk);
+      if (!existing) return;
+      if (existing.observation_count <= 1) {
+        await this.repo.delete(pk);
+        return;
+      }
+      await this.repo.put({ ...existing, observation_count: existing.observation_count - 1 });
+    });
   }
 
   async listForCanonical(

--- a/src/storage/canonical/CanonicalPersonPhoneRepo.concurrency.test.ts
+++ b/src/storage/canonical/CanonicalPersonPhoneRepo.concurrency.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @copyright
+ * Copyright 2026 Steven Roussey
+ * All Rights Reserved
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryTabularStorage } from "workglow";
+import { CanonicalPersonPhoneRepo } from "./CanonicalPersonPhoneRepo";
+import {
+  CanonicalPersonPhonePrimaryKeyNames,
+  CanonicalPersonPhoneSchema,
+  type CanonicalPersonPhone,
+} from "./CanonicalJunctionSchemas";
+
+function makeStorage() {
+  return new InMemoryTabularStorage<
+    typeof CanonicalPersonPhoneSchema,
+    typeof CanonicalPersonPhonePrimaryKeyNames,
+    CanonicalPersonPhone
+  >(CanonicalPersonPhoneSchema, CanonicalPersonPhonePrimaryKeyNames, [
+    ["canonical_person_id", "resolver_version"],
+    ["resolver_version"],
+  ]);
+}
+
+describe("CanonicalPersonPhoneRepo concurrency", () => {
+  let storage: ReturnType<typeof makeStorage>;
+  let repo: CanonicalPersonPhoneRepo;
+
+  beforeEach(() => {
+    storage = makeStorage();
+    repo = new CanonicalPersonPhoneRepo({ canonicalPersonPhoneRepository: storage });
+  });
+
+  it("keeps observation_count consistent under 100 concurrent recordObservation calls for the same PK", async () => {
+    const pk = {
+      canonical_person_id: "uuid-1",
+      international_number: "+14155551234",
+      resolver_version: "1.0.0",
+    };
+    await Promise.all(
+      Array.from({ length: 100 }, () =>
+        repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" })
+      )
+    );
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(100);
+  });
+
+  it("keeps observation_count consistent under mixed record+remove concurrent calls", async () => {
+    const pk = {
+      canonical_person_id: "uuid-1",
+      international_number: "+14155551234",
+      resolver_version: "1.0.0",
+    };
+    for (let i = 0; i < 50; i++) {
+      await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    }
+    const ops: Array<Promise<unknown>> = [];
+    for (let i = 0; i < 50; i++) {
+      ops.push(repo.recordObservation({ ...pk, seen_at: "2026-01-02T00:00:00.000Z" }));
+      ops.push(repo.removeObservation(pk));
+    }
+    await Promise.all(ops);
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(50);
+  });
+
+  it("does not serialize different PKs", async () => {
+    const N = 8;
+    let entered = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const originalPut = storage.put.bind(storage);
+    storage.put = async (row: CanonicalPersonPhone) => {
+      entered++;
+      if (entered === N) release();
+      await gate;
+      return originalPut(row);
+    };
+    const results = Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        repo.recordObservation({
+          canonical_person_id: `uuid-${i}`,
+          international_number: "+14155551234",
+          resolver_version: "1.0.0",
+          seen_at: "2026-01-01T00:00:00.000Z",
+        })
+      )
+    );
+    const deadline = Date.now() + 1000;
+    while (entered < N && Date.now() < deadline) {
+      await new Promise((r) => setImmediate(r));
+    }
+    expect(entered).toBe(N);
+    await results;
+  });
+});

--- a/src/storage/canonical/CanonicalPersonPhoneRepo.removeObservation.test.ts
+++ b/src/storage/canonical/CanonicalPersonPhoneRepo.removeObservation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @copyright
+ * Copyright 2026 Steven Roussey
+ * All Rights Reserved
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryTabularStorage } from "workglow";
+import { CanonicalPersonPhoneRepo } from "./CanonicalPersonPhoneRepo";
+import {
+  CanonicalPersonPhonePrimaryKeyNames,
+  CanonicalPersonPhoneSchema,
+  type CanonicalPersonPhone,
+} from "./CanonicalJunctionSchemas";
+
+describe("CanonicalPersonPhoneRepo.removeObservation", () => {
+  let storage: InMemoryTabularStorage<
+    typeof CanonicalPersonPhoneSchema,
+    typeof CanonicalPersonPhonePrimaryKeyNames,
+    CanonicalPersonPhone
+  >;
+  let repo: CanonicalPersonPhoneRepo;
+  const pk = {
+    canonical_person_id: "uuid-1",
+    international_number: "+14155551234",
+    resolver_version: "1.0.0",
+  };
+
+  beforeEach(() => {
+    storage = new InMemoryTabularStorage<
+      typeof CanonicalPersonPhoneSchema,
+      typeof CanonicalPersonPhonePrimaryKeyNames,
+      CanonicalPersonPhone
+    >(CanonicalPersonPhoneSchema, CanonicalPersonPhonePrimaryKeyNames, [
+      ["canonical_person_id", "resolver_version"],
+      ["resolver_version"],
+    ]);
+    repo = new CanonicalPersonPhoneRepo({ canonicalPersonPhoneRepository: storage });
+  });
+
+  it("decrements observation_count when > 1", async () => {
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-02T00:00:00.000Z" });
+    await repo.removeObservation(pk);
+    const row = await storage.get(pk);
+    expect(row).toBeDefined();
+    expect(row!.observation_count).toBe(1);
+  });
+
+  it("deletes the row when observation_count === 1", async () => {
+    await repo.recordObservation({ ...pk, seen_at: "2026-01-01T00:00:00.000Z" });
+    await repo.removeObservation(pk);
+    const row = await storage.get(pk);
+    expect(row).toBeUndefined();
+  });
+
+  it("is a no-op when the row does not exist", async () => {
+    await expect(repo.removeObservation(pk)).resolves.toBeUndefined();
+    const row = await storage.get(pk);
+    expect(row).toBeUndefined();
+  });
+});

--- a/src/storage/canonical/CanonicalPersonPhoneRepo.ts
+++ b/src/storage/canonical/CanonicalPersonPhoneRepo.ts
@@ -5,6 +5,7 @@
  */
 
 import { globalServiceRegistry } from "workglow";
+import { KeyedMutex } from "../../util/KeyedMutex";
 import {
   CANONICAL_PERSON_PHONE_REPOSITORY_TOKEN,
   type CanonicalPersonPhone,
@@ -22,6 +23,17 @@ interface RecordPersonPhoneArgs {
   seen_at: string;
 }
 
+/** Per-composite-PK read-modify-write lock for `observation_count`; see CanonicalPersonAddressRepo. */
+const junctionLocks = new KeyedMutex<string>();
+
+function junctionKey(pk: {
+  canonical_person_id: string;
+  international_number: string;
+  resolver_version: string;
+}): string {
+  return `${pk.canonical_person_id}\x00${pk.international_number}\x00${pk.resolver_version}`;
+}
+
 export class CanonicalPersonPhoneRepo {
   private repo: CanonicalPersonPhoneRepositoryStorage;
 
@@ -37,24 +49,26 @@ export class CanonicalPersonPhoneRepo {
       international_number: args.international_number,
       resolver_version: args.resolver_version,
     };
-    const existing = await this.repo.get(pk);
-    if (existing) {
-      const updated: CanonicalPersonPhone = {
-        ...existing,
-        observation_count: existing.observation_count + 1,
+    return junctionLocks.lock(junctionKey(pk), async () => {
+      const existing = await this.repo.get(pk);
+      if (existing) {
+        const updated: CanonicalPersonPhone = {
+          ...existing,
+          observation_count: existing.observation_count + 1,
+          last_seen_at: args.seen_at,
+        };
+        await this.repo.put(updated);
+        return updated;
+      }
+      const fresh: CanonicalPersonPhone = {
+        ...pk,
+        observation_count: 1,
+        first_seen_at: args.seen_at,
         last_seen_at: args.seen_at,
       };
-      await this.repo.put(updated);
-      return updated;
-    }
-    const fresh: CanonicalPersonPhone = {
-      ...pk,
-      observation_count: 1,
-      first_seen_at: args.seen_at,
-      last_seen_at: args.seen_at,
-    };
-    await this.repo.put(fresh);
-    return fresh;
+      await this.repo.put(fresh);
+      return fresh;
+    });
   }
 
   /** Remove one observation's contribution; see CanonicalPersonAddressRepo.removeObservation. */
@@ -63,13 +77,15 @@ export class CanonicalPersonPhoneRepo {
     international_number: string;
     resolver_version: string;
   }): Promise<void> {
-    const existing = await this.repo.get(pk);
-    if (!existing) return;
-    if (existing.observation_count <= 1) {
-      await this.repo.delete(pk);
-      return;
-    }
-    await this.repo.put({ ...existing, observation_count: existing.observation_count - 1 });
+    await junctionLocks.lock(junctionKey(pk), async () => {
+      const existing = await this.repo.get(pk);
+      if (!existing) return;
+      if (existing.observation_count <= 1) {
+        await this.repo.delete(pk);
+        return;
+      }
+      await this.repo.put({ ...existing, observation_count: existing.observation_count - 1 });
+    });
   }
 
   async listForCanonical(


### PR DESCRIPTION
## Summary

The four canonical junction repos (`CanonicalPersonAddressRepo`, `CanonicalPersonPhoneRepo`, `CanonicalCompanyAddressRepo`, `CanonicalCompanyPhoneRepo`) did `get(pk) -> mutate observation_count -> put(row)` without serialization. Two concurrent `EntityObserver.observePerson` calls resolving to the same `canonical_person_id` for the same address/phone raced their increments; one was lost. The reap path introduced in #175 amplifies this: `removeObservation` decrements race the same code.

## The fix

- Wrap `recordObservation` and `removeObservation` in a module-scoped `KeyedMutex<string>` inside each of the four junction repos.
- Key shape: serialized composite PK with `\x00` sentinel (never occurs in a UUID / address hash / E.164 number / semver, so distinct PKs can't collide):
  - address junctions -> ``${canonical_(person|company)_id}\x00${address_hash_id}\x00${resolver_version}``
  - phone junctions -> ``${canonical_(person|company)_id}\x00${international_number}\x00${resolver_version}``
- Lock scope is `get + put` only. The resolver call in `EntityObserver` already sits outside the junction critical section, so no head-of-line blocking of resolves.
- Four separate module-level mutexes (one per repo file) so distinct junction kinds never contend with each other.
- Different composite PKs still run concurrently.

## `removeObservation`

`removeObservation(pk)` (the inverse of `recordObservation`) is already present on all four repos and is what the reaper calls. It stays no-op when the row doesn't exist (idempotent replays), decrements when `observation_count > 1`, and deletes when `<= 1`. The mutex now serialises it too, so concurrent record + remove for the same PK can't lose an update.

## Tests

- `Canonical{Person,Company}{Address,Phone}Repo.concurrency.test.ts` (4 files):
  - 100 concurrent `recordObservation` for the same PK -> final `observation_count === 100`.
  - 50 seeded + interleaved 50 record + 50 remove -> final `observation_count === 50` (net zero delta).
  - N concurrent records on distinct PKs -> a barrier-in-`put` proves no head-of-line blocking across keys.
- `Canonical{Person,Company}{Address,Phone}Repo.removeObservation.test.ts` (4 files):
  - decrements when `> 1`; deletes when `=== 1`; no-op when absent.
- `EntityObserver.concurrency.test.ts`:
  - Two concurrent `observePerson` calls for the same canonical + same address -> `observation_count === 2`.

## Verification

- `bun test src/storage/canonical/` -> 94 pass.
- `bun test src/resolver/` -> 66 pass.
- `bun test src/task/forms/ProcessAccessionDocFormTask` -> 14 pass.
- `bunx tsc --noEmit` -> clean.
- `bun test` (full suite) -> 1453 pass, 7 pre-existing network fetch-index test timeouts (`FetchQuarterlyIndexTask` / `FetchDailyIndexTask`) unrelated to this change.

## Test plan

- [ ] CI green
- [ ] `bun test src/storage/canonical/` locally
- [ ] `bun test src/resolver/` locally

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7p61MWFSPiokZHPKNaNEj)_