### PR TITLE
feat(cli): honor --json flag in status and error output

### DIFF
--- a/src/cli/GlobalOptions.test.ts
+++ b/src/cli/GlobalOptions.test.ts
@@ -17,9 +17,13 @@ describe("GlobalOptions", () => {
       expect(help).toContain("--dry-run");
     });
 
+    it("advertises --json now that it is consumed", () => {
+      const help = createProgram().helpInformation();
+      expect(help).toContain("--json");
+    });
+
     it("does not advertise the removed (never-consumed) flags", () => {
       const help = createProgram().helpInformation();
-      expect(help).not.toContain("--json");
       expect(help).not.toContain("--verbose");
       expect(help).not.toContain("--no-color");
     });
@@ -42,6 +46,18 @@ describe("GlobalOptions", () => {
       const program = createProgram();
       program.parse(["--dry-run"], { from: "user" });
       expect(parseGlobalOptions(program).dryRun).toBe(true);
+    });
+
+    it("defaults json to false", () => {
+      const program = createProgram();
+      program.parse([], { from: "user" });
+      expect(parseGlobalOptions(program).json).toBe(false);
+    });
+
+    it("parses --json", () => {
+      const program = createProgram();
+      program.parse(["--json"], { from: "user" });
+      expect(parseGlobalOptions(program).json).toBe(true);
     });
   });
 });

--- a/src/cli/GlobalOptions.ts
+++ b/src/cli/GlobalOptions.ts
@@ -2,20 +2,24 @@ import type { Command } from "commander";
 
 export interface GlobalOptions {
   readonly dryRun: boolean;
+  readonly json: boolean;
 }
 
-// Only `--dry-run` is wired (it gates writes via SEC_DRY_RUN). Previous
-// `--json` / `--verbose` / `--no-color` flags were parsed but never consumed —
-// read commands carry their own `--format`, and output is plain text — so they
-// were removed rather than advertised in --help while doing nothing.
+// `--dry-run` gates writes via SEC_DRY_RUN; `--json` routes status/error output
+// through SEC_JSON_OUTPUT so `statusMessage` / `runCommand` emit machine-parseable
+// JSON instead of pretty text. (The `--verbose` / `--no-color` flags were parsed
+// but never consumed, so they stay unadvertised.)
 export function applyGlobalOptions(program: Command): Command {
-  return program.option("--dry-run", "Show what would happen without changes", false);
+  return program
+    .option("--dry-run", "Show what would happen without changes", false)
+    .option("--json", "Emit status and error output as machine-parseable JSON", false);
 }
 
 export function parseGlobalOptions(cmd: Command): GlobalOptions {
   const opts = cmd.opts();
   return {
     dryRun: opts.dryRun ?? false,
+    json: opts.json ?? false,
   };
 }
 

