### PR TITLE
fix(observation): migrate legacy person_observations.title -> titles[] on startup

### DIFF
--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -79,6 +79,7 @@ import { USE_OF_PROCEEDS_REPOSITORY_TOKEN } from "../storage/use-of-proceeds/Use
 import { XBRL_FACT_REPOSITORY_TOKEN } from "../storage/xbrl/XbrlFactSchema";
 import { FORM_8K_EVENT_REPOSITORY_TOKEN } from "../storage/form-8k-event/Form8KEventSchema";
 import { migrateLegacyForm8KEventsTable } from "../storage/form-8k-event/Form8KEventLegacyMigration";
+import { migrateLegacyPersonObservationsTitles } from "../storage/observation/PersonObservationTitleMigration";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
@@ -162,6 +163,7 @@ export async function setupAllDatabases(): Promise<void> {
   await globalServiceRegistry.get(COMPONENT_VERSION_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(VERSION_EVENT_REPOSITORY_TOKEN).setupDatabase();
+  await migrateLegacyPersonObservationsTitles();
   await globalServiceRegistry.get(PERSON_OBSERVATION_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(COMPANY_OBSERVATION_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(OBSERVATION_PROVENANCE_REPOSITORY_TOKEN).setupDatabase();

--- a/src/storage/observation/PersonObservationTitleMigration.test.ts
+++ b/src/storage/observation/PersonObservationTitleMigration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { globalServiceRegistry, Sqlite } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
+import { closeDb, getDb } from "../../util/db";
+import { migrateLegacyPersonObservationsTitles } from "./PersonObservationTitleMigration";
+
+const TEST_DB_NAME = "person_obs_titles_migration_test";
+
+const LEGACY_TABLE_DDL = `
+  CREATE TABLE person_observations (
+    observation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    accession_number TEXT NOT NULL,
+    extractor_id TEXT NOT NULL,
+    extractor_version TEXT NOT NULL,
+    observation_index INTEGER NOT NULL,
+    title TEXT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE (accession_number, extractor_id, observation_index)
+  )
+`;
+
+interface ColumnInfo {
+  readonly name: string;
+}
+
+interface TitleRow {
+  readonly observation_index: number;
+  readonly titles: string | null;
+}
+
+function columnNames(): ReadonlyArray<string> {
+  const db = getDb();
+  return db
+    .prepare<[], ColumnInfo>(`PRAGMA table_info(person_observations)`)
+    .all()
+    .map((c) => c.name);
+}
+
+describe("migrateLegacyPersonObservationsTitles (sqlite)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    closeDb();
+    if (typeof Sqlite.init === "function") {
+      await Sqlite.init();
+    }
+    tmpDir = mkdtempSync(join(tmpdir(), "sec-person-obs-titles-migration-"));
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "sqlite");
+    globalServiceRegistry.registerInstance(SEC_DB_FOLDER, tmpDir);
+    globalServiceRegistry.registerInstance(SEC_DB_NAME, TEST_DB_NAME);
+  });
+
+  afterEach(() => {
+    closeDb();
+    rmSync(tmpDir, { recursive: true, force: true });
+    // Same fix-up dance as Form8KEventLegacyMigration.test: pin SEC_DB_TYPE
+    // to a sentinel so later tests in this Bun process fall through both
+    // dispatch branches back to the in-memory backend.
+    globalServiceRegistry.registerInstance(
+      SEC_DB_TYPE,
+      "memory" as unknown as "sqlite" | "postgres"
+    );
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("rewrites a legacy `title` column into a JSON `titles` array", async () => {
+    const db = getDb();
+    db.exec(LEGACY_TABLE_DDL);
+    const insert = db.prepare(
+      `INSERT INTO person_observations (accession_number, extractor_id, extractor_version, observation_index, title, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+    );
+    insert.run("0001-24-000001", "S-1", "1.0.0", 0, "CEO", "2026-01-15T00:00:00Z");
+    insert.run(
+      "0001-24-000001",
+      "S-1",
+      "1.0.0",
+      1,
+      "Chief Executive Officer and Director",
+      "2026-01-15T00:00:00Z"
+    );
+    insert.run("0001-24-000001", "S-1", "1.0.0", 2, null, "2026-01-15T00:00:00Z");
+
+    await migrateLegacyPersonObservationsTitles();
+
+    const cols = columnNames();
+    expect(cols).toContain("titles");
+    expect(cols).not.toContain("title");
+
+    const rows = db
+      .prepare<
+        [],
+        TitleRow
+      >(`SELECT observation_index, titles FROM person_observations ORDER BY observation_index`)
+      .all();
+    expect(rows).toHaveLength(3);
+    expect(JSON.parse(rows[0]!.titles ?? "null")).toEqual(["CEO"]);
+    expect(JSON.parse(rows[1]!.titles ?? "null")).toEqual(["Chief Executive Officer and Director"]);
+    expect(rows[2]!.titles).toBeNull();
+  });
+
+  it("is a no-op when the table is already on the new shape", async () => {
+    const db = getDb();
+    db.exec(
+      `CREATE TABLE person_observations (
+        observation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        accession_number TEXT NOT NULL,
+        extractor_id TEXT NOT NULL,
+        extractor_version TEXT NOT NULL,
+        observation_index INTEGER NOT NULL,
+        titles TEXT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (accession_number, extractor_id, observation_index)
+      )`
+    );
+    db.prepare(
+      `INSERT INTO person_observations (accession_number, extractor_id, extractor_version, observation_index, titles, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+    ).run("0001-24-000002", "S-1", "1.0.0", 0, '["CEO"]', "2026-01-15T00:00:00Z");
+
+    await migrateLegacyPersonObservationsTitles();
+
+    const cols = columnNames();
+    expect(cols).toContain("titles");
+    expect(cols).not.toContain("title");
+
+    const rows = db
+      .prepare<
+        [],
+        TitleRow
+      >(`SELECT observation_index, titles FROM person_observations ORDER BY observation_index`)
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0]!.titles ?? "null")).toEqual(["CEO"]);
+  });
+
+  it("is a no-op when the table does not exist yet", async () => {
+    // Fresh DB: no table, no error, and no table conjured out of thin air.
+    await migrateLegacyPersonObservationsTitles();
+    const db = getDb();
+    const remaining = db
+      .prepare<
+        [],
+        { name: string }
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name='person_observations'`)
+      .get();
+    expect(remaining).toBeUndefined();
+  });
+
+  it("reconciles a half-migrated table that carries both `title` and `titles`", async () => {
+    const db = getDb();
+    db.exec(
+      `CREATE TABLE person_observations (
+        observation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        accession_number TEXT NOT NULL,
+        extractor_id TEXT NOT NULL,
+        extractor_version TEXT NOT NULL,
+        observation_index INTEGER NOT NULL,
+        title TEXT NULL,
+        titles TEXT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (accession_number, extractor_id, observation_index)
+      )`
+    );
+    db.prepare(
+      `INSERT INTO person_observations (accession_number, extractor_id, extractor_version, observation_index, title, titles, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run("0001-24-000003", "S-1", "1.0.0", 0, "CEO", null, "2026-01-15T00:00:00Z");
+    db.prepare(
+      `INSERT INTO person_observations (accession_number, extractor_id, extractor_version, observation_index, title, titles, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run("0001-24-000003", "S-1", "1.0.0", 1, "Old", '["New"]', "2026-01-15T00:00:00Z");
+
+    await migrateLegacyPersonObservationsTitles();
+
+    const cols = columnNames();
+    expect(cols).toContain("titles");
+    expect(cols).not.toContain("title");
+
+    const rows = db
+      .prepare<
+        [],
+        TitleRow
+      >(`SELECT observation_index, titles FROM person_observations ORDER BY observation_index`)
+      .all();
+    expect(rows).toHaveLength(2);
+    expect(JSON.parse(rows[0]!.titles ?? "null")).toEqual(["CEO"]);
+    expect(JSON.parse(rows[1]!.titles ?? "null")).toEqual(["New"]);
+  });
+});

--- a/src/storage/observation/PersonObservationTitleMigration.ts
+++ b/src/storage/observation/PersonObservationTitleMigration.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { isDryRun } from "../../cli/isDryRun";
+import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
+import { getDb } from "../../util/db";
+import { getPgPool } from "../../util/pg";
+
+/**
+ * Rewrites a legacy `person_observations.title` (TEXT) column into the current
+ * `person_observations.titles` array column. The rename happened in-place with
+ * no ALTER TABLE, so an operator with a pre-existing database would either
+ * (a) see the next `observePerson` write fail on "column titles does not
+ * exist" or (b) keep writing while the older `title` data was orphaned.
+ *
+ * The probe is structural: if `titles` is already present and `title` is
+ * gone, the migration is a no-op — a fresh DB (created by the current
+ * `setupDatabase()` call that runs immediately afterwards) also exits before
+ * emitting any log. A partially-migrated shape (both columns present) is
+ * treated the same as the pre-migration shape and reconciled: rows where
+ * `titles` is still null are backfilled from `title`, rows that already carry
+ * a `titles` value are left alone, and the legacy column is dropped.
+ */
+export async function migrateLegacyPersonObservationsTitles(): Promise<void> {
+  // Same reasoning as the 8-K migration: raw ALTER/UPDATE bypasses the
+  // repository layer's ReadOnlyTabularStorage wrapper, so --dry-run cannot
+  // observe or intercept the write. Bail explicitly.
+  if (isDryRun()) return;
+
+  const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
+    ? globalServiceRegistry.get(SEC_DB_TYPE)
+    : null;
+
+  if (
+    dbType === "sqlite" &&
+    globalServiceRegistry.has(SEC_DB_FOLDER) &&
+    globalServiceRegistry.has(SEC_DB_NAME)
+  ) {
+    return migrateSqlite();
+  }
+  if (dbType === "postgres") {
+    return migratePostgres();
+  }
+  // In-memory / other backend: nothing to migrate.
+}
+
+function migrateSqlite(): void {
+  const db = getDb();
+  const tableExistsRow = db
+    .prepare<[], { name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='person_observations'`
+    )
+    .get();
+  if (!tableExistsRow) return;
+  const columns = db.prepare<[], { name: string }>(`PRAGMA table_info(person_observations)`).all();
+  const hasTitles = columns.some((c) => c.name === "titles");
+  const hasTitle = columns.some((c) => c.name === "title");
+  if (hasTitles && !hasTitle) return;
+
+  db.exec("BEGIN");
+  try {
+    if (!hasTitles) {
+      db.exec(`ALTER TABLE person_observations ADD COLUMN titles TEXT`);
+    }
+    let backfilled = 0;
+    if (hasTitle) {
+      db.exec(
+        `UPDATE person_observations SET titles = json_array(title) WHERE title IS NOT NULL AND titles IS NULL`
+      );
+      const changes = db.prepare<[], { n: number }>(`SELECT changes() AS n`).get();
+      backfilled = changes?.n ?? 0;
+      db.exec(`ALTER TABLE person_observations DROP COLUMN title`);
+    }
+    db.exec("COMMIT");
+    // Only announce a real migration; a fresh DB (no `title` and no rows)
+    // stays silent so first-run bootstrap does not spam operator output.
+    if (hasTitle) {
+      // eslint-disable-next-line no-console
+      console.info(
+        `[migration] person_observations: dropped legacy \`title\` column (${backfilled} row(s) backfilled into \`titles\`)`
+      );
+    } else if (!hasTitles) {
+      // eslint-disable-next-line no-console
+      console.info(`[migration] person_observations: added \`titles\` column`);
+    }
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+}
+
+async function migratePostgres(): Promise<void> {
+  const pool = getPgPool();
+  const client = await pool.connect();
+  try {
+    const exists = await client.query(
+      `SELECT 1 FROM information_schema.tables WHERE table_name = 'person_observations'`
+    );
+    if (exists.rowCount === 0) return;
+    const cols = await client.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'person_observations'`
+    );
+    const columnSet = new Set(cols.rows.map((r: { column_name: string }) => r.column_name));
+    const hasTitles = columnSet.has("titles");
+    const hasTitle = columnSet.has("title");
+    if (hasTitles && !hasTitle) return;
+
+    await client.query("BEGIN");
+    try {
+      // The current schema emits JSONB for the titles array (VARCHAR(n) is
+      // explicitly excluded from the native-array whitelist in mapPostgresType),
+      // so match that shape here.
+      await client.query(
+        `ALTER TABLE "person_observations" ADD COLUMN IF NOT EXISTS "titles" JSONB`
+      );
+      let backfilled = 0;
+      if (hasTitle) {
+        const updated = await client.query(
+          `UPDATE "person_observations" SET "titles" = jsonb_build_array("title") WHERE "title" IS NOT NULL AND "titles" IS NULL`
+        );
+        backfilled = updated.rowCount ?? 0;
+        await client.query(`ALTER TABLE "person_observations" DROP COLUMN IF EXISTS "title"`);
+      }
+      await client.query("COMMIT");
+      if (hasTitle) {
+        // eslint-disable-next-line no-console
+        console.info(
+          `[migration] person_observations: dropped legacy "title" column (${backfilled} row(s) backfilled into "titles")`
+        );
+      } else if (!hasTitles) {
+        // eslint-disable-next-line no-console
+        console.info(`[migration] person_observations: added "titles" column`);
+      }
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    }
+  } finally {
+    client.release();
+  }
+}


### PR DESCRIPTION
## Summary

The recent rename of `person_observations.title` (TEXT) to `titles` (JSON-encoded array on SQLite, JSONB on Postgres) happened in place with no `ALTER TABLE` and no version-registry migration. Any operator with a pre-existing database would:

- Hit `column titles does not exist` on the next `observePerson` write, or
- Keep writing while the older `title` data was orphaned.

This PR adds a one-shot idempotent startup migration invoked immediately before `PERSON_OBSERVATION_REPOSITORY_TOKEN.setupDatabase()`, mirroring the shape and dispatch of `migrateLegacyForm8KEventsTable`.

## Files

- **NEW** `src/storage/observation/PersonObservationTitleMigration.ts` — dual-backend one-shot migration.
  - **SQLite**: probes `sqlite_master` / `PRAGMA table_info`; if `titles` is absent adds `titles TEXT`; if `title` is present backfills `titles = json_array(title)` on rows whose `titles` is still null, then drops `title`. Wrapped in a single `BEGIN`/`COMMIT`, with `ROLLBACK` on throw.
  - **Postgres**: probes `information_schema`; runs `ADD COLUMN IF NOT EXISTS "titles" JSONB`, backfills via `jsonb_build_array("title")` under the same null-target guard, then `DROP COLUMN IF EXISTS "title"`. All in one transaction. JSONB matches what the ORM actually emits — the array-element whitelist in `mapPostgresType` explicitly excludes VARCHAR, so `Type.Array(Type.String({maxLength:256}))` falls through to `JSONB` rather than a native `VARCHAR(256)[]`.
  - Dry-run mode short-circuits before touching the database.
  - Silent on a fresh DB; emits one info line per backend when a real migration ran (column added, or rows backfilled).
- **EDITED** `src/config/setupAllDatabases.ts` — import the migration and call it directly before `PERSON_OBSERVATION_REPOSITORY_TOKEN.setupDatabase()`.
- **NEW** `src/storage/observation/PersonObservationTitleMigration.test.ts` — SQLite vitest coverage:
  1. Legacy shape with `title` column and three seeded rows (`'CEO'`, `'Chief Executive Officer and Director'`, `NULL`) — after migration, `titles` exists, `title` gone, values are `["CEO"]`, `["Chief Executive Officer and Director"]`, `null`.
  2. Already-migrated shape — no-op, single row's `titles` value preserved.
  3. Absent table — no throw, table stays absent.
  4. Half-migrated (both columns) — row with `title='CEO', titles=NULL` becomes `["CEO"]`; row with `title='Old', titles='["New"]'` keeps `["New"]`; `title` column dropped.

## Test plan

- [x] `bun test src/storage/observation/PersonObservationTitleMigration.test.ts` — 4/4 passing.
- [x] `bun test src/storage/observation/` — 24/24 passing across 5 files.
- [x] `bun test src/storage/form-8k-event/Form8KEventLegacyMigration.test.ts` — 3/3 passing (regression on shared reset-DI dance).
- [x] `bun run build` — clean build (bundle + `tsc`).
- [ ] Postgres branch — deferred to manual verification (mirrors the Form-8K migration precedent).

## Notes

- PRs #197 and #198 are also based on `harness` and will pick up this migration automatically on their next merge from base — no follow-up needed there.
- Postgres coverage is manual only; the SQLite path is covered exhaustively by the four cases above and matches the Form-8K precedent's testing scope.
- No spec / plan / PR-number references appear in source per the repo's code-comment convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UH5fBR7TB6n6JCKVSGHSeg)_