### PR TITLE
feat(spac): AI SPAC classifier, sponsor promote, de-SPAC linkage (#149, #150, #151)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,28 @@ once the model/provider is registered, no version bump required
 (`MODEL_ERROR_REASON_CODES` in `ExtractionDeadLetterSchema.ts`). Every other reason
 code stays version-gated (fix the extractor, bump the version, then retry).
 
+### AI SPAC content classifier (SIC-miscoded SPACs)
+
+Deterministic SPAC classification keys off the SGML-header SIC (`6770` →
+`is_spac`, `classifier_source = "sgml-header"`). A SPAC filed under a miscoded or
+absent SIC would be missed, so `processFormS1` runs an **AI content classifier**
+behind the `S1Classification.classifier_source = "ai"` seam. It is gated twice to
+stay cheap: it only runs when the deterministic path did **not** already flag the
+filing, and only when a cheap keyword heuristic (`looksLikeBlankCheck`,
+`s1/spacContentHeuristic.ts` — ≥2 distinct blank-check signals) trips on the
+prospectus-summary prose. A confident `spac` verdict (`extractSpacClassification`
+distinguishes a true SPAC from a `shell` or `operating` company) flips the local
+`is_spac`, overwrites the classification row with `classifier_source = "ai"`, and
+mints the known-SPAC `spac` row so de-SPAC lifecycle extractors can attach. A
+confident "not a SPAC" is the expected outcome and auto-resolves its
+`MODEL_EMPTY` dead-letter (mirroring the LOI detector); when the model is
+unavailable, a blank-check-looking filing dead-letters `spac-classification`
+(`MODEL_RESOLUTION_ERROR`) so a retry runs it once a model exists. Configure via
+`SEC_S1_CLASSIFIER_MODEL` (default `SecModelDefault`) and
+`SEC_S1_CLASSIFIER_CONFIDENCE_FLOOR` (falls back to `SEC_S1_CONFIDENCE_FLOOR`).
+The `spac-classification` entry in `EVAL_EXTRACTORS` (a true-SPAC positive plus
+shell / operating-company negatives) ranks it through `sec eval extract`.
+
 ### Model comparison harness
 
 `sec eval extract` compares extraction models on **correctness, speed, and cost**
@@ -328,6 +350,19 @@ sec issuer tickers <cik>
 sec issuer deal <cik> [--format json]
 ```
 
+#### Sponsor promote economics
+
+Alongside the unit terms, the SPAC prospectus's "The Offering" / "The Sponsor"
+prose yields the **sponsor promote**: founder (Class B) shares and their
+percentage, private-placement (sponsor) warrant count / price / public warrant
+coverage, and the trust deposit per public share and in total. These land in a
+dedicated `spac_promote_terms` table keyed `(extractor_id, accession_number)` —
+same shape as `spac_unit_terms`, so the S-1's registered promote and a
+424B1/424B4's final promote compare across extractor ids. Extraction rides the
+shared offering-sections runner (`runOfferingSections`, SPAC-only) so both the
+S-1 and priced-424 pipelines populate it; the `sponsor-promote` entry in
+`EVAL_EXTRACTORS` ranks the prompt through `sec eval extract`.
+
 > Note: the version ceremonies `coverage` / `drop-previous` and the batch `resolve`
 > command are **not** supported for the family-tier resolver kinds
 > (`underwriter-family`, `sponsor-family`) — they intentionally error rather than
@@ -352,8 +387,21 @@ item codes (known SPACs only — a `spac` row must already exist): item `1.01` �
 (recomputed from the event stream on every write, so `deal_index` is stable
 across replays) and roll up automatically. `target_name`, `pipe_amount`, and
 redemption amounts stay null until the narrative/AI extractors (S-4 / DEFM14A /
-425) land — 8-K item codes carry no names or amounts. Still deferred: name/SIC/
-ticker transitions and Form 25/15 de-registration.
+425) land — 8-K item codes carry no names or amounts. Still deferred: Form 25/15
+de-registration.
+
+**De-SPAC linkage.** When a deal reaches `completed`, the issuer is linked to its
+post-merger surviving entity. The rollup (`buildSpacRow`) derives `surviving_name`
+from the completed deal's `target_name` (the combined company is named after the
+target) and promotes it onto `current_name`. On the item-2.01 8-K,
+`SpacReportWriter.recordDeSpacLinkage` additionally reads the SPAC CIK's own
+post-close `entity` / `entity_tickers` metadata — the shell keeps its CIK and
+renames, so `current_cik` stays null (it differs only for the deferred newco/S-4
+case) while `surviving_name` / `post_merger_sic` / `post_merger_tickers` come from
+the renamed entity (each set only when it diverges from the SPAC-era value, so
+replays are order-safe). Entity metadata usually refreshes *after* the 2.01 8-K,
+so `sec spac backfill-despac` re-runs the linkage over every completed SPAC to
+fill the still-null slots from now-current entity data.
 
 **Merger proxies** (`DEFM14A`/`PREM14A`, the `DEFM14C`/`PREM14C` consent statements,
 and the `DEFR14A`/`PRER14A` revised proxies; extractor id `merger-proxy`) run
@@ -440,6 +488,7 @@ sec eval extract --extractor loi --models "claude-sonnet-5,onnx-community/LFM2.5
 ```bash
 sec spac report <cik> [--format json]   # consolidated report
 sec spac history <cik> [--format json]  # state-change history
+sec spac backfill-despac [--dry-run]    # refresh post-merger identity for completed SPACs
 ```
 
 ### Generalized extractor backfill

--- a/src/commands/spac.ts
+++ b/src/commands/spac.ts
@@ -9,6 +9,7 @@ import { globalServiceRegistry } from "workglow";
 import { withCli } from "@workglow/cli";
 import { isDryRun } from "../cli/isDryRun";
 import { SpacRepo } from "../storage/spac/SpacRepo";
+import { SpacReportWriter } from "../storage/spac/SpacReportWriter";
 import { SPAC_SPONSOR_LINK_REPOSITORY_TOKEN } from "../storage/canonical/SpacSponsorLinkSchema";
 import { UNDERWRITER_LINK_REPOSITORY_TOKEN } from "../storage/canonical/UnderwriterLinkSchema";
 import { BackfillExtractorTask } from "../task/forms/BackfillExtractorTask";
@@ -115,6 +116,46 @@ export function registerSpacCommands(program: Command): void {
           `${h.valid_from} [${h.status ?? "-"}] via ${h.change_source}${h.valid_to ? "" : " (current)"}`
         );
       }
+    });
+
+  // De-SPAC linkage refresh: the item-2.01 8-K that closes a combination is
+  // usually processed BEFORE the surviving entity's renamed submissions land, so
+  // post_merger_* start null. This re-runs the linkage over every completed SPAC
+  // from now-current entity metadata (idempotent; fills the still-null slots).
+  spacCmd
+    .command("backfill-despac")
+    .description(
+      "Refresh post-merger identity (surviving name / SIC / tickers) for completed SPACs " +
+        "from current entity metadata"
+    )
+    .option("--dry-run", "Report the completed-SPAC count without writing", false)
+    .action(async (opts: { dryRun?: boolean }) => {
+      const repo = new SpacRepo();
+      const completed = (await repo.getAllSpacs()).filter((s) => s.status === "completed");
+      const dry = opts.dryRun === true || isDryRun();
+      let updated = 0;
+      if (!dry) {
+        const writer = new SpacReportWriter();
+        for (const s of completed) {
+          const before = JSON.stringify([s.surviving_name, s.post_merger_sic, s.post_merger_tickers]);
+          await writer.recordDeSpacLinkage({
+            cik: s.cik,
+            accession_number: "despac-refresh",
+            // Anchor at the row's own as_of so the refresh is not treated as a
+            // stale write and can apply the entity-sourced values.
+            filing_date: s.as_of ?? s.completed_date ?? "",
+            form: "8-K",
+          });
+          const after = await repo.getSpac(s.cik);
+          const now = after
+            ? JSON.stringify([after.surviving_name, after.post_merger_sic, after.post_merger_tickers])
+            : before;
+          if (now !== before) updated++;
+        }
+      }
+      console.log(
+        `selected ${completed.length} completed SPAC(s); ${dry ? "dry-run" : `updated ${updated}`}`
+      );
     });
 
   // Historical aliases for `sec extractor backfill <id>` — same generalized

--- a/src/config/DefaultDI.ts
+++ b/src/config/DefaultDI.ts
@@ -211,6 +211,11 @@ import {
   SpacUnitTermsSchema,
 } from "../storage/offering/SpacUnitTermsSchema";
 import {
+  SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN,
+  SpacPromoteTermsPrimaryKeyNames,
+  SpacPromoteTermsSchema,
+} from "../storage/offering/SpacPromoteTermsSchema";
+import {
   ISSUER_TICKER_REPOSITORY_TOKEN,
   IssuerTickerPrimaryKeyNames,
   IssuerTickerSchema,
@@ -932,6 +937,12 @@ export const DefaultDI = () => {
   globalServiceRegistry.registerInstance(
     SPAC_UNIT_TERMS_REPOSITORY_TOKEN,
     createStorage("spac_unit_terms", SpacUnitTermsSchema, SpacUnitTermsPrimaryKeyNames, [["cik"]])
+  );
+  globalServiceRegistry.registerInstance(
+    SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN,
+    createStorage("spac_promote_terms", SpacPromoteTermsSchema, SpacPromoteTermsPrimaryKeyNames, [
+      ["cik"],
+    ])
   );
   globalServiceRegistry.registerInstance(
     ISSUER_TICKER_REPOSITORY_TOKEN,

--- a/src/config/TestingDI.ts
+++ b/src/config/TestingDI.ts
@@ -209,6 +209,11 @@ import {
   SpacUnitTermsSchema,
 } from "../storage/offering/SpacUnitTermsSchema";
 import {
+  SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN,
+  SpacPromoteTermsPrimaryKeyNames,
+  SpacPromoteTermsSchema,
+} from "../storage/offering/SpacPromoteTermsSchema";
+import {
   ISSUER_TICKER_REPOSITORY_TOKEN,
   IssuerTickerPrimaryKeyNames,
   IssuerTickerSchema,
@@ -838,6 +843,10 @@ export function resetDependencyInjectionsForTesting() {
   globalServiceRegistry.registerInstance(
     SPAC_UNIT_TERMS_REPOSITORY_TOKEN,
     new InMemoryTabularStorage(SpacUnitTermsSchema, SpacUnitTermsPrimaryKeyNames, [["cik"]])
+  );
+  globalServiceRegistry.registerInstance(
+    SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN,
+    new InMemoryTabularStorage(SpacPromoteTermsSchema, SpacPromoteTermsPrimaryKeyNames, [["cik"]])
   );
   globalServiceRegistry.registerInstance(
     ISSUER_TICKER_REPOSITORY_TOKEN,

--- a/src/config/registerModels.ts
+++ b/src/config/registerModels.ts
@@ -339,6 +339,7 @@ function secModelIds(): string[] {
   const ids = new Set<string>([SecModelDefault, SecHftModelDefault]);
   for (const key of [
     "SEC_S1_MODEL",
+    "SEC_S1_CLASSIFIER_MODEL",
     "SEC_MERGER_PROXY_MODEL",
     "SEC_REDEMPTION_MODEL",
     "SEC_LOI_MODEL",

--- a/src/config/resetAllDatabases.ts
+++ b/src/config/resetAllDatabases.ts
@@ -82,6 +82,7 @@ import {
 import { ISSUER_TICKER_REPOSITORY_TOKEN } from "../storage/offering/IssuerTickerSchema";
 import { OFFERING_TERMS_REPOSITORY_TOKEN } from "../storage/offering/OfferingTermsSchema";
 import { SPAC_UNIT_TERMS_REPOSITORY_TOKEN } from "../storage/offering/SpacUnitTermsSchema";
+import { SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN } from "../storage/offering/SpacPromoteTermsSchema";
 import { OBSERVATION_PROVENANCE_REPOSITORY_TOKEN } from "../storage/provenance/ObservationProvenanceSchema";
 import { RELATED_PARTY_TRANSACTION_REPOSITORY_TOKEN } from "../storage/related-party/RelatedPartyTransactionSchema";
 import {
@@ -161,6 +162,7 @@ export async function resetAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(ISSUER_TICKER_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(OFFERING_TERMS_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(SPAC_UNIT_TERMS_REPOSITORY_TOKEN).deleteAll();
+  await globalServiceRegistry.get(SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(USE_OF_PROCEEDS_REPOSITORY_TOKEN).deleteAll();
   await globalServiceRegistry.get(XBRL_FACT_REPOSITORY_TOKEN).deleteAll();
   // SPAC lifecycle: derived `spac` row + append-only deal/event/extraction tables.

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -69,6 +69,7 @@ import { SPONSOR_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN } from "../storage/canonical
 import { SPAC_SPONSOR_LINK_REPOSITORY_TOKEN } from "../storage/canonical/SpacSponsorLinkSchema";
 import { OFFERING_TERMS_REPOSITORY_TOKEN } from "../storage/offering/OfferingTermsSchema";
 import { SPAC_UNIT_TERMS_REPOSITORY_TOKEN } from "../storage/offering/SpacUnitTermsSchema";
+import { SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN } from "../storage/offering/SpacPromoteTermsSchema";
 import { ISSUER_TICKER_REPOSITORY_TOKEN } from "../storage/offering/IssuerTickerSchema";
 import { CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalUnderwriterFamilySchema";
 import { UNDERWRITER_FAMILY_MEMBERSHIP_REPOSITORY_TOKEN } from "../storage/canonical/UnderwriterFamilyMembershipSchema";
@@ -184,6 +185,7 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(SPAC_SPONSOR_LINK_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(OFFERING_TERMS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(SPAC_UNIT_TERMS_REPOSITORY_TOKEN).setupDatabase();
+  await globalServiceRegistry.get(SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(ISSUER_TICKER_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(CANONICAL_UNDERWRITER_FAMILY_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry

--- a/src/eval/fixtures.ts
+++ b/src/eval/fixtures.ts
@@ -11,6 +11,8 @@ import {
   extractManagement,
   extractOfferingTerms,
   extractRelatedParty,
+  extractSpacClassification,
+  extractSponsorPromote,
 } from "../sec/forms/registration-statements/s1/sectionExtractors";
 
 /**
@@ -76,6 +78,34 @@ export const EVAL_EXTRACTORS: Record<string, EvalExtractor> = {
       "right_fraction_per_unit",
       "trust_per_unit",
     ],
+    instructionOverheadChars: 1300,
+  },
+  // Single-object extractor over a SPAC "The Offering" / "The Sponsor" section;
+  // positional alignment (no keyField). Scored on the objective promote figures.
+  "sponsor-promote": {
+    run: async (text, model) => {
+      const row = await extractSponsorPromote(text, model);
+      return row === null ? [] : [row];
+    },
+    compareFields: [
+      "founder_shares",
+      "founder_percent",
+      "private_placement_warrants",
+      "public_warrant_coverage",
+      "trust_per_public_share",
+    ],
+    instructionOverheadChars: 1400,
+  },
+  // Detection-style classifier over a registration filing's summary prose: a
+  // true SPAC yields one row; a shell or operating company yields none, so a
+  // fixture with `expected: []` scores a false positive as lost precision.
+  "spac-classification": {
+    run: async (text, model) => {
+      const row = await extractSpacClassification(text, model);
+      return row === null ? [] : [row];
+    },
+    keyField: "entity_kind",
+    compareFields: ["is_spac", "entity_kind"],
     instructionOverheadChars: 1300,
   },
   // Detection-style single-object extractor over a known-SPAC 8-K narrative:
@@ -167,7 +197,71 @@ const LOI_NEG_TRUST = `Item 8.01 Other Events.
 
 On January 20, 2026, the Company announced that, in order to extend the period of time it has to consummate its initial business combination by three months, its sponsor deposited $1,725,000 into the Company's trust account. The Company has not yet selected a business combination target and has not, nor has anyone on its behalf, initiated any substantive discussions with any business combination target.`;
 
+/**
+ * SPAC prospectus "The Offering" / "The Sponsor" prose for the `sponsor-promote`
+ * extractor. A customary 20% founder promote, half-warrant public coverage, and
+ * a $10.00 trust deposit, with the sponsor's private-placement warrants at $1.00.
+ */
+const SPONSOR_PROMOTE_STANDARD = `The Offering
+
+We are offering 20,000,000 units at a price of $10.00 per unit. Each unit consists of one Class A ordinary share and one-half of one redeemable warrant. Each whole warrant entitles the holder to purchase one Class A ordinary share at a price of $11.50 per share.
+
+Founder Shares. Our sponsor currently holds 5,000,000 Class B ordinary shares (the "founder shares"). The founder shares will represent 20% of our issued and outstanding shares after this offering.
+
+Private Placement Warrants. Simultaneously with the closing of this offering, our sponsor has agreed to purchase an aggregate of 10,000,000 private placement warrants at a price of $1.00 per warrant, generating gross proceeds of $10,000,000.
+
+Trust Account. A total of $200,000,000 (or $10.00 per public share) will be deposited into a trust account established for the benefit of our public shareholders.`;
+
+/**
+ * A richer offering where the sponsor over-funds the trust to $10.20 per share
+ * and the private-placement warrants are priced at $1.50.
+ */
+const SPONSOR_PROMOTE_OVERFUNDED = `The Offering
+
+This is an offering of 25,000,000 units at $10.00 per unit. Each unit is comprised of one Class A ordinary share and one-third of one redeemable warrant.
+
+The Sponsor. Our sponsor owns 6,250,000 founder shares, representing approximately 20% of our outstanding ordinary shares following the completion of this offering. Our sponsor has committed to purchase 8,000,000 private placement warrants at $1.50 per warrant.
+
+Of the net proceeds of this offering and the private placement, $255,000,000, or $10.20 per public share, will be placed in the trust account.`;
+
+/**
+ * Registration-summary prose for the `spac-classification` extractor: a true
+ * blank-check SPAC (positive), a dormant reverse-merger shell (negative), and an
+ * ordinary operating company (negative). The classifier must fire ONLY on the
+ * true SPAC — the whole point is to catch a SIC-miscoded SPAC without
+ * mislabeling a shell or an operating business.
+ */
+const CLASSIFY_TRUE_SPAC = `Prospectus Summary
+
+We are a blank check company incorporated in the Cayman Islands as an exempted company and formed for the purpose of effecting a merger, share exchange, asset acquisition, share purchase, reorganization or similar business combination with one or more businesses. We have not selected any specific business combination target. A total of $200,000,000 will be deposited into a trust account for the benefit of our public shareholders. Our sponsor has purchased founder shares and private placement warrants.`;
+
+const CLASSIFY_SHELL = `Prospectus Summary
+
+We are a shell company with no current operations. We were previously engaged in mineral exploration, which we discontinued in 2021. We intend to identify and complete a reverse merger with an existing operating company that has already been identified by our management. We do not maintain a trust account and this is not a blank check offering.`;
+
+const CLASSIFY_OPERATING = `Prospectus Summary
+
+We are a leading designer and manufacturer of precision industrial pumps used in the oil and gas, chemical and water-treatment industries. Founded in 2004, we generated revenue of $312 million in the most recent fiscal year and operate four manufacturing facilities across North America. This prospectus relates to the initial public offering of our common stock.`;
+
 export const EVAL_FIXTURES: readonly EvalFixture[] = [
+  {
+    name: "spac-classification-true-spac",
+    extractor: "spac-classification",
+    text: CLASSIFY_TRUE_SPAC,
+    expected: [{ is_spac: true, entity_kind: "spac" }],
+  },
+  {
+    name: "spac-classification-negative-shell",
+    extractor: "spac-classification",
+    text: CLASSIFY_SHELL,
+    expected: [],
+  },
+  {
+    name: "spac-classification-negative-operating",
+    extractor: "spac-classification",
+    text: CLASSIFY_OPERATING,
+    expected: [],
+  },
   {
     name: "s1-management-operating-company",
     extractor: "management",
@@ -190,6 +284,34 @@ export const EVAL_FIXTURES: readonly EvalFixture[] = [
       { full_name: "Jonathan P. Reyes", titles: ["Chief Executive Officer", "Director"] },
       { full_name: "Aisha Nwosu", titles: ["Chief Financial Officer"] },
       { full_name: "Robert Kaminski", titles: ["Chairman of the Board of Directors"] },
+    ],
+  },
+  {
+    name: "sponsor-promote-standard-20pct",
+    extractor: "sponsor-promote",
+    text: SPONSOR_PROMOTE_STANDARD,
+    expected: [
+      {
+        founder_shares: 5000000,
+        founder_percent: 0.2,
+        private_placement_warrants: 10000000,
+        public_warrant_coverage: 0.5,
+        trust_per_public_share: 10.0,
+      },
+    ],
+  },
+  {
+    name: "sponsor-promote-overfunded-trust",
+    extractor: "sponsor-promote",
+    text: SPONSOR_PROMOTE_OVERFUNDED,
+    expected: [
+      {
+        founder_shares: 6250000,
+        founder_percent: 0.2,
+        private_placement_warrants: 8000000,
+        public_warrant_coverage: 0.3333,
+        trust_per_public_share: 10.2,
+      },
     ],
   },
   {

--- a/src/sec/forms/miscellaneous-filings/Form_8_K.storage.ts
+++ b/src/sec/forms/miscellaneous-filings/Form_8_K.storage.ts
@@ -119,6 +119,17 @@ export async function processForm8K({
         primary_document: null,
         events: spacEvents,
       });
+      // De-SPAC linkage: item 2.01 completes the combination — link the shell to
+      // its post-merger identity from the CIK's own post-close entity metadata.
+      // Runs after the milestone write so the row's status is already `completed`.
+      if (spacEvents.some((e) => e.event_type === "completed")) {
+        await new SpacReportWriter().recordDeSpacLinkage({
+          cik,
+          accession_number,
+          filing_date,
+          form,
+        });
+      }
     }
   }
 

--- a/src/sec/forms/miscellaneous-filings/spac8kMilestones.test.ts
+++ b/src/sec/forms/miscellaneous-filings/spac8kMilestones.test.ts
@@ -7,6 +7,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { resetDependencyInjectionsForTesting } from "../../../config/TestingDI";
 import { setupAllDatabases } from "../../../config/setupAllDatabases";
+import { EntityRepo } from "../../../storage/entity/EntityRepo";
 import { SpacRepo } from "../../../storage/spac/SpacRepo";
 import { SpacReportWriter } from "../../../storage/spac/SpacReportWriter";
 import { Form_8_K } from "./Form_8_K";
@@ -93,6 +94,36 @@ describe("processForm8K SPAC milestone wiring", () => {
     const deals = await repo.getDeals(100);
     expect(deals.length).toBe(1);
     expect(deals[0].outcome).toBe("completed");
+  });
+
+  it("links post-merger identity from entity metadata on the item 2.01 close", async () => {
+    await seedSpac(150);
+    // Post-close submissions have renamed the surviving operating company.
+    await new EntityRepo().saveEntity({
+      cik: 150,
+      name: "Combined Operating Co, Inc.",
+      type: null,
+      sic: 3711,
+      ein: null,
+      description: null,
+      website: null,
+      investor_website: null,
+      category: null,
+      fiscal_year: null,
+      state_incorporation: null,
+      state_incorporation_desc: null,
+    });
+    await new EntityRepo().saveEntityTicker({ cik: 150, ticker: "COCO", exchange: "NASDAQ" });
+
+    await run8K(150, "150-close", "2.01", "2021-06-15");
+
+    const row = await repo.getSpac(150);
+    expect(row?.status).toBe("completed");
+    expect(row?.surviving_name).toBe("Combined Operating Co, Inc.");
+    expect(row?.current_name).toBe("Combined Operating Co, Inc.");
+    expect(row?.post_merger_sic).toBe(3711);
+    expect(JSON.parse(row!.post_merger_tickers!)).toEqual(["COCO"]);
+    expect(row?.spac_name).toBe("Test SPAC"); // shell name preserved
   });
 
   it("writes no SPAC events for a CIK with no spac row", async () => {

--- a/src/sec/forms/registration-statements/Form_S_1.storage.classifier.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.classifier.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetDependencyInjectionsForTesting } from "../../../config/TestingDI";
+import { setupAllDatabases } from "../../../config/setupAllDatabases";
+import { S1ClassificationRepo } from "../../../storage/classification/S1ClassificationRepo";
+import { SpacRepo } from "../../../storage/spac/SpacRepo";
+import { processFormS1 } from "./Form_S_1.storage";
+import { fakeS1Model, registerFakeStructuredProvider } from "./s1/testing/fakeStructuredProvider";
+
+// A Prospectus Summary section with dense blank-check vocabulary (trips the
+// content heuristic) so the AI classifier runs.
+const BLANK_CHECK_SUMMARY_HTML = [
+  "<h1>PROSPECTUS SUMMARY</h1>",
+  "<p>We are a blank check company incorporated as a Cayman Islands exempted company " +
+    "for the purpose of effecting an initial business combination. A total of $200,000,000 " +
+    "will be deposited into the trust account for the benefit of our public shareholders. " +
+    "Our sponsor holds founder shares.</p>",
+].join("");
+
+// An ordinary operating-company summary — no blank-check vocabulary, so the
+// heuristic never fires and no AI classification call is made.
+const OPERATING_SUMMARY_HTML = [
+  "<h1>PROSPECTUS SUMMARY</h1>",
+  "<p>We design and manufacture industrial pumps for the energy sector. We have been " +
+    "profitable since 2019 and operate three factories.</p>",
+].join("");
+
+// A non-6770 (miscoded-eligible) SIC so the deterministic path yields is_spac=false.
+const MISCODED_HEADER = {
+  sic: 6199,
+  sicDescription: "FINANCE SERVICES",
+  cik: 1900001,
+  companyName: "Nebula Capital Corp",
+  filingDate: "20260102",
+};
+
+let cleanup: (() => void) | undefined;
+
+describe("processFormS1 AI SPAC classifier", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("upgrades a SIC-miscoded blank-check filing to a known SPAC via the ai seam", async () => {
+    const { unregister } = registerFakeStructuredProvider([
+      { is_spac: true, entity_kind: "spac", confidence: 0.95, source_span: "blank check company" },
+    ]);
+    cleanup = unregister;
+
+    await processFormS1({
+      cik: 1900001,
+      file_number: "333-9",
+      accession_number: "0000000000-26-000009",
+      filing_date: "2026-01-02",
+      primary_doc: "s1.htm",
+      form: "S-1",
+      formS1: {
+        header: MISCODED_HEADER,
+        html: BLANK_CHECK_SUMMARY_HTML,
+        xbrlInstanceXml: null,
+        feeExhibitHtml: null,
+      },
+      model: fakeS1Model(),
+    });
+
+    const cls = await new S1ClassificationRepo().get("S-1", "0000000000-26-000009");
+    expect(cls?.is_spac).toBe(true);
+    expect(cls?.classifier_source).toBe("ai");
+    // The upgrade mints a known-SPAC row so de-SPAC lifecycle extractors can attach.
+    expect(await new SpacRepo().getSpac(1900001)).toBeDefined();
+  });
+
+  it("leaves a blank-check-looking filing unclassified when the model says not-a-SPAC", async () => {
+    const { unregister } = registerFakeStructuredProvider([
+      { is_spac: false, entity_kind: "operating", confidence: 0.9, source_span: null },
+    ]);
+    cleanup = unregister;
+
+    await processFormS1({
+      cik: 1900002,
+      file_number: "333-10",
+      accession_number: "0000000000-26-000010",
+      filing_date: "2026-01-02",
+      primary_doc: "s1.htm",
+      form: "S-1",
+      formS1: {
+        header: { ...MISCODED_HEADER, cik: 1900002 },
+        html: BLANK_CHECK_SUMMARY_HTML,
+        xbrlInstanceXml: null,
+        feeExhibitHtml: null,
+      },
+      model: fakeS1Model(),
+    });
+
+    const cls = await new S1ClassificationRepo().get("S-1", "0000000000-26-000010");
+    expect(cls?.is_spac).toBe(false);
+    // Not upgraded: the deterministic source stands, and no SPAC row is minted.
+    expect(cls?.classifier_source).toBe("sgml-header");
+    expect(await new SpacRepo().getSpac(1900002)).toBeUndefined();
+  });
+
+  it("never invokes the classifier for a non-blank-check operating-company S-1", async () => {
+    const provider = registerFakeStructuredProvider([
+      { is_spac: true, entity_kind: "spac", confidence: 0.99, source_span: "blank check company" },
+    ]);
+    cleanup = provider.unregister;
+
+    await processFormS1({
+      cik: 1900003,
+      file_number: "333-11",
+      accession_number: "0000000000-26-000011",
+      filing_date: "2026-01-02",
+      primary_doc: "s1.htm",
+      form: "S-1",
+      formS1: {
+        header: { ...MISCODED_HEADER, cik: 1900003 },
+        html: OPERATING_SUMMARY_HTML,
+        xbrlInstanceXml: null,
+        feeExhibitHtml: null,
+      },
+      model: fakeS1Model(),
+    });
+
+    // Heuristic never tripped → no classification model call, no upgrade.
+    expect(provider.calls.length).toBe(0);
+    const cls = await new S1ClassificationRepo().get("S-1", "0000000000-26-000011");
+    expect(cls?.is_spac).toBe(false);
+    expect(await new SpacRepo().getSpac(1900003)).toBeUndefined();
+  });
+});

--- a/src/sec/forms/registration-statements/Form_S_1.storage.offering.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.offering.test.ts
@@ -10,6 +10,7 @@ import { setupAllDatabases } from "../../../config/setupAllDatabases";
 import { IssuerTickerRepo } from "../../../storage/offering/IssuerTickerRepo";
 import { OfferingTermsRepo } from "../../../storage/offering/OfferingTermsRepo";
 import { SpacUnitTermsRepo } from "../../../storage/offering/SpacUnitTermsRepo";
+import { SpacPromoteTermsRepo } from "../../../storage/offering/SpacPromoteTermsRepo";
 import { processFormS1 } from "./Form_S_1.storage";
 import { fakeS1Model, registerFakeStructuredProvider } from "./s1/testing/fakeStructuredProvider";
 
@@ -156,5 +157,84 @@ describe("processFormS1 offering terms", () => {
     expect(await new OfferingTermsRepo().get("S-1", "0000000000-26-000002")).toBeUndefined();
     const history = await new IssuerTickerRepo().history(1848507);
     expect(history.map((t) => t.ticker).sort()).toEqual(["ACQ", "ACQU", "ACQW"]);
+  });
+
+  it("writes sponsor promote terms for a SPAC filing", async () => {
+    // Call order inside a SPAC S-1 with only The Offering + Underwriting present:
+    // offering-terms (1), sponsor-promote (2), underwriters (3). Use-of-proceeds
+    // and the profile/sponsor sections are absent (SECTION_NOT_FOUND, no call).
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        security_type: "Units",
+        units_offered: 20000000,
+        price_per_unit: 10,
+        confidence: 0.9,
+        source_span: "5,000,000 shares",
+        tickers: [{ ticker: "ACQU", exchange: "NASDAQ", security_type: "Units", is_primary: true }],
+      },
+      {
+        founder_shares: 5000000,
+        founder_percent: 0.2,
+        private_placement_warrants: 10000000,
+        private_placement_warrant_price: 1.0,
+        public_warrant_coverage: 0.5,
+        trust_per_public_share: 10.0,
+        trust_total: 200000000,
+        confidence: 0.9,
+        source_span: "5,000,000 shares",
+      },
+      { underwriters: [] },
+    ]);
+    cleanup = unregister;
+
+    await processFormS1({
+      cik: 1848507,
+      file_number: "333-3",
+      accession_number: "0000000000-26-000003",
+      filing_date: "2026-01-02",
+      primary_doc: "s1.htm",
+      form: "S-1",
+      formS1: {
+        header: SPAC_HEADER,
+        html: OFFERING_HTML,
+        xbrlInstanceXml: null,
+        feeExhibitHtml: null,
+      },
+      model: fakeS1Model(),
+    });
+
+    const promote = await new SpacPromoteTermsRepo().get("S-1", "0000000000-26-000003");
+    expect(promote?.founder_shares).toBe(5000000);
+    expect(promote?.founder_percent).toBe(0.2);
+    expect(promote?.private_placement_warrants).toBe(10000000);
+    expect(promote?.public_warrant_coverage).toBe(0.5);
+    expect(promote?.trust_per_public_share).toBe(10.0);
+    expect(promote?.trust_total).toBe(200000000);
+  });
+
+  it("skips promote for a non-SPAC filing", async () => {
+    const { unregister } = registerFakeStructuredProvider([
+      { security_type: "Common Stock", confidence: 0.9, source_span: "5,000,000 shares", tickers: [] },
+      { underwriters: [] },
+    ]);
+    cleanup = unregister;
+
+    await processFormS1({
+      cik: 1018724,
+      file_number: "333-4",
+      accession_number: "0000000000-26-000004",
+      filing_date: "2026-01-02",
+      primary_doc: "s1.htm",
+      form: "S-1",
+      formS1: {
+        header: NULL_HEADER,
+        html: OFFERING_HTML,
+        xbrlInstanceXml: null,
+        feeExhibitHtml: null,
+      },
+      model: fakeS1Model(),
+    });
+
+    expect(await new SpacPromoteTermsRepo().get("S-1", "0000000000-26-000004")).toBeUndefined();
   });
 });

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -30,9 +30,16 @@ import {
   extractBeneficialOwnership,
   extractManagement,
   extractRelatedParty,
+  extractSpacClassification,
   extractSpacProfile,
   extractSpacSponsors,
 } from "./s1/sectionExtractors";