--- a/src/cli/dryRunRouting.test.ts
+++ b/src/cli/dryRunRouting.test.ts
@@ -21,8 +21,11 @@ import { isDryRun } from "./isDryRun";
  * reads can be simplified.
  */
 describe("--dry-run option routing", () => {
-  function build(): { program: Command; seen: { sub?: boolean; global?: boolean } } {
-    const seen: { sub?: boolean; global?: boolean } = {};
+  function build(): {
+    program: Command;
+    seen: { sub?: boolean; global?: boolean; jsonGlobal?: boolean };
+  } {
+    const seen: { sub?: boolean; global?: boolean; jsonGlobal?: boolean } = {};
     const program = new Command("sec").exitOverride();
     applyGlobalOptions(program);
     const group = program.command("group");
@@ -32,6 +35,7 @@ describe("--dry-run option routing", () => {
       .action((_arg: string, opts: { dryRun?: boolean }) => {
         seen.sub = opts.dryRun === true;
         seen.global = parseGlobalOptions(program).dryRun;
+        seen.jsonGlobal = parseGlobalOptions(program).json;
       });
     return { program, seen };
   }
@@ -43,11 +47,18 @@ describe("--dry-run option routing", () => {
     expect(seen.sub).toBe(false);
   });
 
+  it("routes a post-subcommand --json to the program-level option", async () => {
+    const { program, seen } = build();
+    await program.parseAsync(["node", "sec", "group", "do", "x", "--json"]);
+    expect(seen.jsonGlobal).toBe(true);
+  });
+
   it("neither option is set without the flag", async () => {
     const { program, seen } = build();
     await program.parseAsync(["node", "sec", "group", "do", "x"]);
     expect(seen.global).toBe(false);
     expect(seen.sub).toBe(false);
+    expect(seen.jsonGlobal).toBe(false);
   });
 
   it("isDryRun reflects the registered SEC_DRY_RUN token", () => {

--- a/src/cli/groups/init.ts
+++ b/src/cli/groups/init.ts
@@ -7,7 +7,7 @@ import { globalServiceRegistry, Sqlite } from "workglow";
 import { DefaultDI } from "../../config/DefaultDI";
 import { EnvToDI } from "../../config/EnvToDI";
 import { setupAllDatabases } from "../../config/setupAllDatabases";
-import { SEC_DRY_RUN } from "../../config/tokens";
+import { SEC_DRY_RUN, SEC_JSON_OUTPUT } from "../../config/tokens";
 import { parseGlobalOptions } from "../GlobalOptions";
 import { runCommand } from "../runCommand";
 
@@ -64,8 +64,10 @@ export function addInitCommand(parent: Command): void {
     .command("init")
     .description("Interactive first-run setup wizard")
     .action(async () => {
-      const dryRun = parseGlobalOptions(parent).dryRun;
+      const globalOpts = parseGlobalOptions(parent);
+      const dryRun = globalOpts.dryRun;
       globalServiceRegistry.registerInstance(SEC_DRY_RUN, dryRun);
+      globalServiceRegistry.registerInstance(SEC_JSON_OUTPUT, globalOpts.json);
 
       await runCommand(async () => {
         const envPath = resolve(process.cwd(), ".env.local");

--- a/src/cli/isJsonOutput.ts
+++ b/src/cli/isJsonOutput.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { SEC_JSON_OUTPUT } from "../config/tokens";
+
+/**
+ * True when the global `--json` flag was passed, so status/error output should
+ * be machine-parseable JSON instead of pretty text. Reads the DI-registered
+ * flag, mirroring {@link isDryRun}; defaults to `false` when unregistered (e.g.
+ * pure-CLI invocations before the preAction hook runs).
+ */
+export function isJsonOutput(): boolean {
+  return globalServiceRegistry.has(SEC_JSON_OUTPUT) && globalServiceRegistry.get(SEC_JSON_OUTPUT);
+}

--- a/src/cli/output/Progress.test.ts
+++ b/src/cli/output/Progress.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { globalServiceRegistry } from "workglow";
+import { SEC_JSON_OUTPUT } from "../../config/tokens";
 import { createProgress, createSpinner, statusMessage } from "./Progress";
 
 describe("statusMessage", () => {
@@ -16,6 +18,36 @@ describe("statusMessage", () => {
 
   it("formats warn with exclamation prefix", () => {
     expect(statusMessage("warn", "Careful")).toBe("! Careful");
+  });
+});
+
+describe("statusMessage under --json", () => {
+  afterEach(() => {
+    globalServiceRegistry.registerInstance(SEC_JSON_OUTPUT, false);
+  });
+
+  it("emits a parseable JSON object for errors", () => {
+    globalServiceRegistry.registerInstance(SEC_JSON_OUTPUT, true);
+    const out = statusMessage("error", "boom");
+    expect(JSON.parse(out)).toEqual({ status: "error", message: "boom" });
+  });
+
+  it("emits JSON for non-error statuses too", () => {
+    globalServiceRegistry.registerInstance(SEC_JSON_OUTPUT, true);
+    expect(JSON.parse(statusMessage("success", "Done"))).toEqual({
+      status: "success",
+      message: "Done",
+    });
+  });
+
+  it("does not prefix the message with a glyph in JSON mode", () => {
+    globalServiceRegistry.registerInstance(SEC_JSON_OUTPUT, true);
+    expect(statusMessage("error", "Failed")).not.toContain("x ");
+  });
+
+  it("returns to pretty text once the flag is cleared", () => {
+    globalServiceRegistry.registerInstance(SEC_JSON_OUTPUT, false);
+    expect(statusMessage("error", "Failed")).toBe("x Failed");
   });
 });
 

--- a/src/cli/output/Progress.ts
+++ b/src/cli/output/Progress.ts
@@ -32,8 +32,8 @@ const BAR_WIDTH = 20;
 
 /**
  * Formats a status line for the CLI. Under the global `--json` flag it returns a
- * single machine-parseable object (`{"status","message"}`) so integrations can
- * parse success/error output instead of scraping pretty prefixes.
+ * single machine-parseable object (`{"status":"error","message":"..."}`) so
+ * integrations can parse success/error output instead of scraping pretty prefixes.
  */
 export function statusMessage(type: StatusType, msg: string): string {
   if (isJsonOutput()) {

--- a/src/cli/output/Progress.ts
+++ b/src/cli/output/Progress.ts
@@ -1,3 +1,5 @@
+import { isJsonOutput } from "../isJsonOutput";
+
 export interface ProgressOptions {
   readonly total: number;
   readonly label: string;
@@ -28,7 +30,15 @@ const STATUS_PREFIXES: Record<StatusType, string> = {
 
 const BAR_WIDTH = 20;
 
+/**
+ * Formats a status line for the CLI. Under the global `--json` flag it returns a
+ * single machine-parseable object (`{"status","message"}`) so integrations can
+ * parse success/error output instead of scraping pretty prefixes.
+ */
 export function statusMessage(type: StatusType, msg: string): string {
+  if (isJsonOutput()) {
+    return JSON.stringify({ status: type, message: msg });
+  }
   return `${STATUS_PREFIXES[type]} ${msg}`;
 }
 

--- a/src/cli/runCommand.test.ts
+++ b/src/cli/runCommand.test.ts
@@ -51,6 +51,25 @@ describe("runCommand", () => {
     }
   });
 
+  it("writes a JSON error object to stderr when --json is set", async () => {
+    const { globalServiceRegistry } = await import("workglow");
+    const { SEC_JSON_OUTPUT } = await import("../config/tokens");
+    globalServiceRegistry.registerInstance(SEC_JSON_OUTPUT, true);
+    const action = mock(() => Promise.reject(new Error("kaboom")));
+    const stderrWrite = mock(() => true);
+    const origWrite = process.stderr.write;
+    process.stderr.write = stderrWrite as typeof process.stderr.write;
+    try {
+      const code = await runCommand(action);
+      expect(code).toBe(1);
+      const output = (stderrWrite.mock.calls[0][0] as string).trim();
+      expect(JSON.parse(output)).toEqual({ status: "error", message: "kaboom" });
+    } finally {
+      process.stderr.write = origWrite;
+      globalServiceRegistry.registerInstance(SEC_JSON_OUTPUT, false);
+    }
+  });
+
   it("prints dry-run banner when SEC_DRY_RUN is set", async () => {
     const { globalServiceRegistry } = await import("workglow");
     const { SEC_DRY_RUN } = await import("../config/tokens");

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -27,7 +27,7 @@ import { DefaultDI } from "../config/DefaultDI";
 import { EnvToDI } from "../config/EnvToDI";
 import { registerSecModels } from "../config/registerModels";
 import { registerSecProviders } from "../config/registerProviders";
-import { SEC_DRY_RUN } from "../config/tokens";
+import { SEC_DRY_RUN, SEC_JSON_OUTPUT } from "../config/tokens";
 import { SecJobQueueClient, SecJobQueueServer, SecJobQueueStorage } from "../fetch/SecJobQueue";
 
 export const AddCommands = (program: Command): void => {
@@ -48,6 +48,7 @@ export const AddCommands = (program: Command): void => {
 
     const globalOpts = parseGlobalOptions(program);
     globalServiceRegistry.registerInstance(SEC_DRY_RUN, globalOpts.dryRun);
+    globalServiceRegistry.registerInstance(SEC_JSON_OUTPUT, globalOpts.json);
 
     EnvToDI();
     DefaultDI();

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -17,3 +17,4 @@ export const SEC_PG_USER = createServiceToken<string>("sec.pg.user");
 export const SEC_PG_PASSWORD = createServiceToken<string>("sec.pg.password");
 export const SEC_PG_DATABASE = createServiceToken<string>("sec.pg.database");
 export const SEC_DRY_RUN = createServiceToken<boolean>("sec.dry.run");
+export const SEC_JSON_OUTPUT = createServiceToken<boolean>("sec.json.output");

--- a/src/sec.ts
+++ b/src/sec.ts
@@ -3,6 +3,7 @@
 import { program } from "commander";
 import { getTaskQueueRegistry } from "workglow";
 import { applyGlobalOptions } from "./cli/GlobalOptions";
+import { statusMessage } from "./cli/output/Progress";
 import { AddCommands } from "./commands";
 import { SecCliConfigurationError } from "./config/EnvToDI";
 import { closeDb } from "./util/db";
@@ -22,7 +23,7 @@ try {
 } catch (e) {
   primaryError = e;
   if (e instanceof SecCliConfigurationError) {
-    console.error(e.message);
+    console.error(statusMessage("error", e.message));
     process.exitCode = 1;
   }
 } finally {


### PR DESCRIPTION
Closes #143

## Summary

CLI status and error output was always pretty-printed, so integrations could not machine-parse it. This reintroduces the global `--json` flag and actually wires it through, so `statusMessage` / `runCommand` emit machine-parseable JSON instead of glyph-prefixed text.

The flag previously existed but had been removed as "parsed but never consumed." It now routes through a `SEC_JSON_OUTPUT` DI token, mirroring the existing `SEC_DRY_RUN` / `isDryRun()` pattern.

## Changes

- **`src/config/tokens.ts`** — new `SEC_JSON_OUTPUT` DI token.
- **`src/cli/isJsonOutput.ts`** (new) — reads the token; defaults to `false` when unregistered (e.g. pure-CLI invocations before the preAction hook runs), mirroring `isDryRun()`.
- **`src/cli/output/Progress.ts`** — `statusMessage()` returns `{"status","message"}` JSON under `--json` instead of the glyph-prefixed line. Since `runCommand`'s error path already routes through `statusMessage`, its errors become JSON automatically.
- **`src/cli/GlobalOptions.ts`** — adds the `--json` global option and returns it from `parseGlobalOptions`.
- **`src/commands/index.ts`** & **`src/cli/groups/init.ts`** — register the flag into DI (the `preAction` hook for normal commands, and the `init` command which bypasses that hook). Registered before `EnvToDI()` runs, so configuration errors are covered too.
- **`src/sec.ts`** — routes the `SecCliConfigurationError` message through `statusMessage` so it also honors `--json`.

## Behavior

```
# pretty (default)
$ sec db status
x SEC CLI is not configured for Postgres; set SEC_PG_URL, or SEC_PG_HOST + SEC_PG_DATABASE.

# machine-parseable
$ sec --json db status
{"status":"error","message":"SEC CLI is not configured for Postgres; set SEC_PG_URL, or SEC_PG_HOST + SEC_PG_DATABASE."}
```

## Testing

- New/updated unit tests in `Progress.test.ts`, `runCommand.test.ts`, and `GlobalOptions.test.ts`; full CLI suite (252 tests) passes.
- `tsc` clean.
- Verified end-to-end against both the `runCommand` error path and the `sec.ts` configuration-error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174YErFdh2ZSGaUaCwhdoaj