### PR TITLE
fix(sec): CLI validation, portal-attribute reporting, gguf path check

### DIFF
--- a/src/cli/groups/query.test.ts
+++ b/src/cli/groups/query.test.ts
@@ -18,4 +18,20 @@ describe("query CIK options", () => {
       );
     }
   });
+
+  it("rejects an explicitly empty --sic on entities and --portal on crowdfunding", () => {
+    const program = new Command("sec");
+    addQueryCommands(program);
+    const query = program.commands.find((command) => command.name() === "query");
+    const cases: Array<[string, string]> = [
+      ["entities", "--sic"],
+      ["crowdfunding", "--portal"],
+    ];
+    for (const [commandName, flag] of cases) {
+      const command = query!.commands.find((candidate) => candidate.name() === commandName);
+      const option = command?.options.find((o) => o.long === flag);
+      expect(option?.parseArg).toBeFunction();
+      expect(() => option!.parseArg!("", undefined)).toThrow('"" is not a valid number');
+    }
+  });
 });

--- a/src/cli/groups/query.ts
+++ b/src/cli/groups/query.ts
@@ -102,7 +102,7 @@ export function addQueryCommands(program: Command): void {
     .command("entities [search]")
     .description("Search entities in the database")
     .option("--cik <cik>", "Filter by CIK", parseIntOption)
-    .option("--sic <sic>", "Filter by SIC code")
+    .option("--sic <sic>", "Filter by SIC code", parseIntOption)
     .option("--state <state>", "Filter by state")
     .option("--limit <n>", "Limit results", parseIntOption, 25)
     .option("--offset <n>", "Offset results", parseIntOption, 0)
@@ -118,7 +118,7 @@ export function addQueryCommands(program: Command): void {
             defaults: {
               search,
               cik: options.cik as number | undefined,
-              sic: options.sic ? parseInt(options.sic as string, 10) : undefined,
+              sic: options.sic as number | undefined,
               state: options.state as string | undefined,
               limit,
               offset,
@@ -222,7 +222,7 @@ export function addQueryCommands(program: Command): void {
     .command("crowdfunding [search]")
     .description("Search crowdfunding offerings")
     .option("--cik <cik>", "Filter by CIK", parseIntOption)
-    .option("--portal <portal>", "Filter by portal")
+    .option("--portal <portal>", "Filter by portal", parseIntOption)
     .option("--after <date>", "Filter after date")
     .option("--before <date>", "Filter before date")
     .option("--limit <n>", "Limit results", parseIntOption, 25)
@@ -238,7 +238,7 @@ export function addQueryCommands(program: Command): void {
             defaults: {
               search,
               cik: options.cik as number | undefined,
-              portal: options.portal ? parseInt(options.portal as string, 10) : undefined,
+              portal: options.portal as number | undefined,
               after: options.after as string | undefined,
               before: options.before as string | undefined,
               limit,
@@ -309,7 +309,7 @@ export function addQueryCommands(program: Command): void {
         const format = validateFormat(options.format as string);
         const summary = await runWorkflowCli<QueryRegASummaryTaskOutput>([
           new QueryRegASummaryTask({
-            defaults: { cik: cik ? parseIntOption(cik) : undefined },
+            defaults: { cik: cik !== undefined ? parseIntOption(cik) : undefined },
           }),
         ]);
 
@@ -358,10 +358,17 @@ export function addQueryCommands(program: Command): void {
         const limit = options.limit as number;
         const offset = options.offset as number;
         const format = validateFormat(options.format as string);
+        // Require an all-digit string; parseInt would silently accept
+        // "123abc" as 123 and produce a plausible-but-wrong CIK. Mirrors
+        // the same guard on the `xbrl --cik` option below.
+        const trimmed = cik.trim();
+        if (!/^\d+$/.test(trimmed)) {
+          throw new Error(`Invalid CIK "${cik}". Must be a positive integer.`);
+        }
         const result = await runWorkflowCli<QueryResult<unknown>>([
           new QueryFactsTask({
             defaults: {
-              cik: parseInt(cik, 10),
+              cik: Number(trimmed),
               name: options.name as string | undefined,
               taxonomy: options.taxonomy as string | undefined,
               year: options.year as number | undefined,

--- a/src/commands/accreditedPortal.ts
+++ b/src/commands/accreditedPortal.ts
@@ -303,9 +303,10 @@ export function registerAccreditedPortalCommands(program: Command): void {
         portalId = portal.portal_id;
       }
       const result = await backfillFormDAttribution({ portalId });
+      const scope = portalId ? `portal ${portalId}` : "all portals";
       console.log(
         `attributed ${result.attributions} filings across ${result.filings} Form D accessions` +
-          (portalId ? ` (portal ${portalId}, cleared ${result.cleared} prior rows)` : "")
+          ` (${scope}, cleared ${result.cleared} prior rows)`
       );
     });
 

--- a/src/config/registerModels.ts
+++ b/src/config/registerModels.ts
@@ -8,6 +8,7 @@ import { isAbsolute, join } from "node:path";
 import type { ModelRecord, ServiceRegistry } from "workglow";
 import { getGlobalModelRepository, globalServiceRegistry } from "workglow";
 import { SecHftModelDefault, SecModelDefault } from "./Constants";
+import { SecCliConfigurationError } from "./EnvToDI";
 
 /**
  * Provider discriminators. Mirror the constants the provider packages register
@@ -341,7 +342,18 @@ function ggufCacheFileName(uri: string): string {
  */
 function ggufPathConfig(rawPath: string): Record<string, unknown> {
   if (!isRemoteGgufUri(rawPath)) {
-    return { model_path: isAbsolute(rawPath) ? rawPath : join(ggufModelsDir(), rawPath) };
+    const resolved = isAbsolute(rawPath) ? rawPath : join(ggufModelsDir(), rawPath);
+    // A `gguf:` id must point at a `.gguf` weights file. Absent the guard, a
+    // typo (or the id shape as a whole) can silently coerce node-llama-cpp
+    // into loading an arbitrary file off disk — the provider takes what the
+    // record's `model_path` says. The remote-URI branch stays unchecked: the
+    // download harness always caches under a synthesized `.gguf` filename.
+    if (!/\.gguf$/i.test(resolved)) {
+      throw new SecCliConfigurationError(
+        `gguf:${rawPath} must resolve to a .gguf file (got ${resolved})`
+      );
+    }
+    return { model_path: resolved };
   }
   const dir = ggufModelsDir();
   return {

--- a/src/resolver/backfillFormDAttribution.ts
+++ b/src/resolver/backfillFormDAttribution.ts
@@ -59,12 +59,10 @@ export async function backfillFormDAttribution(options: {
   const attributionRepo = new FormDPortalAttributionRepo();
   const signalRepo = new AccreditedPortalSignalRepo();
 
-  let cleared = 0;
-  if (options.portalId !== undefined) {
-    cleared = await attributionRepo.clearPortal(options.portalId);
-  } else {
-    await attributionRepo.clearAll();
-  }
+  const cleared =
+    options.portalId !== undefined
+      ? await attributionRepo.clearPortal(options.portalId)
+      : await attributionRepo.clearAll();
 
   const signals =
     options.portalId !== undefined

--- a/src/storage/accredited-portal/FormDPortalAttributionRepo.ts
+++ b/src/storage/accredited-portal/FormDPortalAttributionRepo.ts
@@ -75,8 +75,12 @@ export class FormDPortalAttributionRepo implements FormDPortalAttributionRepoOpt
     return count;
   }
 
-  /** Clears the whole table ahead of an unscoped recompute. */
-  async clearAll(): Promise<void> {
-    await this.attributionRepository.deleteAll();
+  /** Clears the whole table ahead of an unscoped recompute. Returns rows cleared. */
+  async clearAll(): Promise<number> {
+    const count = await this.attributionRepository.count();
+    if (count > 0) {
+      await this.attributionRepository.deleteAll();
+    }
+    return count;
   }
 }


### PR DESCRIPTION
Four surgical fixes surfaced by an automated review sweep of recent `main` changes.

## Summary

- **`sec query facts <cik>`** validates its positional CIK the same way the `xbrl` subcommand does (`/^\d+$/` + explicit error). `parseInt("123abc", 10)` was silently returning `123` and querying the wrong entity.
- **`--sic` on `entities`**, **`--portal` on `crowdfunding`**, and the optional positional `[cik]` on **`reg-a-summary`** now reject an explicitly empty string instead of silently dropping the filter — extending commit `3901122`'s `--cik` fix (`parseIntOption` at the Commander layer for the flags; `cik !== undefined ? parseIntOption(cik) : undefined` for the optional positional).
- **`accredited-portal attribute --all`** now reports the number of cleared rows. `clearAll()` returned `void`, so the backfill couldn't capture a count and the CLI message was gated to only mention `cleared` on `--portal`. `clearAll()` now counts-then-deletes (mirroring `clearPortal`), and the CLI print surfaces the count on both scopes.
- **`SEC_*_MODEL=gguf:<path>`** with a non-`.gguf` local path now throws a `SecCliConfigurationError` at record-build time. node-llama-cpp's `model_path` was previously handed straight to the provider without a suffix check, letting a typo point loading at an arbitrary file. The remote-URI branches (`gguf:hf:…`, `gguf:https://…`) are untouched — they always synthesize a `.gguf` cache filename.

## Test plan

- [x] `bun x tsc --noEmit` — clean.
- [x] `bun test src/cli/groups/query.test.ts src/config/registerModels.test.ts` — pass.
- [x] `bun test src/cli/ src/config/` — pass across the wider CLI + config surface.
- [x] `bun test src/resolver/` — pass (backfill path).
- [x] `bun test src/storage/accredited-portal/` — pass (attribution repo).
- [x] One added regression test in `src/cli/groups/query.test.ts` asserts `--sic` on `entities` and `--portal` on `crowdfunding` both reject `""` via `parseIntOption`.