+import type { SpacClassificationRow } from "./s1/spacClassifierSchema";
+import { looksLikeBlankCheck } from "./s1/spacContentHeuristic";
+import {
+  getSpacClassifierConfidenceFloor,
+  getSpacClassifierModel,
+} from "./s1/spacClassifierModel";
 import type { SpacProfileRow } from "./s1/spacProfileSchema";
 import type { BeneficialOwnerRow, ManagementPersonRow, RelatedPartyRow } from "./s1/sectionSchemas";
 import { makeRunSection } from "./s1/sectionRunner";
@@ -163,7 +170,10 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
 
   // --- Deterministic SPAC classification from the SGML-header SIC ---
   const headerSic = formS1.header?.sic ?? null;
-  const isSpac = headerSic === 6770;
+  // Mutable: the AI content classifier below can upgrade a SIC-miscoded SPAC
+  // from false → true after segmentation, before the registration/profile/
+  // offering blocks read it.
+  let isSpac = headerSic === 6770;
   await new S1ClassificationRepo().save({
     extractor_id: EXTRACTOR_ID,
     accession_number,
@@ -216,6 +226,11 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
       S1_SECTIONS.RELATED_PARTY,
       ...OFFERING_SECTION_NAMES,
       ...(isSpac ? ["spac-profile", "spac-sponsors"] : []),
+      // A SIC-miscoded, blank-check-looking non-SPAC filing gets a
+      // spac-classification dead-letter so a retry runs the AI classifier once a
+      // model is available. Gated on the cheap heuristic over the raw HTML so an
+      // ordinary S-1 does not flood the worklist.
+      ...(!isSpac && looksLikeBlankCheck(formS1.html) ? ["spac-classification"] : []),
     ];
     for (const section of sectionNames) {
       await recordFail(section, "MODEL_RESOLUTION_ERROR", modelError);
@@ -248,6 +263,7 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
       S1_SECTIONS.RELATED_PARTY,
       ...OFFERING_SECTION_NAMES,
       ...(isSpac ? ["spac-profile", "spac-sponsors"] : []),
+      ...(!isSpac && looksLikeBlankCheck(formS1.html) ? ["spac-classification"] : []),
     ];
     for (const section of sectionNames) {
       await recordFail(section, "PARSE_ERROR", detail);
@@ -269,6 +285,85 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
   // but the original entity blocks only checked `=== undefined`. Section text
   // sourced directly from `byName` is never the empty string (the segmenter
   // emits non-empty section bodies), so the two checks coincide in practice.
+
+  // --- AI SPAC content classification (SIC-miscoded upgrade path) ---
+  // The deterministic classifier above only flags SIC == 6770. A SPAC filed
+  // under a miscoded/absent SIC would be missed, so — when the filing was NOT
+  // already classified as a SPAC and its summary prose is blank-check-like (the
+  // cheap heuristic keeps the AI call rare, reserved for plausibly miscoded
+  // filings) — run an AI content classifier behind the `classifier_source =
+  // "ai"` seam. A confident SPAC verdict upgrades the local flag AND overwrites
+  // the classification row, so the registration / profile / offering blocks
+  // below treat it as a known SPAC and its de-SPAC 8-K milestones can attach.
+  if (!isSpac) {
+    const classifyText = byName.get(S1_SECTIONS.PROSPECTUS_SUMMARY) ?? "";
+    if (looksLikeBlankCheck(classifyText)) {
+      let classifierModel: ModelConfig | null = null;
+      let classifierError: string | null = null;
+      try {
+        classifierModel = args.model ?? (await getSpacClassifierModel());
+      } catch (err) {
+        classifierError = err instanceof Error ? err.message : String(err);
+      }
+      if (classifierModel === null) {
+        await recordFail("spac-classification", "MODEL_RESOLUTION_ERROR", classifierError);
+      } else {
+        const classifierModelResolved = classifierModel;
+        const classifierHolder = { upgraded: false };
+        const classifierRunSection = makeRunSection({
+          deadLetters,
+          extractor_id: EXTRACTOR_ID,
+          extractor_version,
+          accession_number,
+          confidenceFloor: getSpacClassifierConfidenceFloor(),
+        });
+        await classifierRunSection<SpacClassificationRow>({
+          sectionName: "spac-classification",
+          text: classifyText,
+          emptyDetail: "not classified as a SPAC",
+          lowConfidenceDetail: "SPAC classification below confidence floor",
+          verifyRow: (text, r) => verifyRowSpan(text, r.source_span),
+          unverifiedAllDetail:
+            "the confident SPAC classification had source_span not present in section text",
+          extract: async (text) => {
+            const c = await extractSpacClassification(text, classifierModelResolved);
+            return c === null ? [] : [c];
+          },
+          persist: async () => {
+            classifierHolder.upgraded = true;
+            return 1;
+          },
+        });
+        if (classifierHolder.upgraded) {
+          isSpac = true;
+          await new S1ClassificationRepo().save({
+            extractor_id: EXTRACTOR_ID,
+            accession_number,
+            cik,
+            sic: headerSic,
+            sic_description: formS1.header?.sicDescription ?? null,
+            is_spac: true,
+            classifier_source: "ai",
+            created_at: new Date().toISOString(),
+          });
+        } else {
+          // "Not a miscoded SPAC" is the expected outcome — auto-resolve the
+          // MODEL_EMPTY entry so a confident negative doesn't linger on the
+          // version-gated retry worklist (mirrors the LOI detector). A genuine
+          // problem (LOW_CONFIDENCE_ALL / UNVERIFIED_SOURCE_SPAN / NONCE_MISMATCH)
+          // stays pending.
+          const entry = await deadLetters.get(
+            EXTRACTOR_ID,
+            accession_number,
+            "spac-classification"
+          );
+          if (entry?.reason_code === "MODEL_EMPTY") {
+            await deadLetters.markResolved(EXTRACTOR_ID, accession_number, "spac-classification");
+          }
+        }
+      }
+    }
+  }
 
   // --- SPAC profile (gated) → registration event + row ---
   // Runs before the base registration write so the AI-extracted focus /

--- a/src/sec/forms/registration-statements/s1/extractSponsorPromote.test.ts
+++ b/src/sec/forms/registration-statements/s1/extractSponsorPromote.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { extractSponsorPromote } from "./sectionExtractors";
+import { fakeS1Model, registerFakeStructuredProvider } from "./testing/fakeStructuredProvider";
+
+let cleanup: (() => void) | undefined;
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+describe("extractSponsorPromote", () => {
+  it("returns the parsed promote row", async () => {
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        founder_shares: 5000000,
+        founder_percent: 0.2,
+        private_placement_warrants: 10000000,
+        private_placement_warrant_price: 1.0,
+        public_warrant_coverage: 0.5,
+        trust_per_public_share: 10.0,
+        trust_total: 200000000,
+        confidence: 0.92,
+        source_span: "our sponsor currently holds 5,000,000 Class B ordinary shares",
+      },
+    ]);
+    cleanup = unregister;
+    const text = "Our sponsor currently holds 5,000,000 Class B ordinary shares (the founder shares).";
+    const row = await extractSponsorPromote(text, fakeS1Model());
+    expect(row).not.toBeNull();
+    expect(row?.founder_shares).toBe(5000000);
+    expect(row?.founder_percent).toBe(0.2);
+    expect(row?.private_placement_warrants).toBe(10000000);
+    expect(row?.public_warrant_coverage).toBe(0.5);
+    expect(row?.trust_per_public_share).toBe(10.0);
+    expect(row?.trust_total).toBe(200000000);
+  });
+
+  it("returns null when the model cites no source span", async () => {
+    // A null source_span drops the row even at high confidence — there is no
+    // verbatim anchor for the figures, so the section runner cannot verify it.
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        founder_shares: 1,
+        founder_percent: null,
+        private_placement_warrants: null,
+        private_placement_warrant_price: null,
+        public_warrant_coverage: null,
+        trust_per_public_share: null,
+        trust_total: null,
+        confidence: 0.95,
+        source_span: null,
+      },
+    ]);
+    cleanup = unregister;
+    const row = await extractSponsorPromote("no promote here", fakeS1Model());
+    expect(row).toBeNull();
+  });
+
+  it("passes through a partial disclosure (only some figures stated)", async () => {
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        founder_shares: null,
+        founder_percent: 0.2,
+        private_placement_warrants: null,
+        private_placement_warrant_price: null,
+        public_warrant_coverage: null,
+        trust_per_public_share: 10.2,
+        trust_total: null,
+        confidence: 0.8,
+        source_span: "$10.20 per public share will be deposited into the trust account",
+      },
+    ]);
+    cleanup = unregister;
+    const row = await extractSponsorPromote(
+      "$10.20 per public share will be deposited into the trust account.",
+      fakeS1Model()
+    );
+    expect(row).not.toBeNull();
+    expect(row?.founder_shares).toBeNull();
+    expect(row?.founder_percent).toBe(0.2);
+    expect(row?.trust_per_public_share).toBe(10.2);
+  });
+});

