### PR TITLE
Expose library surface for superset CLIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,18 @@
     "test": "bun test"
   },
   "bin": "./dist/sec.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "bun": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./*": "./src/*.ts",
+    "./package.json": "./package.json"
+  },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -7,23 +7,22 @@
     "bunset": "bunset --patch --push",
     "release": "bun run build && bun run test && bun run bunset",
     "dev": "concurrently -c 'auto' -n 'sec:' 'bun:dev-*'",
-    "dev-js": "bun build --watch --target=bun --sourcemap=external --packages=external --outdir ./dist ./src/sec.ts",
+    "dev-js": "bun build --watch --target=bun --sourcemap=external --packages=external --outdir ./dist ./src/sec.ts ./src/index.ts",
     "dev-types": "tsc --watch --preserveWatchOutput",
     "build": "bun run build-clean && bun run build-js && bun run build-types",
     "build-clean": "rm -fr dist/*",
-    "build-js": "bun build --target=bun --packages=external --outdir ./dist ./src/sec.ts",
+    "build-js": "bun build --target=bun --packages=external --outdir ./dist ./src/sec.ts ./src/index.ts",
     "build-types": "rm -f tsconfig.tsbuildinfo && tsc",
+    "bunsrc-source": "bun ./scripts/bunsrc.ts source",
+    "bunsrc-dist": "bun ./scripts/bunsrc.ts dist",
     "test": "bun test"
   },
   "bin": "./dist/sec.js",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "bun": "./src/index.ts",
-      "default": "./src/index.ts"
-    },
-    "./*": "./src/*.ts",
-    "./package.json": "./package.json"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",

