### PR TITLE
Upgrade TypeBox to 1.3.6 and migrate TypeStringEnum

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "html-entities": "^2.6.0",
         "pdf2json": "^4.0.3",
         "pg": "^8.21.0",
-        "typebox": "1.2.8",
+        "typebox": "1.3.6",
         "words-to-numbers": "^1.5.1",
         "workglow": "0.3.15",
         "xml2js": "^0.6.2",
@@ -989,7 +989,7 @@
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
-    "typebox": ["typebox@1.2.8", "", {}, "sha512-rlsKhsd7L3082m9nxhFIB4Gl8jizLd/6YlFAWaz96hdV8+VJRjwYaYmDlT0jlTRwkb48SxCSSirqUtrg/HilNw=="],
+    "typebox": ["typebox@1.3.6", "", {}, "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "html-entities": "^2.6.0",
     "pdf2json": "^4.0.3",
     "pg": "^8.21.0",
-    "typebox": "1.2.8",
+    "typebox": "1.3.6",
     "words-to-numbers": "^1.5.1",
     "workglow": "0.3.15",
     "xml2js": "^0.6.2"

--- a/src/util/TypeBoxUtil.ts
+++ b/src/util/TypeBoxUtil.ts
@@ -1,4 +1,4 @@
-import { type TSchema, Type } from "typebox";
+import { type TSchema, type TUnsafe, Type } from "typebox";
 
 /**
  * Creates a nullable type by wrapping the given type in a union with null.
@@ -32,34 +32,23 @@ export const TypeBlob = (annotations: Record<string, unknown> = {}) =>
     .Decode((value: unknown) => value as Uint8Array)
     .Encode((value: Uint8Array) => Buffer.from(value));
 
-export class TypeStringEnumType<T extends string[] | readonly string[]> extends Type.Base<
-  T[number]
-> {
-  public readonly type = "string";
-  public readonly enum: T;
-
-  constructor(values: T, annotations: Record<string, unknown> = {}) {
-    super();
-    this.enum = values;
-    Object.assign(this, annotations);
-    // create a non-enumerable property called annotations
-    Object.defineProperty(this, "annotations", {
-      value: annotations,
-      enumerable: false,
-    });
-  }
-
-  public Check(value: unknown): value is T[number] {
-    return typeof value === "string" && this.enum.includes(value);
-  }
-
-  public Clone(): TypeStringEnumType<T> {
-    // @ts-expect-error - annotations is not a property of TypeStringEnumType
-    return new TypeStringEnumType(this.enum, this.annotations);
-  }
-}
-
+/**
+ * Creates a `{ type: "string", enum: [...] }` schema whose values are validated
+ * against the provided list.
+ *
+ * Replaces the former `Type.Base` subclass (removed in TypeBox 1.3) with the
+ * migration path TypeBox recommends — {@link Type.Unsafe} to carry the JSON
+ * Schema shape plus {@link Type.Refine} to enforce enum membership at runtime.
+ *
+ * The result is typed as an intersection with `{ type: "string" }` because
+ * `TUnsafe` does not surface the literal `type` keyword in its static type,
+ * which the DataPortSchema discriminated union relies on to accept the schema.
+ */
 export const TypeStringEnum = <T extends string[] | readonly string[]>(
   values: T,
   annotations: Record<string, unknown> = {}
-) => new TypeStringEnumType(values as string[], annotations);
+): TUnsafe<string> & { readonly type: "string" } =>
+  Type.Refine(
+    Type.Unsafe<string>({ type: "string", enum: values, ...annotations }),
+    (value) => typeof value === "string" && (values as readonly string[]).includes(value)
+  ) as unknown as TUnsafe<string> & { readonly type: "string" };


### PR DESCRIPTION
## Summary

Upgrades TypeBox from 1.2.8 to 1.3.6 and migrates the `TypeStringEnum` implementation to use the new `Type.Unsafe` + `Type.Refine` pattern, replacing the deprecated `Type.Base` subclass approach.

## Changes

- **Dependency upgrade**: TypeBox 1.2.8 → 1.3.6
- **TypeStringEnum refactor**: 
  - Removed `TypeStringEnumType` class that extended `Type.Base` (deprecated in TypeBox 1.3)
  - Replaced with `Type.Unsafe` to define the JSON Schema shape (`{ type: "string", enum: [...] }`)
  - Added `Type.Refine` to enforce runtime validation that values are strings and exist in the enum list
  - Cast result as `TUnsafe<string> & { readonly type: "string" }` to preserve the `type` discriminator for `DataPortSchema` union compatibility
- **Import update**: Added `TUnsafe` type import from TypeBox

## Implementation Details

The migration follows TypeBox's recommended path for custom schema types. The `Type.Refine` wrapper ensures that at runtime, only string values present in the provided enum array pass validation, maintaining the same behavior as the original class-based implementation while being compatible with TypeBox 1.3's architecture.

https://claude.ai/code/session_01N8AJR1XDxUnHnM4FKnJzPy