--- a/src/sec/forms/registration-statements/s1/offeringSections.ts
+++ b/src/sec/forms/registration-statements/s1/offeringSections.ts
@@ -13,6 +13,7 @@ import { UnderwriterFamilyMembershipRepo } from "../../../../storage/canonical/U
 import { UnderwriterLinkRepo } from "../../../../storage/canonical/UnderwriterLinkRepo";
 import { OfferingTermsRepo } from "../../../../storage/offering/OfferingTermsRepo";
 import { SpacUnitTermsRepo } from "../../../../storage/offering/SpacUnitTermsRepo";
+import { SpacPromoteTermsRepo } from "../../../../storage/offering/SpacPromoteTermsRepo";
 import { IssuerTickerRepo } from "../../../../storage/offering/IssuerTickerRepo";
 import type { ObservationProvenanceRepo } from "../../../../storage/provenance/ObservationProvenanceRepo";
 import { UseOfProceedsRepo } from "../../../../storage/use-of-proceeds/UseOfProceedsRepo";
@@ -20,9 +21,11 @@ import { S1_SECTIONS, type S1SectionName } from "./DocumentSegmenter";
 import type { OfferingTermsRow } from "./offeringTermsSchema";
 import {
   extractOfferingTerms,
+  extractSponsorPromote,
   extractUnderwriters,
   extractUseOfProceeds,
 } from "./sectionExtractors";