--- a/scripts/bunsrc.ts
+++ b/scripts/bunsrc.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+
+// Flip this package's `exports` between source (./src/*.ts) and built
+// (./dist/*.js) files. Handy while bun-linked into a consumer (e.g. embarc-data):
+// point exports at source so edits are picked up live without a rebuild/publish,
+// then flip back to dist before committing / publishing.
+//
+// Adapted from the libs monorepo's scripts/bunsrc-workspace.ts, scoped to this
+// single package instead of iterating workspaces.
+//
+//   bun run bunsrc-source   # use ./src/*.ts   (development, bun link)
+//   bun run bunsrc-dist     # use ./dist/*.js  (committed / published state)
+
+import { $ } from "bun";
+
+function toSource(exports: string): string {
+  return exports
+    .replace(/("types":\s*")\.\/dist\/([^"]+)\.d\.ts"/g, `$1./src/$2.ts"`)
+    .replace(
+      /("(?:import|bun|node|browser|module|react-native|default)":\s*")\.\/dist\/([^"]+)\.js"/g,
+      `$1./src/$2.ts"`
+    );
+}
+
+function toDist(exports: string): string {
+  return exports
+    .replace(/("types":\s*")\.\/src\/([^"]+)\.ts"/g, `$1./dist/$2.d.ts"`)
+    .replace(
+      /("(?:import|bun|node|browser|module|react-native|default)":\s*")\.\/src\/([^"]+)\.ts"/g,
+      `$1./dist/$2.js"`
+    );
+}
+
+async function updateExports(mode: "source" | "dist"): Promise<void> {
+  const exports = (await $`bun pm pkg get exports`.quiet()).text().trim();
+  if (exports === "{}" || exports === "") {
+    console.log("No exports field to update.");
+    return;
+  }
+  const newExports = mode === "source" ? toSource(exports) : toDist(exports);
+  if (newExports === exports) {
+    console.log(`Exports already in ${mode} mode.`);
+    return;
+  }
+  await $`bun pm pkg set exports=${newExports} --json`;
+  console.log(`Exports switched to ${mode} mode.`);
+}
+
+async function main(): Promise<void> {
+  const mode = process.argv[2];
+  if (mode !== "source" && mode !== "dist") {
+    console.error("Usage: bun run scripts/bunsrc.ts <source|dist>");
+    console.error("  source: use source files (./src/*.ts) — development / bun link");
+    console.error("  dist:   use built files (./dist/*.js) — committed / published");
+    process.exit(1);
+  }
+  await updateExports(mode);
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,66 +6,56 @@
 
 // Public library surface for `@workglow/sec`.
 //
-// The `sec` CLI (src/sec.ts) is one consumer of this surface; downstream
-// packages that build a *superset* CLI (e.g. `embarc-data`) import from here
-// to reuse every SEC command, plus the DI/config, job queue, and teardown
-// wiring the CLI relies on.
+// This barrel IS the package's entry point (package.json `exports["."]` maps to
+// the built `dist/index.js`). The `sec` CLI (src/sec.ts) is one consumer of this
+// surface; downstream packages that build a *superset* CLI (e.g. `embarc-data`)
+// import from here to reuse every SEC command, plus the DI/config, job queue,
+// and teardown wiring the CLI relies on.
 //
-// This barrel exposes the common, collision-free surface. Every other module
-// (individual tasks, storage schemas/repositories, resolvers, form parsers,
-// low-level utils) stays reachable via wildcard subpath imports declared in
-// package.json `exports`, e.g.:
-//
-//   import { SpacReportTask } from "@workglow/sec/task/spac/SpacReportTask";
-//   import { SpacSchema } from "@workglow/sec/storage/spac/SpacSchema";
-//   import { CompanyResolver } from "@workglow/sec/resolver/CompanyResolver";
-//
-// so a superset can build on "all tasks and schemas" without this file having
-// to re-export several hundred symbols.
+// Everything a superset builds on is re-exported by name below — add to this
+// file when a new symbol needs to be public.
 
 // ── CLI construction ────────────────────────────────────────────────────────
 // `AddCommands(program)` registers every SEC command *and* installs the
 // commander preAction hook that bootstraps DI (EnvToDI/DefaultDI), models,
 // providers, and starts the fetch job queue. A superset CLI keeps calling this
 // (then adds its own commands) so that bootstrap still fires.
-export { AddCommands } from "./commands";
 export {
   applyGlobalOptions,
   parseGlobalOptions,
   parseIntOption,
   type GlobalOptions,
 } from "./cli/GlobalOptions";
+export { isDryRun } from "./cli/isDryRun";
+export { isJsonOutput } from "./cli/isJsonOutput";
+export * from "./cli/output";
 export { runCommand } from "./cli/runCommand";
 export { runWorkflowCli } from "./cli/runWorkflow";
-export * from "./cli/output";
+export { AddCommands } from "./commands";
 
 // ── Config / dependency injection ───────────────────────────────────────────
-export * from "./config/tokens";
 export * from "./config/Constants";
-export { EnvToDI, SecCliConfigurationError } from "./config/EnvToDI";
-export { DefaultDI } from "./config/DefaultDI";
 export { createStorage } from "./config/createStorage";
+export { DefaultDI } from "./config/DefaultDI";
+export { EnvToDI, SecCliConfigurationError } from "./config/EnvToDI";
 export { registerSecModels } from "./config/registerModels";
 export { registerSecProviders } from "./config/registerProviders";
+export * from "./config/tokens";
 
 // ── Fetch job queue + fetch task bases ──────────────────────────────────────
-export {
-  SecJobQueueClient,
-  SecJobQueueServer,
-  SecJobQueueStorage,
-} from "./task/fetch/SecJobQueue";
-export { SecFetchTask } from "./task/fetch/SecFetchTask";
 export {
   SecCachedFetchTask,
   type SecCachedFetchTaskInput,
   type response_type,
 } from "./task/fetch/SecCachedFetchTask";
+export { SecFetchTask } from "./task/fetch/SecFetchTask";
+export { SecJobQueueClient, SecJobQueueServer, SecJobQueueStorage } from "./task/fetch/SecJobQueue";
 
 // ── Lifecycle / teardown ────────────────────────────────────────────────────
 // A superset CLI must run these in its own shutdown path (mirroring src/sec.ts)
 // or the process hangs on live DB handles and model worker threads.
-export { getDb, closeDb } from "./util/db";
-export { getPgPool, closePgPool } from "./util/pg";
+export { closeDb, getDb } from "./util/db";
+export { closePgPool, getPgPool } from "./util/pg";
 export { terminateWorkers } from "./util/workers";
 
 // ── Re-exported workglow primitives a superset commonly needs ────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Public library surface for `@workglow/sec`.
+//
+// The `sec` CLI (src/sec.ts) is one consumer of this surface; downstream
+// packages that build a *superset* CLI (e.g. `embarc-data`) import from here
+// to reuse every SEC command, plus the DI/config, job queue, and teardown
+// wiring the CLI relies on.
+//
+// This barrel exposes the common, collision-free surface. Every other module
+// (individual tasks, storage schemas/repositories, resolvers, form parsers,
+// low-level utils) stays reachable via wildcard subpath imports declared in
+// package.json `exports`, e.g.:
+//
+//   import { SpacReportTask } from "@workglow/sec/task/spac/SpacReportTask";
+//   import { SpacSchema } from "@workglow/sec/storage/spac/SpacSchema";
+//   import { CompanyResolver } from "@workglow/sec/resolver/CompanyResolver";
+//
+// so a superset can build on "all tasks and schemas" without this file having
+// to re-export several hundred symbols.
+
+// ── CLI construction ────────────────────────────────────────────────────────
+// `AddCommands(program)` registers every SEC command *and* installs the
+// commander preAction hook that bootstraps DI (EnvToDI/DefaultDI), models,
+// providers, and starts the fetch job queue. A superset CLI keeps calling this
+// (then adds its own commands) so that bootstrap still fires.
+export { AddCommands } from "./commands";
+export {
+  applyGlobalOptions,
+  parseGlobalOptions,
+  parseIntOption,
+  type GlobalOptions,
+} from "./cli/GlobalOptions";
+export { runCommand } from "./cli/runCommand";
+export { runWorkflowCli } from "./cli/runWorkflow";
+export * from "./cli/output";
+
+// ── Config / dependency injection ───────────────────────────────────────────
+export * from "./config/tokens";
+export * from "./config/Constants";
+export { EnvToDI, SecCliConfigurationError } from "./config/EnvToDI";
+export { DefaultDI } from "./config/DefaultDI";
+export { createStorage } from "./config/createStorage";
+export { registerSecModels } from "./config/registerModels";
+export { registerSecProviders } from "./config/registerProviders";
+
+// ── Fetch job queue + fetch task bases ──────────────────────────────────────
+export {
+  SecJobQueueClient,
+  SecJobQueueServer,
+  SecJobQueueStorage,
+} from "./task/fetch/SecJobQueue";
+export { SecFetchTask } from "./task/fetch/SecFetchTask";
+export {
+  SecCachedFetchTask,
+  type SecCachedFetchTaskInput,
+  type response_type,
+} from "./task/fetch/SecCachedFetchTask";
+
+// ── Lifecycle / teardown ────────────────────────────────────────────────────
+// A superset CLI must run these in its own shutdown path (mirroring src/sec.ts)
+// or the process hangs on live DB handles and model worker threads.
+export { getDb, closeDb } from "./util/db";
+export { getPgPool, closePgPool } from "./util/pg";
+export { terminateWorkers } from "./util/workers";
+
+// ── Re-exported workglow primitives a superset commonly needs ────────────────
+// Saves supersets from taking a direct `workglow` dependency just to stop the
+// shared task-queue registry during shutdown.
+export { getTaskQueueRegistry } from "workglow";


### PR DESCRIPTION
Add a public `src/index.ts` barrel and package `exports` so downstream packages (e.g. the private embarc-data superset) can import the SEC command-wiring, DI/config, job queue, and teardown helpers instead of only running the `sec` bin.

- src/index.ts re-exports the common, collision-free surface: AddCommands, applyGlobalOptions, config/DI (EnvToDI, DefaultDI, tokens, Constants), the fetch job queue + fetch task bases, lifecycle teardown (closeDb/closePgPool/terminateWorkers), and a convenience re-export of workglow's getTaskQueueRegistry.
- package.json `exports`: `.` -> src/index.ts plus a `./*` wildcard so any task/schema/resolver/util stays reachable by path (source-based, since the package is private and consumed via `bun link`). Build both entrypoints.

No behavioral change to the CLI.

Claude-Session: https://claude.ai/code/session_01SN7APmki7GFHYYyhBd8ZFM