+import type { SponsorPromoteRow } from "./sponsorPromoteSchema";
 import type { RunSection } from "./sectionRunner";
 import type { UnderwriterRowOut } from "./underwriterSchema";
 import type { UseOfProceedsLineRow } from "./useOfProceedsSchema";
@@ -31,6 +34,7 @@ import { boundSourceSpan, verifyRowSpan } from "./verifySourceSpan";
 /** Section names used by the offering-related dead letters. */
 export const OFFERING_SECTION_NAMES = [
   "offering-terms",
+  "sponsor-promote",
   "underwriters",
   "use-of-proceeds",
 ] as const;
@@ -93,6 +97,7 @@ export async function runOfferingSections(args: OfferingSectionsArgs): Promise<v
 
   const offeringTermsRepo = new OfferingTermsRepo();
   const spacUnitTermsRepo = new SpacUnitTermsRepo();
+  const spacPromoteTermsRepo = new SpacPromoteTermsRepo();
   const issuerTickerRepo = new IssuerTickerRepo();
   const useOfProceedsRepo = new UseOfProceedsRepo();
   const underwriterFamilyResolver = new UnderwriterFamilyResolver({
@@ -191,6 +196,55 @@ export async function runOfferingSections(args: OfferingSectionsArgs): Promise<v
           created_at: now,
         });
       }
+      return 1;
+    },
+  });
+
+  // --- Sponsor promote economics (SPAC only) ---
+  // Founder-share promote, private-placement warrant coverage, and trust sizing.
+  // These live in "The Offering" and "The Sponsor" prose; read both (falling back
+  // to the concatenated offering/underwriting text when a dedicated sponsor
+  // heading is absent). Skipped for non-SPAC filings.
+  const promoteText = [
+    byName.get(S1_SECTIONS.THE_OFFERING),
+    byName.get(S1_SECTIONS.THE_SPONSOR),
+    byName.get(S1_SECTIONS.PROSPECTUS_SUMMARY),
+  ]
+    .filter((t): t is string => typeof t === "string")
+    .join("\n\n");
+  await runSection<SponsorPromoteRow>({
+    sectionName: "sponsor-promote",
+    skip: !isSpac,
+    text: promoteText,
+    notFoundDetail: "no The Offering / The Sponsor / Prospectus Summary section text",
+    emptyDetail: "no sponsor promote terms returned",
+    lowConfidenceDetail: "below confidence floor",
+    // Prompt-injection backstop: refuse to persist a promote row whose
+    // source_span is not a verbatim substring of the section text.
+    verifyRow: (text, r) => verifyRowSpan(text, r.source_span),
+    unverifiedAllDetail:
+      "all $T confident sponsor-promote rows had source_span not present in section text",
+    extract: async (text) => {
+      const promote = await extractSponsorPromote(text, model);
+      return promote === null ? [] : [promote];
+    },
+    persist: async (rows) => {
+      const promote = rows[0];
+      await spacPromoteTermsRepo.save({
+        extractor_id,
+        accession_number,
+        cik,
+        founder_shares: toIntCount(promote.founder_shares),
+        founder_percent: promote.founder_percent,
+        private_placement_warrants: toIntCount(promote.private_placement_warrants),
+        private_placement_warrant_price: promote.private_placement_warrant_price,
+        public_warrant_coverage: promote.public_warrant_coverage,
+        trust_per_public_share: promote.trust_per_public_share,
+        trust_total: promote.trust_total,
+        confidence: promote.confidence,
+        source_span: boundSourceSpan(promote.source_span),
+        created_at: new Date().toISOString(),
+      });
       return 1;
     },
   });

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.ts
@@ -21,6 +21,13 @@ import {
   type SpacProfileRow,
 } from "./spacProfileSchema";
 import { OfferingTermsOutputSchema, type OfferingTermsRow } from "./offeringTermsSchema";
+import { SponsorPromoteOutputSchema, type SponsorPromoteRow } from "./sponsorPromoteSchema";
+import {
+  SPAC_ENTITY_KINDS,
+  SpacClassificationOutputSchema,
+  type SpacClassificationRow,
+  type SpacEntityKind,
+} from "./spacClassifierSchema";
 import { UnderwriterOutputSchema, type UnderwriterRowOut } from "./underwriterSchema";
 import { UseOfProceedsOutputSchema, type UseOfProceedsLineRow } from "./useOfProceedsSchema";
 import { MergerDealOutputSchema, type MergerDealRow } from "./mergerDealSchema";
@@ -517,6 +524,53 @@ export async function extractOfferingTerms(
   return obj as unknown as OfferingTermsRow;
 }
 
+/**
+ * Extracts SPAC sponsor promote economics from a prospectus's "The Offering" /
+ * "The Sponsor" prose: founder (Class B) shares and their percentage, the
+ * private-placement warrant count / price / public warrant coverage, and the
+ * trust deposit per public share and in total. Returns null when the model is
+ * not confident or cites no source span (mirrors {@link extractOfferingTerms}).
+ */
+export async function extractSponsorPromote(
+  sectionText: string,
+  model: ModelConfig
+): Promise<SponsorPromoteRow | null> {
+  const instructions =
+    "The text between the tags below is from a SPAC (blank-check) prospectus. Extract the " +
+    "SPONSOR PROMOTE ECONOMICS. Give founder_shares (the number of founder / Class B / " +
+    "founders' shares held by the sponsor, or null), founder_percent (those founder shares " +
+    "as a FRACTION of the post-IPO shares outstanding — e.g. 0.20 for 20%, the customary " +
+    "promote — or null), private_placement_warrants (the number of private placement / " +
+    "sponsor warrants purchased, or null), private_placement_warrant_price (the purchase " +
+    "price per private placement warrant in dollars, e.g. 1.00 or 1.50, or null), " +
+    "public_warrant_coverage (the warrant fraction included with each PUBLIC unit — e.g. " +
+    "0.5 for one-half of a redeemable warrant per unit — or null), trust_per_public_share " +
+    "(the amount deposited into the trust account per public share in dollars, e.g. 10.00 " +
+    "or 10.20, or null), and trust_total (the total dollar amount held in trust, or null). " +
+    "Report only figures explicitly stated; do NOT compute a percentage or a total the " +
+    "text does not state. Give a confidence in [0,1] and the verbatim source_span you drew " +
+    "the figures from. Return JSON matching the schema.";
+  const obj = await runGuardedExtraction(
+    model,
+    instructions,
+    sectionText,
+    SponsorPromoteOutputSchema
+  );
+  if (obj.confidence == null || obj.source_span == null) return null;
+  return {
+    founder_shares: (obj.founder_shares as number | null) ?? null,
+    founder_percent: (obj.founder_percent as number | null) ?? null,
+    private_placement_warrants: (obj.private_placement_warrants as number | null) ?? null,
+    private_placement_warrant_price:
+      (obj.private_placement_warrant_price as number | null) ?? null,
+    public_warrant_coverage: (obj.public_warrant_coverage as number | null) ?? null,
+    trust_per_public_share: (obj.trust_per_public_share as number | null) ?? null,
+    trust_total: (obj.trust_total as number | null) ?? null,
+    confidence: obj.confidence as number,
+    source_span: obj.source_span as string,
+  };
+}
+
 export async function extractUnderwriters(
   sectionText: string,
   model: ModelConfig
@@ -581,6 +635,51 @@ export async function extractSpacProfile(
     description: (obj.description as string | null) ?? null,
     team: (obj.team as string | null) ?? null,
     url_spac: (obj.url_spac as string | null) ?? null,
+    confidence: obj.confidence as number,
+    source_span: obj.source_span as string,
+  };
+}
+
+/**
+ * Content-classifies a registration filing whose SGML-header SIC was NOT the
+ * deterministic blank-check code, to catch SIC-miscoded SPACs and distinguish a
+ * true SPAC from an ordinary shell or operating company. Returns null when the
+ * model is not confident, cites no source span, or does not classify the filing
+ * as a SPAC (`is_spac === false`) — so a confident "not a SPAC" yields no row,
+ * mirroring the LOI detector. An `entity_kind` outside the allowed set is
+ * coerced to null → dropped, so a hallucinated kind never flips the flag.
+ */
+export async function extractSpacClassification(
+  sectionText: string,
+  model: ModelConfig
+): Promise<SpacClassificationRow | null> {
+  const instructions =
+    "The text between the tags below is prose from a company's SEC registration " +
+    "statement (an S-1 / F-1 / DRS). Classify what KIND of issuer it is. Set entity_kind " +
+    "to 'spac' ONLY for a true special-purpose acquisition company / blank-check company: " +
+    "a newly formed entity with no operations that raised (or is raising) an IPO to hold " +
+    "the proceeds in a trust account and later acquire an unidentified operating business " +
+    "(an 'initial business combination'). Set entity_kind to 'shell' for a non-operating " +
+    "shell that is NOT a blank-check IPO vehicle (e.g. a dormant company, or a shell used " +
+    "for a reverse merger with an already-identified business). Set entity_kind to " +
+    "'operating' for a company with a real, existing line of business. Set is_spac true " +
+    "if and only if entity_kind is 'spac'. Give a confidence in [0,1] and the verbatim " +
+    "source_span you drew the determination from (null only if is_spac is false). Return " +
+    "JSON matching the schema.";
+  const obj = await runGuardedExtraction(
+    model,
+    instructions,
+    sectionText,
+    SpacClassificationOutputSchema
+  );
+  if (obj.is_spac !== true) return null;
+  const kind = obj.entity_kind;
+  if (typeof kind !== "string" || !SPAC_ENTITY_KINDS.includes(kind as SpacEntityKind)) return null;
+  if (kind !== "spac") return null;
+  if (obj.confidence == null || obj.source_span == null) return null;
+  return {
+    is_spac: true,
+    entity_kind: "spac",
     confidence: obj.confidence as number,
     source_span: obj.source_span as string,
   };

--- a/src/sec/forms/registration-statements/s1/spacClassifier.test.ts
+++ b/src/sec/forms/registration-statements/s1/spacClassifier.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { extractSpacClassification } from "./sectionExtractors";
+import { looksLikeBlankCheck } from "./spacContentHeuristic";
+import { fakeS1Model, registerFakeStructuredProvider } from "./testing/fakeStructuredProvider";
+
+let cleanup: (() => void) | undefined;
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+describe("looksLikeBlankCheck", () => {
+  it("fires on dense blank-check vocabulary", () => {
+    const text =
+      "We are a blank check company incorporated to effect an initial business combination. " +
+      "A total of $200,000,000 will be deposited into the trust account.";
+    expect(looksLikeBlankCheck(text)).toBe(true);
+  });
+
+  it("does not fire on a lone business-combination mention", () => {
+    const text =
+      "We manufacture industrial pumps. A future business combination could dilute holders " +
+      "of our common stock, as described in the risk factors.";
+    expect(looksLikeBlankCheck(text)).toBe(false);
+  });
+
+  it("returns false for empty text", () => {
+    expect(looksLikeBlankCheck("")).toBe(false);
+  });
+
+  it("honors a higher minSignals threshold", () => {
+    const text = "We are a blank check company with founder shares held by the sponsor.";
+    // Three signals: blank check, founder shares, our sponsor? ("the sponsor" != "our sponsor")
+    expect(looksLikeBlankCheck(text, 2)).toBe(true);
+    expect(looksLikeBlankCheck(text, 5)).toBe(false);
+  });
+});
+
+describe("extractSpacClassification", () => {
+  it("returns a row for a confident SPAC verdict", async () => {
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        is_spac: true,
+        entity_kind: "spac",
+        confidence: 0.95,
+        source_span: "blank check company",
+      },
+    ]);
+    cleanup = unregister;
+    const row = await extractSpacClassification(
+      "We are a blank check company with a trust account.",
+      fakeS1Model()
+    );
+    expect(row).not.toBeNull();
+    expect(row?.is_spac).toBe(true);
+    expect(row?.entity_kind).toBe("spac");
+  });
+
+  it("returns null for a confident non-SPAC verdict", async () => {
+    const { unregister } = registerFakeStructuredProvider([
+      { is_spac: false, entity_kind: "operating", confidence: 0.9, source_span: null },
+    ]);
+    cleanup = unregister;
+    const row = await extractSpacClassification("We manufacture pumps.", fakeS1Model());
+    expect(row).toBeNull();
+  });
+
+  it("returns null for a shell that is not a blank-check vehicle", async () => {
+    // entity_kind "shell" (dormant / reverse-merger shell) is NOT a SPAC — the
+    // classifier must not flip is_spac even if the model set is_spac true by
+    // mistake; the entity_kind guard drops it.
+    const { unregister } = registerFakeStructuredProvider([
+      { is_spac: true, entity_kind: "shell", confidence: 0.9, source_span: "shell company" },
+    ]);
+    cleanup = unregister;
+    const row = await extractSpacClassification("A dormant shell company.", fakeS1Model());
+    expect(row).toBeNull();
+  });
+});

--- a/src/sec/forms/registration-statements/s1/spacClassifierModel.ts
+++ b/src/sec/forms/registration-statements/s1/spacClassifierModel.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ModelConfig } from "workglow";
+import { getGlobalModelRepository } from "workglow";
+import { SecModelDefault } from "../../../../config/Constants";
+import { resolveModelId } from "./s1Model";
+import { CONFIDENCE_FLOOR, parseConfidenceFloor } from "./sectionRunner";
+
+export { resolveModelId };
+
+/** The model id used for the SPAC content classifier; overridable via SEC_S1_CLASSIFIER_MODEL. */
+export function getSpacClassifierModelId(): string {
+  const id = (process.env.SEC_S1_CLASSIFIER_MODEL ?? "").trim();
+  return id === "" ? SecModelDefault : id;
+}
+
+/** Resolves the configured SPAC-classifier model into a ModelConfig. */
+export async function getSpacClassifierModel(): Promise<ModelConfig> {
+  const id = getSpacClassifierModelId();
+  const record = await getGlobalModelRepository().findByName(id);
+  if (!record) {
+    throw new Error(
+      `SPAC classifier model '${id}' is not registered. Register it or set ` +
+        `SEC_S1_CLASSIFIER_MODEL to a known model id.`
+    );
+  }
+  return record as ModelConfig;
+}
+
+/**
+ * Confidence floor for the SPAC content classifier. `SEC_S1_CLASSIFIER_CONFIDENCE_FLOOR`
+ * overrides; when unset it falls back to the shared `CONFIDENCE_FLOOR`
+ * (`SEC_S1_CONFIDENCE_FLOOR`). A miscoded-SPAC upgrade is a consequential write
+ * (it mints a known-SPAC row), so operators can raise this to demand a stronger
+ * signal than the general S-1 floor.
+ */
+export function getSpacClassifierConfidenceFloor(): number {
+  return parseConfidenceFloor(process.env.SEC_S1_CLASSIFIER_CONFIDENCE_FLOOR, CONFIDENCE_FLOOR);
+}

--- a/src/sec/forms/registration-statements/s1/spacClassifierSchema.ts
+++ b/src/sec/forms/registration-statements/s1/spacClassifierSchema.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DataPortSchema } from "workglow";
+
+/**
+ * Entity kinds the content classifier distinguishes. `spac` is a true
+ * blank-check acquisition vehicle; `shell` is a non-operating shell that is NOT
+ * a blank-check IPO vehicle (e.g. a dormant reverse-merger shell); `operating`
+ * is a real operating business. Only `spac` flips a miscoded filing to is_spac.
+ */
+export const SPAC_ENTITY_KINDS = ["spac", "shell", "operating"] as const;
+export type SpacEntityKind = (typeof SPAC_ENTITY_KINDS)[number];
+
+/**
+ * The single classification object the model returns for a registration filing
+ * whose SGML-header SIC was NOT the deterministic blank-check code (6770). Used
+ * to catch SIC-miscoded SPACs and distinguish a true SPAC from an ordinary shell
+ * or operating company (mirrors the single-object detection extractors).
+ */
+export const SpacClassificationOutputSchema = {
+  type: "object",
+  properties: {
+    is_spac: {
+      type: "boolean",
+    },
+    entity_kind: { type: "string", enum: SPAC_ENTITY_KINDS },
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+    source_span: { type: ["string", "null"] },
+    nonce_seen: { type: "string", pattern: "^[0-9a-f]{16}$" },
+  },
+  required: ["is_spac", "entity_kind", "confidence", "nonce_seen"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export interface SpacClassificationRow {
+  is_spac: boolean;
+  entity_kind: SpacEntityKind;
+  confidence: number;
+  source_span: string;
+}

--- a/src/sec/forms/registration-statements/s1/spacContentHeuristic.ts
+++ b/src/sec/forms/registration-statements/s1/spacContentHeuristic.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Strong blank-check / SPAC signal phrases. A genuine SPAC prospectus repeats
+ * this vocabulary densely; an ordinary operating company that merely mentions a
+ * "business combination" once in a risk factor does not. Matching is
+ * case-insensitive and whitespace-insensitive (the prose is rendered from HTML,
+ * so runs of whitespace vary).
+ */
+const BLANK_CHECK_SIGNALS: readonly RegExp[] = [
+  /blank[\s-]*check/i,
+  /special[\s-]+purpose[\s-]+acquisition/i,
+  /initial[\s-]+business[\s-]+combination/i,
+  /trust[\s-]+account/i,
+  /redeem[\w]*\s+(?:their|its|the)?\s*public[\s-]+shares/i,
+  /founder[\s-]+shares/i,
+  /our[\s-]+sponsor/i,
+];
+
+/**
+ * Cheap deterministic pre-filter that decides whether a registration filing's
+ * prose is SPAC-like enough to be worth an AI content-classification call. Only
+ * used for filings the deterministic SIC path did NOT already classify as a SPAC
+ * (SIC ≠ 6770), so the AI call stays rare — reserved for plausibly miscoded
+ * filings rather than every S-1. Requires at least `minSignals` DISTINCT strong
+ * blank-check signals so a single stray "business combination" in an operating
+ * company's risk factors does not trip it.
+ */
+export function looksLikeBlankCheck(text: string, minSignals = 2): boolean {
+  if (!text) return false;
+  let hits = 0;
+  for (const re of BLANK_CHECK_SIGNALS) {
+    if (re.test(text)) {
+      hits += 1;
+      if (hits >= minSignals) return true;
+    }
+  }
+  return false;
+}

--- a/src/sec/forms/registration-statements/s1/sponsorPromoteSchema.ts
+++ b/src/sec/forms/registration-statements/s1/sponsorPromoteSchema.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DataPortSchema } from "workglow";
+
+const NULLABLE_NUMBER = { type: ["number", "null"] } as const;
+const NULLABLE_STRING = { type: ["string", "null"] } as const;
+
+/**
+ * One sponsor-promote object, extracted from a SPAC prospectus's "The Offering" /
+ * "The Sponsor" prose: founder-share promote, private-placement warrant coverage,
+ * and trust sizing. Every figure is nullable — a filing that discloses only some
+ * of them yields the rest as null (mirrors {@link OfferingTermsOutputSchema}).
+ */
+export const SponsorPromoteOutputSchema = {
+  type: "object",
+  properties: {
+    founder_shares: NULLABLE_NUMBER,
+    founder_percent: NULLABLE_NUMBER,
+    private_placement_warrants: NULLABLE_NUMBER,
+    private_placement_warrant_price: NULLABLE_NUMBER,
+    public_warrant_coverage: NULLABLE_NUMBER,
+    trust_per_public_share: NULLABLE_NUMBER,
+    trust_total: NULLABLE_NUMBER,
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+    // Nullable so a model that finds no promote disclosure returns a null span
+    // (→ the section runner records MODEL_EMPTY) instead of failing validation.
+    source_span: NULLABLE_STRING,
+    nonce_seen: { type: "string", pattern: "^[0-9a-f]{16}$" },
+  },
+  required: ["confidence", "nonce_seen"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export interface SponsorPromoteRow {
+  founder_shares: number | null;
+  founder_percent: number | null;
+  private_placement_warrants: number | null;
+  private_placement_warrant_price: number | null;
+  public_warrant_coverage: number | null;
+  trust_per_public_share: number | null;
+  trust_total: number | null;
+  confidence: number;
+  source_span: string;
+}

--- a/src/storage/offering/SpacPromoteTermsRepo.test.ts
+++ b/src/storage/offering/SpacPromoteTermsRepo.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { SpacPromoteTermsRepo } from "./SpacPromoteTermsRepo";
+import type { SpacPromoteTerms } from "./SpacPromoteTermsSchema";
+
+function row(
+  p: Partial<SpacPromoteTerms> &
+    Pick<SpacPromoteTerms, "extractor_id" | "accession_number" | "cik">
+): SpacPromoteTerms {
+  return {
+    founder_shares: null,
+    founder_percent: null,
+    private_placement_warrants: null,
+    private_placement_warrant_price: null,
+    public_warrant_coverage: null,
+    trust_per_public_share: null,
+    trust_total: null,
+    confidence: 0.9,
+    source_span: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    ...p,
+  };
+}
+
+describe("SpacPromoteTermsRepo", () => {
+  let repo: SpacPromoteTermsRepo;
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+    repo = new SpacPromoteTermsRepo();
+  });
+
+  it("round-trips a row and overwrites by (extractor_id, accession)", async () => {
+    await repo.save(row({ extractor_id: "S-1", accession_number: "a1", cik: 5, founder_shares: 100 }));
+    await repo.save(row({ extractor_id: "S-1", accession_number: "a1", cik: 5, founder_shares: 200 }));
+    expect((await repo.get("S-1", "a1"))?.founder_shares).toBe(200);
+  });
+
+  it("keeps the S-1 registered and 424 final promote as distinct rows", async () => {
+    await repo.save(
+      row({ extractor_id: "S-1", accession_number: "a1", cik: 5, trust_per_public_share: 10.0 })
+    );
+    await repo.save(
+      row({ extractor_id: "424", accession_number: "a2", cik: 5, trust_per_public_share: 10.2 })
+    );
+    const rows = await repo.listByCik(5);
+    expect(rows.length).toBe(2);
+    expect((await repo.get("S-1", "a1"))?.trust_per_public_share).toBe(10.0);
+    expect((await repo.get("424", "a2"))?.trust_per_public_share).toBe(10.2);
+  });
+
+  it("returns [] for a CIK with no promote rows", async () => {
+    expect(await repo.listByCik(99)).toEqual([]);
+  });
+});

--- a/src/storage/offering/SpacPromoteTermsRepo.ts
+++ b/src/storage/offering/SpacPromoteTermsRepo.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import {
+  SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN,
+  type SpacPromoteTerms,
+  type SpacPromoteTermsRepositoryStorage,
+} from "./SpacPromoteTermsSchema";
+
+export class SpacPromoteTermsRepo {
+  private readonly storage: SpacPromoteTermsRepositoryStorage;
+
+  constructor(storage?: SpacPromoteTermsRepositoryStorage) {
+    this.storage = storage ?? globalServiceRegistry.get(SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN);
+  }
+
+  async save(row: SpacPromoteTerms): Promise<void> {
+    await this.storage.put(row);
+  }
+
+  async get(extractor_id: string, accession_number: string): Promise<SpacPromoteTerms | undefined> {
+    return this.storage.get({ extractor_id, accession_number });
+  }
+
+  /** All rows for an issuer (across extractor ids and filings), newest extract first. */
+  async listByCik(cik: number): Promise<SpacPromoteTerms[]> {
+    const rows = (await this.storage.query({ cik })) ?? [];
+    return rows.sort(
+      (a, b) =>
+        b.created_at.localeCompare(a.created_at) ||
+        b.accession_number.localeCompare(a.accession_number)
+    );
+  }
+}

--- a/src/storage/offering/SpacPromoteTermsSchema.ts
+++ b/src/storage/offering/SpacPromoteTermsSchema.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Static, Type } from "typebox";
+import type { ITabularStorage } from "workglow";
+import { createServiceToken } from "workglow";
+import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
+import { TypeNullable } from "../../util/TypeBoxUtil";
+
+/**
+ * Sponsor promote economics for a SPAC filing (one row per SPAC prospectus).
+ * Captures the founder-share promote, private-placement warrant coverage, and
+ * trust sizing the S-1/424 discloses — the figures that quantify sponsor
+ * incentives and public-share dilution. Keyed `(extractor_id, accession_number)`
+ * like the other offering tables so an S-1's registered promote and a 424's
+ * final promote can be compared across extractor ids.
+ */
+export const SpacPromoteTermsSchema = Type.Object({
+  extractor_id: Type.String({ maxLength: 16 }),
+  accession_number: Type.String({ maxLength: 25 }),
+  cik: TypeNullable(TypeSecCik()),
+  // Founder (Class B / promote) shares.
+  founder_shares: TypeNullable(Type.Integer()),
+  founder_percent: TypeNullable(
+    Type.Number({ description: "Founder shares as a fraction of post-IPO shares (e.g. 0.20)" })
+  ),
+  // Private-placement (sponsor) warrants + public warrant coverage.
+  private_placement_warrants: TypeNullable(Type.Integer()),
+  private_placement_warrant_price: TypeNullable(Type.Number()),
+  public_warrant_coverage: TypeNullable(
+    Type.Number({ description: "Warrant fraction per public unit (e.g. 0.5)" })
+  ),
+  // Trust sizing.
+  trust_per_public_share: TypeNullable(
+    Type.Number({ description: "Amount deposited in trust per public share (e.g. 10.20)" })
+  ),
+  trust_total: TypeNullable(Type.Number({ description: "Total amount held in trust" })),
+  confidence: TypeNullable(Type.Number()),
+  source_span: TypeNullable(Type.String()),
+  created_at: Type.String(),
+});
+export type SpacPromoteTerms = Static<typeof SpacPromoteTermsSchema>;
+
+export const SpacPromoteTermsPrimaryKeyNames = ["extractor_id", "accession_number"] as const;
+
+export type SpacPromoteTermsRepositoryStorage = ITabularStorage<
+  typeof SpacPromoteTermsSchema,
+  typeof SpacPromoteTermsPrimaryKeyNames,
+  SpacPromoteTerms
+>;
+
+export const SPAC_PROMOTE_TERMS_REPOSITORY_TOKEN =
+  createServiceToken<SpacPromoteTermsRepositoryStorage>("sec.storage.spacPromoteTermsRepository");

--- a/src/storage/spac/SpacReportWriter.deSpac.test.ts
+++ b/src/storage/spac/SpacReportWriter.deSpac.test.ts
@@ -85,6 +85,105 @@ describe("SpacReportWriter.recordDeSpacLinkage", () => {
     expect(row?.spac_sic).toBe(6770);
   });
 
+  it("is a write-once snapshot: a later rebrand does not mutate populated linkage", async () => {
+    const cik = 703;
+    await registerAndComplete(cik);
+    await entities.saveEntity({
+      cik,
+      name: "NewCo Industries, Inc.",
+      type: null,
+      sic: 3711,
+      ein: null,
+      description: null,
+      website: null,
+      investor_website: null,
+      category: null,
+      fiscal_year: null,
+      state_incorporation: null,
+      state_incorporation_desc: null,
+    });
+    await entities.saveEntityTicker({ cik, ticker: "NEWCO", exchange: "NASDAQ" });
+    await writer.recordDeSpacLinkage({
+      cik,
+      accession_number: `${cik}-close`,
+      filing_date: "2021-06-16",
+      form: "8-K",
+    });
+
+    // The issuer later rebrands (and re-tickers). A subsequent linkage refresh
+    // must NOT overwrite the close-time snapshot.
+    await entities.saveEntity({
+      cik,
+      name: "Rebranded Holdings, Inc.",
+      type: null,
+      sic: 3714,
+      ein: null,
+      description: null,
+      website: null,
+      investor_website: null,
+      category: null,
+      fiscal_year: null,
+      state_incorporation: null,
+      state_incorporation_desc: null,
+    });
+    await entities.saveEntityTicker({ cik, ticker: "RBHI", exchange: "NASDAQ" });
+    await writer.recordDeSpacLinkage({
+      cik,
+      accession_number: `${cik}-refresh`,
+      filing_date: "2022-01-01",
+      form: "8-K",
+    });
+
+    const row = await repo.getSpac(cik);
+    expect(row?.surviving_name).toBe("NewCo Industries, Inc.");
+    expect(row?.post_merger_sic).toBe(3711);
+    expect(JSON.parse(row!.post_merger_tickers!)).toEqual(["NEWCO"]);
+  });
+
+  it("does not populate post_merger_tickers when the symbols mirror the SPAC-era tickers", async () => {
+    const cik = 704;
+    await writer.recordRegistration({
+      cik,
+      accession_number: `${cik}-reg`,
+      filing_date: "2020-12-01",
+      form: "S-1",
+      primary_document: "s1.htm",
+      spac_name: "Shell Acquisition Corp",
+      spac_sic: 6770,
+    });
+    await writer.recordIpo({
+      cik,
+      accession_number: `${cik}-ipo`,
+      filing_date: "2021-01-15",
+      form: "424B4",
+      primary_document: "424.htm",
+      ipo_proceeds: 200_000_000,
+      trust_amount: 200_000_000,
+      spac_tickers: ["SHELL"],
+    });
+    await writer.recordDealMilestones({
+      cik,
+      accession_number: `${cik}-close`,
+      filing_date: "2021-06-16",
+      form: "8-K",
+      primary_document: null,
+      events: [{ event_type: "completed", event_date: "2021-06-15" }],
+    });
+    // Entity tickers still carry the SPAC-era symbol (submissions not yet updated).
+    await entities.saveEntityTicker({ cik, ticker: "SHELL", exchange: "NASDAQ" });
+
+    await writer.recordDeSpacLinkage({
+      cik,
+      accession_number: `${cik}-close`,
+      filing_date: "2021-06-16",
+      form: "8-K",
+    });
+
+    const row = await repo.getSpac(cik);
+    // The SPAC-era symbol must not leak into the post-merger snapshot.
+    expect(row?.post_merger_tickers).toBeNull();
+  });
+
   it("no-ops when the SPAC has not completed a combination", async () => {
     const cik = 701;
     await writer.recordRegistration({

--- a/src/storage/spac/SpacReportWriter.deSpac.test.ts
+++ b/src/storage/spac/SpacReportWriter.deSpac.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { EntityRepo } from "../entity/EntityRepo";
+import { SpacRepo } from "./SpacRepo";
+import { SpacReportWriter } from "./SpacReportWriter";
+
+describe("SpacReportWriter.recordDeSpacLinkage", () => {
+  let repo: SpacRepo;
+  let writer: SpacReportWriter;
+  let entities: EntityRepo;
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+    repo = new SpacRepo();
+    writer = new SpacReportWriter();
+    entities = new EntityRepo();
+  });
+
+  async function registerAndComplete(cik: number): Promise<void> {
+    await writer.recordRegistration({
+      cik,
+      accession_number: `${cik}-reg`,
+      filing_date: "2020-12-01",
+      form: "S-1",
+      primary_document: "s1.htm",
+      spac_name: "Shell Acquisition Corp",
+      spac_sic: 6770,
+    });
+    await writer.recordDealMilestones({
+      cik,
+      accession_number: `${cik}-close`,
+      filing_date: "2021-06-16",
+      form: "8-K",
+      primary_document: null,
+      events: [{ event_type: "completed", event_date: "2021-06-15" }],
+    });
+  }
+
+  it("links post-merger name / SIC / tickers from the CIK's own entity metadata", async () => {
+    const cik = 700;
+    await registerAndComplete(cik);
+    // Post-close submissions have refreshed the entity to the renamed operating company.
+    await entities.saveEntity({
+      cik,
+      name: "NewCo Industries, Inc.",
+      type: null,
+      sic: 3711,
+      ein: null,
+      description: null,
+      website: null,
+      investor_website: null,
+      category: null,
+      fiscal_year: null,
+      state_incorporation: null,
+      state_incorporation_desc: null,
+    });
+    await entities.saveEntityTicker({ cik, ticker: "NEWCO", exchange: "NASDAQ" });
+
+    await writer.recordDeSpacLinkage({
+      cik,
+      accession_number: `${cik}-close`,
+      filing_date: "2021-06-16",
+      form: "8-K",
+    });
+
+    const row = await repo.getSpac(cik);
+    expect(row?.status).toBe("completed");
+    expect(row?.surviving_name).toBe("NewCo Industries, Inc.");
+    expect(row?.current_name).toBe("NewCo Industries, Inc.");
+    expect(row?.post_merger_sic).toBe(3711);
+    expect(row?.current_sic).toBe(3711);
+    expect(JSON.parse(row!.post_merger_tickers!)).toEqual(["NEWCO"]);
+    expect(JSON.parse(row!.current_tickers!)).toEqual(["NEWCO"]);
+    // The shell keeps its CIK in the common case, so current_cik stays null.
+    expect(row?.current_cik).toBeNull();
+    // SPAC-era columns are preserved.
+    expect(row?.spac_name).toBe("Shell Acquisition Corp");
+    expect(row?.spac_sic).toBe(6770);
+  });
+
+  it("no-ops when the SPAC has not completed a combination", async () => {
+    const cik = 701;
+    await writer.recordRegistration({
+      cik,
+      accession_number: `${cik}-reg`,
+      filing_date: "2020-12-01",
+      form: "S-1",
+      primary_document: "s1.htm",
+      spac_name: "Shell Acquisition Corp",
+      spac_sic: 6770,
+    });
+    // Entity renamed but no completion event — linkage must not populate.
+    await entities.saveEntity({
+      cik,
+      name: "Premature NewCo",
+      type: null,
+      sic: 3711,
+      ein: null,
+      description: null,
+      website: null,
+      investor_website: null,
+      category: null,
+      fiscal_year: null,
+      state_incorporation: null,
+      state_incorporation_desc: null,
+    });
+
+    await writer.recordDeSpacLinkage({
+      cik,
+      accession_number: `${cik}-x`,
+      filing_date: "2021-01-01",
+      form: "8-K",
+    });
+
+    const row = await repo.getSpac(cik);
+    expect(row?.status).toBe("registered");
+    expect(row?.surviving_name).toBeNull();
+    expect(row?.post_merger_sic).toBeNull();
+    expect(row?.post_merger_tickers).toBeNull();
+  });
+
+  it("no-ops (leaves post_merger_* null) when entity metadata has not caught up", async () => {
+    const cik = 702;
+    await registerAndComplete(cik);
+    // No entity row saved (submissions not yet refreshed to the rename).
+    await writer.recordDeSpacLinkage({
+      cik,
+      accession_number: `${cik}-close`,
+      filing_date: "2021-06-16",
+      form: "8-K",
+    });
+    const row = await repo.getSpac(cik);
+    expect(row?.status).toBe("completed");
+    expect(row?.post_merger_sic).toBeNull();
+    expect(row?.post_merger_tickers).toBeNull();
+  });
+});

--- a/src/storage/spac/SpacReportWriter.ts
+++ b/src/storage/spac/SpacReportWriter.ts
@@ -15,6 +15,7 @@ import type { Spac } from "./SpacSchema";
 import type { SpacEvent, SpacEventType } from "./SpacEventSchema";
 import type { SpacHistory } from "./SpacHistorySchema";
 import { CHANGE_LOG_REPOSITORY_TOKEN } from "../change-tracking/ChangeLogSchema";
+import { EntityRepo } from "../entity/EntityRepo";
 import { AsyncMutex } from "../../util/AsyncMutex";
 
 /**
@@ -163,9 +164,11 @@ export class SpacReportWriter {
   private readonly repo: SpacRepo;
   private readonly mergerExtractions = new SpacMergerExtractionRepo();
   private readonly redemptionExtractions = new SpacRedemptionExtractionRepo();
+  private readonly entityRepo: EntityRepo;
 
-  constructor(repo: SpacRepo = new SpacRepo()) {
+  constructor(repo: SpacRepo = new SpacRepo(), entityRepo: EntityRepo = new EntityRepo()) {
     this.repo = repo;
+    this.entityRepo = entityRepo;
   }
 
   async recordRegistration(args: RecordRegistrationArgs): Promise<void> {
@@ -308,6 +311,60 @@ export class SpacReportWriter {
     await withCikLock(args.cik, async () => {
       await this.recomputeAndSaveDeals(args.cik);
       await this.rebuild(args.cik, args.filing_date, `${args.form}:${args.accession_number}`, {});
+    });
+  }
+
+  /**
+   * De-SPAC linkage: once a SPAC has completed a business combination, link the
+   * (now operating) shell to its post-merger identity from the CIK's own
+   * post-close entity metadata. In the common case the shell survives legally
+   * and keeps its CIK, renaming to the combined company — so `current_cik` stays
+   * null (it differs only for the deferred newco/S-4 structures) and the
+   * surviving name / SIC / tickers come from the entity + entity_tickers rows.
+   *
+   * Idempotent and order-safe: only enriches a row whose derived status is
+   * already `completed` (the 2.01 milestone landed first), and only sets a field
+   * that diverges from its SPAC-era value, so a replay with stale entity data
+   * cannot regress a populated linkage. No-ops when the entity metadata has not
+   * yet caught up to the rename (post_merger_* stay null until it does).
+   */
+  async recordDeSpacLinkage(args: {
+    readonly cik: number;
+    readonly accession_number: string;
+    readonly filing_date: string;
+    readonly form: string;
+  }): Promise<void> {
+    await withCikLock(args.cik, async () => {
+      const existing = await this.repo.getSpac(args.cik);
+      if (!existing || existing.status !== "completed") return;
+      const [entity, tickers] = await Promise.all([
+        this.entityRepo.getEntity(args.cik),
+        this.entityRepo.getEntityTickers(args.cik),
+      ]);
+      const patch: {
+        surviving_name?: string | null;
+        post_merger_sic?: number | null;
+        post_merger_tickers?: string | null;
+      } = {};
+      // Renamed surviving entity: the current entity name once it diverges from
+      // the blank-check shell name. Overrides the deal-target-derived fallback.
+      if (entity?.name != null && entity.name !== existing.spac_name) {
+        patch.surviving_name = entity.name;
+      }
+      // Operating-company SIC once it diverges from the SPAC-era ~6770.
+      if (entity?.sic != null && entity.sic !== existing.spac_sic) {
+        patch.post_merger_sic = entity.sic;
+      }
+      // New listing symbol(s) — JSON string[] mirroring the spac_tickers shape.
+      const symbols = tickers.map((t) => t.ticker).filter((s): s is string => !!s);
+      if (symbols.length > 0) patch.post_merger_tickers = JSON.stringify(symbols);
+      if (Object.keys(patch).length === 0) return;
+      await this.rebuild(
+        args.cik,
+        args.filing_date,
+        `${args.form}:${args.accession_number}`,
+        patch
+      );
     });
   }
 

--- a/src/storage/spac/SpacReportWriter.ts
+++ b/src/storage/spac/SpacReportWriter.ts
@@ -322,11 +322,15 @@ export class SpacReportWriter {
    * null (it differs only for the deferred newco/S-4 structures) and the
    * surviving name / SIC / tickers come from the entity + entity_tickers rows.
    *
-   * Idempotent and order-safe: only enriches a row whose derived status is
-   * already `completed` (the 2.01 milestone landed first), and only sets a field
-   * that diverges from its SPAC-era value, so a replay with stale entity data
-   * cannot regress a populated linkage. No-ops when the entity metadata has not
-   * yet caught up to the rename (post_merger_* stay null until it does).
+   * These are **close-time snapshots**, written once: each field is set only
+   * when its slot is still empty (or, for `surviving_name`, still holds the
+   * deal-target fallback the rollup derives) AND the entity value diverges from
+   * the SPAC-era value. So a later replay, `backfill-despac` refresh, or a
+   * post-close issuer rebrand cannot mutate an already-populated snapshot, and a
+   * ticker set is never populated with SPAC-era symbols. No-ops when the entity
+   * metadata has not yet caught up to the rename (post_merger_* stay null until
+   * it does). Only enriches a row whose derived status is already `completed`
+   * (the 2.01 milestone landed first).
    */
   async recordDeSpacLinkage(args: {
     readonly cik: number;
@@ -337,27 +341,50 @@ export class SpacReportWriter {
     await withCikLock(args.cik, async () => {
       const existing = await this.repo.getSpac(args.cik);
       if (!existing || existing.status !== "completed") return;
-      const [entity, tickers] = await Promise.all([
+      const [entity, tickers, deals] = await Promise.all([
         this.entityRepo.getEntity(args.cik),
         this.entityRepo.getEntityTickers(args.cik),
+        this.repo.getDeals(args.cik),
       ]);
       const patch: {
         surviving_name?: string | null;
         post_merger_sic?: number | null;
         post_merger_tickers?: string | null;
       } = {};
-      // Renamed surviving entity: the current entity name once it diverges from
-      // the blank-check shell name. Overrides the deal-target-derived fallback.
-      if (entity?.name != null && entity.name !== existing.spac_name) {
+      // Renamed surviving entity: fill from the current entity name once it
+      // diverges from the blank-check shell name. Write-once — upgrade the
+      // deal-target fallback the rollup derived (or fill an empty slot) exactly
+      // once, but never overwrite an already entity-sourced snapshot on a later
+      // replay/rebrand.
+      const dealTargetFallback = deals.find((d) => d.outcome === "completed")?.target_name ?? null;
+      const survivingUpgradeable =
+        existing.surviving_name == null || existing.surviving_name === dealTargetFallback;
+      if (entity?.name != null && entity.name !== existing.spac_name && survivingUpgradeable) {
         patch.surviving_name = entity.name;
       }
-      // Operating-company SIC once it diverges from the SPAC-era ~6770.
-      if (entity?.sic != null && entity.sic !== existing.spac_sic) {
+      // Operating-company SIC once it diverges from the SPAC-era ~6770. Write-once.
+      if (
+        existing.post_merger_sic == null &&
+        entity?.sic != null &&
+        entity.sic !== existing.spac_sic
+      ) {
         patch.post_merger_sic = entity.sic;
       }
       // New listing symbol(s) — JSON string[] mirroring the spac_tickers shape.
-      const symbols = tickers.map((t) => t.ticker).filter((s): s is string => !!s);
-      if (symbols.length > 0) patch.post_merger_tickers = JSON.stringify(symbols);
+      // Write-once, deduped + sorted for determinism, and only when the symbol
+      // set diverges from the SPAC-era tickers (never mirror them here).
+      if (existing.post_merger_tickers == null) {
+        const symbols = [
+          ...new Set(tickers.map((t) => t.ticker).filter((s): s is string => !!s)),
+        ].sort();
+        const spacSymbols = parseTickerArray(existing.spac_tickers);
+        if (
+          symbols.length > 0 &&
+          JSON.stringify(symbols) !== JSON.stringify([...spacSymbols].sort())
+        ) {
+          patch.post_merger_tickers = JSON.stringify(symbols);
+        }
+      }
       if (Object.keys(patch).length === 0) return;
       await this.rebuild(
         args.cik,
@@ -571,4 +598,15 @@ export class SpacReportWriter {
 function serialize(value: unknown): string | null {
   if (value === null || value === undefined) return null;
   return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+/** Parse a JSON-encoded string[] ticker column, tolerating null/garbage as []. */
+function parseTickerArray(raw: string | null): string[] {
+  if (raw == null || raw === "") return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === "string") : [];
+  } catch {
+    return [];
+  }
 }

--- a/src/storage/spac/spacRollup.test.ts
+++ b/src/storage/spac/spacRollup.test.ts
@@ -67,6 +67,63 @@ describe("buildSpacRow", () => {
     expect(row.as_of).toBe("2021-01-15");
   });
 
+  it("derives surviving_name from a completed deal's target (de-SPAC linkage)", () => {
+    const row = buildSpacRow({
+      existing: undefined,
+      cik: 1,
+      deals: [
+        deal({
+          deal_index: 0,
+          outcome: "completed",
+          target_name: "Lucid Motors, Inc.",
+          outcome_date: "2021-07-23",
+        }),
+      ],
+      events: [
+        ev({ event_type: "registration", event_date: "2020-04-30" }),
+        ev({ event_type: "completed", event_date: "2021-07-23" }),
+      ],
+      patch: { spac_name: "Churchill Capital Corp IV", spac_sic: 6770 },
+      filingDate: "2021-07-23",
+    });
+    expect(row.status).toBe("completed");
+    expect(row.completed_date).toBe("2021-07-23");
+    // The combined entity is named after the target; current_name mirrors it.
+    expect(row.surviving_name).toBe("Lucid Motors, Inc.");
+    expect(row.current_name).toBe("Lucid Motors, Inc.");
+    // The shell name is preserved on the SPAC-era column.
+    expect(row.spac_name).toBe("Churchill Capital Corp IV");
+  });
+
+  it("an explicit surviving_name patch (entity-sourced) overrides the deal target", () => {
+    const row = buildSpacRow({
+      existing: undefined,
+      cik: 1,
+      deals: [deal({ deal_index: 0, outcome: "completed", target_name: "Target Co", outcome_date: "2021-06-15" })],
+      events: [ev({ event_type: "completed", event_date: "2021-06-15" })],
+      patch: { spac_name: "Shell SPAC", surviving_name: "Renamed NewCo Inc", post_merger_sic: 3711 },
+      filingDate: "2021-06-15",
+    });
+    expect(row.surviving_name).toBe("Renamed NewCo Inc");
+    expect(row.current_name).toBe("Renamed NewCo Inc");
+    expect(row.post_merger_sic).toBe(3711);
+    expect(row.current_sic).toBe(3711);
+  });
+
+  it("leaves surviving_name null for a still-pending deal", () => {
+    const row = buildSpacRow({
+      existing: undefined,
+      cik: 1,
+      deals: [deal({ deal_index: 0, outcome: "pending", target_name: "Target Co", announced_date: "2021-05-01" })],
+      events: [ev({ event_type: "definitive_agreement", event_date: "2021-05-01" })],
+      patch: { spac_name: "Shell SPAC" },
+      filingDate: "2021-05-01",
+    });
+    expect(row.status).toBe("deal_announced");
+    expect(row.surviving_name).toBeNull();
+    expect(row.current_name).toBe("Shell SPAC");
+  });
+
   it("merges narrative enrichment scalars from the patch", () => {
     const row = buildSpacRow({
       existing: undefined,

--- a/src/storage/spac/spacRollup.ts
+++ b/src/storage/spac/spacRollup.ts
@@ -175,20 +175,44 @@ export function buildSpacRow(input: BuildSpacRowInput): Spac {
   const spac_sic = pick("spac_sic");
   const spac_tickers = pick("spac_tickers");
 
-  // Pre-merger, current_* mirrors spac_* unless a later filing set them explicitly.
-  const surviving_name = pick("surviving_name");
-  const current_name =
-    applied.current_name ?? existing?.current_name ?? surviving_name ?? spac_name;
-  const current_sic =
-    applied.current_sic ?? existing?.current_sic ?? pick("post_merger_sic") ?? spac_sic;
-  const current_tickers =
-    applied.current_tickers ??
-    existing?.current_tickers ??
-    pick("post_merger_tickers") ??
-    spac_tickers;
-
   // Event/deal-derived fields: always recomputed (order-independent, idempotent).
   const active = activeDeal(deals);
+  const completed = active?.outcome === "completed";
+
+  // De-SPAC linkage: a completed business combination links the shell to its
+  // surviving entity. Absent an explicit (entity-sourced) name from a
+  // `recordDeSpacLinkage` patch, the combined company is named after the deal's
+  // target, so derive `surviving_name` from the completed deal's target_name.
+  const survivingExplicit = pick("surviving_name");
+  const surviving_name = survivingExplicit ?? (completed ? (active?.target_name ?? null) : null);
+  const post_merger_sic = pick("post_merger_sic");
+  const post_merger_tickers = pick("post_merger_tickers");
+
+  // current_* is the latest-known identity. Pre-merger it mirrors spac_*; a
+  // completed de-SPAC promotes the surviving / post-merger identity over the
+  // stale mirrored value, so a row that stored current_name = spac_name at
+  // registration reflects the rename once the combination closes. When the
+  // post-merger value is not yet known (no target/entity data), it falls
+  // through to the previously mirrored value.
+  const current_name =
+    applied.current_name ??
+    (completed ? surviving_name : null) ??
+    existing?.current_name ??
+    surviving_name ??
+    spac_name;
+  const current_sic =
+    applied.current_sic ??
+    (completed ? post_merger_sic : null) ??
+    existing?.current_sic ??
+    post_merger_sic ??
+    spac_sic;
+  const current_tickers =
+    applied.current_tickers ??
+    (completed ? post_merger_tickers : null) ??
+    existing?.current_tickers ??
+    post_merger_tickers ??
+    spac_tickers;
+
   const investorPres = latestInvestorPres(events);
   const hasFailed =
     events.some((e) => e.event_type === "liquidation" || e.event_type === "deregistration") &&
@@ -210,10 +234,10 @@ export function buildSpacRow(input: BuildSpacRowInput): Spac {
     surviving_name,
     current_name,
     spac_sic,
-    post_merger_sic: pick("post_merger_sic"),
+    post_merger_sic,
     current_sic,
     spac_tickers,
-    post_merger_tickers: pick("post_merger_tickers"),
+    post_merger_tickers,
     current_tickers,
     ipo_proceeds: pick("ipo_proceeds"),
     trust_amount: pick("trust_amount"),


### PR DESCRIPTION
Implements three SPAC roadmap items, based on `harness`.

## #149 — AI content classifier for miscoded SPACs
`extractSpacClassification` runs behind the existing `S1Classification.classifier_source = "ai"` seam to catch SPACs filed under a miscoded/absent SIC. It runs in `processFormS1` only when the deterministic SIC path did **not** flag the filing **and** a cheap keyword heuristic (`looksLikeBlankCheck`, ≥2 blank-check signals) trips, so the AI call stays rare. A confident `spac` verdict (it distinguishes a true SPAC from `shell`/`operating`) flips `is_spac`, overwrites the classification row as `"ai"`, and mints the known-SPAC row so lifecycle extractors attach. "Not a SPAC" auto-resolves its `MODEL_EMPTY` dead-letter (like the LOI detector); a model-unavailable blank-check filing dead-letters `spac-classification` for retry.
- Config: `SEC_S1_CLASSIFIER_MODEL` / `SEC_S1_CLASSIFIER_CONFIDENCE_FLOOR`; registered in `secModelIds()`; added to `EVAL_EXTRACTORS`.

## #150 — Sponsor promote economics
`extractSponsorPromote` + a new `spac_promote_terms` table capture founder (Class B) shares & percentage, private-placement warrant count/price/public coverage, and trust per-share/total. Keyed `(extractor_id, accession_number)` like `spac_unit_terms`, so S-1-registered and 424-final promote compare across extractor ids. Wired into the shared `runOfferingSections` (SPAC-only) so both S-1 and priced-424 pipelines populate it; added to the eval harness and DI.

## #151 — De-SPAC linkage
On a completed combination, `buildSpacRow` derives `surviving_name`/`current_name` from the deal target, and `SpacReportWriter.recordDeSpacLinkage` (invoked on the item-2.01 8-K) fills `surviving_name`/`post_merger_sic`/`post_merger_tickers` from the SPAC CIK's post-close `entity`/`entity_tickers` metadata — each only when it diverges from the SPAC-era value, so replays stay order-safe. `current_cik` stays null in the common CIK-survives case. New `sec spac backfill-despac` refreshes completed SPACs after submissions catch up.

## Testing
- `npx tsc --noEmit` clean.
- New/updated tests: classifier heuristic + extractor + `processFormS1` integration, sponsor-promote extractor + storage + offering-wiring, de-SPAC rollup + writer + 8-K integration.
- Affected suites green: `src/storage`, `src/config`, `src/task/forms`, `src/sec/forms/registration-statements`, `src/sec/forms/miscellaneous-filings`, `src/eval`.

No new extractor id was added — the classifier reuses `S-1`, promote reuses `S-1`/`424`, de-SPAC linkage rides the `8-K` path. Genuinely separate newco/S-4 CIK linkage remains deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqMBp35YzRXtkJMu4Xa4zm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqMBp35YzRXtkJMu4Xa4zm)_