### PR TITLE
Support Canadian address parsing with French street type handling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@sroussey/parse-address": "^2.4.2",
+        "@sroussey/parse-address": "^3.0.0-beta1",
         "@sroussey/parse-full-name": "^2.0.0",
         "@workglow/cli": "0.3.26",
         "awesome-phonenumber": "^7.8.0",
@@ -39,8 +39,8 @@
     },
   },
   "trustedDependencies": [
-    "@huggingface/transformers",
     "onnxruntime-node",
+    "@huggingface/transformers",
   ],
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
@@ -289,7 +289,7 @@
 
     "@sroussey/json-schema-to-ts": ["@sroussey/json-schema-to-ts@3.1.4", "", { "dependencies": { "@sroussey/ts-algebra": "^2.0.0" } }, "sha512-wGYvgjUI0MoFTICZSoqJEB16bvXJ8lViVHrl3GNNRH871fuk3L6QlsmhWgAr/J0UKHyL1Swz6FVo5ABJTifbKg=="],
 
-    "@sroussey/parse-address": ["@sroussey/parse-address@2.4.2", "", { "dependencies": { "xregexp": "^5.1.2" } }, "sha512-KLQX00WY96RgZnhzQg2pAS/XylVYuXY3MqkynyF/+jMt1vDFJieT7LQSWlwNOpiRpgQbr8x3lBxOVFGil9WMaA=="],
+    "@sroussey/parse-address": ["@sroussey/parse-address@3.0.0-beta1", "", { "dependencies": { "xregexp": "^5.1.2" } }, "sha512-BHsASxmCjPNOg6vzXXv+TxWFoEm27Mg2LhgCp4nIYL6swcOqNfZrMAkjvZs2f3BZKj/NO0XY72wGeVs+l4vqXg=="],
 
     "@sroussey/parse-full-name": ["@sroussey/parse-full-name@2.0.0", "", {}, "sha512-JRfrQnwsQW5HZ8me9BStTc95A4NdgPTElmlHtEEcLlcp1GteExnWaFUIq+zUrEAz8HPT2DnRj8dF7eJGNYG0kw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@sroussey/parse-address": "^3.0.0-beta1",
+        "@sroussey/parse-address": "^3.0.1",
         "@sroussey/parse-full-name": "^2.0.0",
         "@workglow/cli": "0.3.26",
         "awesome-phonenumber": "^7.8.0",
@@ -289,7 +289,7 @@
 
     "@sroussey/json-schema-to-ts": ["@sroussey/json-schema-to-ts@3.1.4", "", { "dependencies": { "@sroussey/ts-algebra": "^2.0.0" } }, "sha512-wGYvgjUI0MoFTICZSoqJEB16bvXJ8lViVHrl3GNNRH871fuk3L6QlsmhWgAr/J0UKHyL1Swz6FVo5ABJTifbKg=="],
 
-    "@sroussey/parse-address": ["@sroussey/parse-address@3.0.0-beta1", "", { "dependencies": { "xregexp": "^5.1.2" } }, "sha512-BHsASxmCjPNOg6vzXXv+TxWFoEm27Mg2LhgCp4nIYL6swcOqNfZrMAkjvZs2f3BZKj/NO0XY72wGeVs+l4vqXg=="],
+    "@sroussey/parse-address": ["@sroussey/parse-address@3.0.1", "", { "dependencies": { "xregexp": "^5.1.2" } }, "sha512-w8UUmRo/0IuRR3qXZyeSJFQGLIoaoxG+Aht6Dn7ScRtpgMNaqHWveceZM2eOQmyDRAvUD8CmsJq1qfjxi02Dhg=="],
 
     "@sroussey/parse-full-name": ["@sroussey/parse-full-name@2.0.0", "", {}, "sha512-JRfrQnwsQW5HZ8me9BStTc95A4NdgPTElmlHtEEcLlcp1GteExnWaFUIq+zUrEAz8HPT2DnRj8dF7eJGNYG0kw=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@sroussey/parse-address": "^3.0.0-beta1",
+    "@sroussey/parse-address": "^3.0.1",
     "@sroussey/parse-full-name": "^2.0.0",
     "@workglow/cli": "0.3.26",
     "awesome-phonenumber": "^7.8.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@sroussey/parse-address": "^2.4.2",
+    "@sroussey/parse-address": "^3.0.0-beta1",
     "@sroussey/parse-full-name": "^2.0.0",
     "@workglow/cli": "0.3.26",
     "awesome-phonenumber": "^7.8.0",

--- a/src/storage/address/AddressNormalization.test.ts
+++ b/src/storage/address/AddressNormalization.test.ts
@@ -122,6 +122,64 @@ describe("cleanAddress", () => {
       const result = normalizeAddress(input);
       expect(result!.state_or_country).toBe("A0"); // Should be detected from keyword
     });
+
+    it("should normalize a Canadian (English) street line and split the unit", () => {
+      const input = {
+        street1: "999 Seymour Street",
+        street2: "Suite 1200",
+        city: "Vancouver",
+        stateOrCountry: "A1", // British Columbia
+        zipCode: "V6B 3K1",
+      };
+
+      const result = normalizeAddress(input);
+      expect(result!.country_code).toBe("CA");
+      expect(result!.street1).toBe("999 Seymour St");
+      expect(result!.street2).toBe("Suite 1200");
+    });
+
+    it("should preserve French leading-type ordering on Quebec streets", () => {
+      const input = {
+        street1: "123 Rue Principale",
+        city: "Montreal",
+        stateOrCountry: "A8", // Quebec
+        zipCode: "H1A 1A1",
+      };
+
+      const result = normalizeAddress(input);
+      expect(result!.country_code).toBe("CA");
+      // Must stay "123 Rue Principale", NOT reorder to "123 Principale Rue".
+      expect(result!.street1).toBe("123 Rue Principale");
+    });
+
+    it("should abbreviate an English Ontario street and its trailing direction", () => {
+      const input = {
+        street1: "100 King Street West",
+        city: "Toronto",
+        stateOrCountry: "A6", // Ontario
+        zipCode: "M5X 1A9",
+      };
+
+      const result = normalizeAddress(input);
+      expect(result!.country_code).toBe("CA");
+      expect(result!.street1).toBe("100 King St W");
+    });
+
+    it("should keep the raw street line when the parser would drop a word", () => {
+      // The beta CA parser truncates some French compound names ("du Parc" ->
+      // "du"); the loss guard must fall back to the raw line rather than persist
+      // a truncated "1500 Ave du".
+      const input = {
+        street1: "1500 Avenue du Parc",
+        city: "Montreal",
+        stateOrCountry: "A8", // Quebec
+        zipCode: "H2X 3P6",
+      };
+
+      const result = normalizeAddress(input);
+      expect(result!.country_code).toBe("CA");
+      expect(result!.street1).toBe("1500 Avenue du Parc");
+    });
   });
 
   describe("UK Addresses", () => {

--- a/src/storage/address/AddressNormalization.test.ts
+++ b/src/storage/address/AddressNormalization.test.ts
@@ -165,10 +165,10 @@ describe("cleanAddress", () => {
       expect(result!.street1).toBe("100 King St W");
     });
 
-    it("should keep the raw street line when the parser would drop a word", () => {
-      // The beta CA parser truncates some French compound names ("du Parc" ->
-      // "du"); the loss guard must fall back to the raw line rather than persist
-      // a truncated "1500 Ave du".
+    it("should normalize a French compound street name without dropping a word", () => {
+      // parse-address 3.x captures the full French compound ("du Parc") rather
+      // than truncating to "du", so the type abbreviates in place and no word is
+      // lost: "1500 Avenue du Parc" -> "1500 Ave du Parc".
       const input = {
         street1: "1500 Avenue du Parc",
         city: "Montreal",
@@ -178,7 +178,7 @@ describe("cleanAddress", () => {
 
       const result = normalizeAddress(input);
       expect(result!.country_code).toBe("CA");
-      expect(result!.street1).toBe("1500 Avenue du Parc");
+      expect(result!.street1).toBe("1500 Ave du Parc");
     });
   });
 

--- a/src/storage/address/AddressNormalization.ts
+++ b/src/storage/address/AddressNormalization.ts
@@ -177,25 +177,24 @@ function streetTokenCount(...lines: (string | null)[]): number {
  * street type, folds a secondary-unit designator down into street2, and (for
  * Canada) preserves French leading-type ordering.
  *
- * Only the street components are read back. City/state/postal come pre-separated
- * from EDGAR as structured fields, so the parser's re-extracted `city` /
- * `postal_code` are intentionally ignored — the EDGAR-supplied `zipCode` (run
- * through {@link normalizePostalCode}) is authoritative, and re-deriving it from
- * a concatenated string would only add a second, lossier source of truth.
+ * Only the street lines are handed to the parser. City/state/postal come
+ * pre-separated from EDGAR as structured fields and are deliberately excluded
+ * from the parse input: EDGAR's `stateOrCountry` is a SEC region code (e.g.
+ * "A8" for Quebec), not one the parser recognizes, and appending it would trip
+ * the parser's token-preservation fallback into returning the whole string as
+ * `street`. The EDGAR-supplied `zipCode` (via {@link normalizePostalCode}) is
+ * authoritative, so there is nothing to gain from re-deriving it here either.
  */
 function normalizeStreetAddress(
   parser: AddressParser,
   street1: string | null,
   street2: string | null,
-  street3: string | null,
-  city: string | null,
-  state: string | null,
-  zip: string | null
+  street3: string | null
 ): [string | null, string | null, string | null] {
   if (!street1) return [street1, street2, street3];
 
   try {
-    const streetInput = [street1, street2, street3, city, state, zip]
+    const streetInput = [street1, street2, street3]
       .filter((s) => s?.trim())
       .join(", ");
 
@@ -208,7 +207,7 @@ function normalizeStreetAddress(
 
     const houseNumber =
       [number, civic_number_suffix]
-        .filter((s) => s?.toString().trim())
+        .filter((s): s is string => Boolean(s?.toString().trim()))
         .map((s) => s.toString().trim())
         .join("") || null;
 
@@ -228,20 +227,20 @@ function normalizeStreetAddress(
 
     const newStreet1 =
       orderedStreet1
-        .filter((s) => s?.toString().trim())
+        .filter((s): s is string => Boolean(s?.toString().trim()))
         .map((s) => s.toString().trim())
         .join(" ") || null;
 
     const newStreet2 =
       [sec_unit_type, sec_unit_num]
-        .filter((s) => s?.toString().trim())
+        .filter((s): s is string => Boolean(s?.toString().trim()))
         .map((s) => s.toString().trim())
         .join(" ") || null;
 
-    // Loss guard: the parser should only abbreviate and reorder, never drop a
-    // word. If the rebuilt street lines carry fewer tokens than the source (the
-    // beta CA parser truncates some French compound names such as "Avenue du
-    // Parc"), keep the raw lines instead of persisting a truncated address.
+    // Loss guard (defense-in-depth): @sroussey/parse-address 3.x already
+    // guarantees it never drops a street token, but keep a local check anyway —
+    // if the rebuilt lines ever carry fewer tokens than the source, keep the raw
+    // lines rather than persist a truncated address.
     if (streetTokenCount(newStreet1, newStreet2) < streetTokenCount(street1, street2, street3)) {
       return [street1, street2, street3];
     }
@@ -370,10 +369,7 @@ export function normalizeAddress(importAddress: AddressImport | null): Address |
       streetParser,
       street1,
       street2,
-      street3,
-      city,
-      state_or_country,
-      zip
+      street3
     );
   }
 

--- a/src/storage/address/AddressNormalization.ts
+++ b/src/storage/address/AddressNormalization.ts
@@ -25,7 +25,57 @@ export type AddressImport = {
   foreignStateTerritory?: string | null;
 };
 
-const parser = new AddressParser();
+// One parser per supported country. EDGAR carries US and Canadian addresses
+// with parseable street lines; every other country keeps its raw street line
+// (see streetParserForCountry).
+const usAddressParser = new AddressParser("us");
+const caAddressParser = new AddressParser("ca");
+
+/**
+ * French-language street lines lead with the street type ("123 Rue Principale")
+ * rather than trailing it ("123 Main St"). Used to preserve the source ordering
+ * when rebuilding a Canadian street line — see {@link normalizeStreetAddress}.
+ */
+const FRENCH_LEADING_STREET_TYPES = new Set([
+  "rue",
+  "chemin",
+  "avenue",
+  "av",
+  "boulevard",
+  "boul",
+  "bd",
+  "allee",
+  "allée",
+  "cote",
+  "côte",
+  "place",
+  "impasse",
+  "montee",
+  "montée",
+  "rang",
+  "croissant",
+  "ruelle",
+  "voie",
+  "promenade",
+  "carre",
+  "carré",
+  "cours",
+]);
+
+/**
+ * Resolves the street parser for a resolved ISO country code, or null when the
+ * country has no dedicated parser (the raw street line is then kept as-is).
+ */
+function streetParserForCountry(countryCode: string | null): AddressParser | null {
+  switch (countryCode) {
+    case "US":
+      return usAddressParser;
+    case "CA":
+      return caAddressParser;
+    default:
+      return null;
+  }
+}
 
 /**
  * Cleans street address by removing care-of patterns and company endings
@@ -107,17 +157,42 @@ function normalizePostalCode(
 }
 
 /**
- * Parses US addresses using address parser for standardization
+ * Counts whitespace-separated tokens across the given lines (punctuation folded
+ * to spaces). Abbreviation ("Street" → "St") and reordering keep the token count
+ * unchanged; dropping a word lowers it — see the loss guard in
+ * {@link normalizeStreetAddress}.
  */
-function normalizeUSStreetAddress(
+function streetTokenCount(...lines: (string | null)[]): number {
+  return lines
+    .filter((line): line is string => !!line)
+    .join(" ")
+    .toLowerCase()
+    .replace(/[.,]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+/**
+ * Standardizes a street line via the country's address parser: abbreviates the
+ * street type, folds a secondary-unit designator down into street2, and (for
+ * Canada) preserves French leading-type ordering.
+ *
+ * Only the street components are read back. City/state/postal come pre-separated
+ * from EDGAR as structured fields, so the parser's re-extracted `city` /
+ * `postal_code` are intentionally ignored — the EDGAR-supplied `zipCode` (run
+ * through {@link normalizePostalCode}) is authoritative, and re-deriving it from
+ * a concatenated string would only add a second, lossier source of truth.
+ */
+function normalizeStreetAddress(
+  parser: AddressParser,
   street1: string | null,
   street2: string | null,
   street3: string | null,
   city: string | null,
   state: string | null,
   zip: string | null
-): [string | null, string | null, string | null, string | null] {
-  if (!street1) return [street1, street2, street3, city];
+): [string | null, string | null, string | null] {
+  if (!street1) return [street1, street2, street3];
 
   try {
     const streetInput = [street1, street2, street3, city, state, zip]
@@ -126,21 +201,33 @@ function normalizeUSStreetAddress(
 
     const parts = parser.parseLocation(streetInput);
 
-    if (!parts) return [street1, street2, street3, city];
+    if (!parts) return [street1, street2, street3];
 
-    const {
-      number,
-      prefix,
-      street,
-      type,
-      suffix,
-      sec_unit_type,
-      sec_unit_num,
-      city: cleanCity,
-    } = parts;
+    const { number, civic_number_suffix, prefix, street, type, suffix, sec_unit_type, sec_unit_num } =
+      parts;
+
+    const houseNumber =
+      [number, civic_number_suffix]
+        .filter((s) => s?.toString().trim())
+        .map((s) => s.toString().trim())
+        .join("") || null;
+
+    // A French street line leads with the type ("123 Rue Principale") while an
+    // English one trails it ("123 Main St"). The parser splits `type` out either
+    // way, so keying off the source ordering — the first token after the civic
+    // number — is what prevents rebuilding "123 Rue Principale" as the reordered
+    // "123 Principale Rue". Ambiguous words (Avenue, Place) are disambiguated by
+    // position, not by the word itself.
+    const streetHint = street1.replace(/^\s*\d+[a-z]?\s+/i, "").trimStart();
+    const firstToken = streetHint.split(/[\s,]+/)[0]?.toLowerCase().replace(/[.]/g, "") ?? "";
+    const typeLeadsStreet = !!type && !!street && FRENCH_LEADING_STREET_TYPES.has(firstToken);
+
+    const orderedStreet1 = typeLeadsStreet
+      ? [houseNumber, prefix, type, street, suffix]
+      : [houseNumber, prefix, street, type, suffix];
 
     const newStreet1 =
-      [number, prefix, street, type, suffix]
+      orderedStreet1
         .filter((s) => s?.toString().trim())
         .map((s) => s.toString().trim())
         .join(" ") || null;
@@ -150,15 +237,24 @@ function normalizeUSStreetAddress(
         .filter((s) => s?.toString().trim())
         .map((s) => s.toString().trim())
         .join(" ") || null;
-    if (newStreet1) {
-      return [newStreet1, newStreet2, null, cleanCity];
-    } else if (newStreet2) {
-      return [newStreet2, null, null, cleanCity];
+
+    // Loss guard: the parser should only abbreviate and reorder, never drop a
+    // word. If the rebuilt street lines carry fewer tokens than the source (the
+    // beta CA parser truncates some French compound names such as "Avenue du
+    // Parc"), keep the raw lines instead of persisting a truncated address.
+    if (streetTokenCount(newStreet1, newStreet2) < streetTokenCount(street1, street2, street3)) {
+      return [street1, street2, street3];
     }
-    return [null, null, null, cleanCity];
+
+    if (newStreet1) {
+      return [newStreet1, newStreet2, null];
+    } else if (newStreet2) {
+      return [newStreet2, null, null];
+    }
+    return [null, null, null];
   } catch (error) {
     console.warn("Address parsing failed:", error);
-    return [street1, street2, street3, city];
+    return [street1, street2, street3];
   }
 }
 
@@ -268,8 +364,10 @@ export function normalizeAddress(importAddress: AddressImport | null): Address |
 
   city = normalizeCity(city ?? "");
 
-  if (country_code == "US") {
-    [street1, street2, street3] = normalizeUSStreetAddress(
+  const streetParser = streetParserForCountry(country_code);
+  if (streetParser) {
+    [street1, street2, street3] = normalizeStreetAddress(
+      streetParser,
       street1,
       street2,
       street3,


### PR DESCRIPTION
## Summary

Extends address normalization to support Canadian addresses alongside US addresses, with special handling for French-language street lines that lead with the street type (e.g., "123 Rue Principale") rather than trailing it. Upgrades the address parser library to v3.0.0-beta1 to enable country-specific parsing.

## Key Changes

- **Multi-country parser support**: Replaced single US parser with country-specific parsers (`usAddressParser` and `caAddressParser`), dispatched via new `streetParserForCountry()` function
- **French street type detection**: Added `FRENCH_LEADING_STREET_TYPES` set to detect when a street line uses French leading-type ordering, preserving the original word order instead of reordering to English trailing-type format
- **Generalized street normalization**: Renamed `normalizeUSStreetAddress()` to `normalizeStreetAddress()` and made it country-agnostic; now accepts a parser instance and handles both US and Canadian addresses
- **Loss guard**: Implemented `streetTokenCount()` helper to detect when the parser would drop words (e.g., truncating "Avenue du Parc" to "Ave du"), falling back to raw street lines to prevent data loss
- **Parser output handling**: Updated to extract `civic_number_suffix` from parser output and properly reconstruct house numbers; removed city re-extraction since EDGAR provides city as a structured field
- **Dependency upgrade**: Updated `@sroussey/parse-address` from v2.4.2 to v3.0.0-beta1
- **Test coverage**: Added four new test cases covering English Canadian streets, French Quebec streets, trailing direction abbreviation, and the loss-guard fallback

## Implementation Details

- The French street type detection works by examining the first token after the civic number in the source street line, allowing disambiguation of ambiguous words (Avenue, Place) by position rather than the word itself
- The loss guard compares token counts before and after parsing; if tokens are lost, the raw street lines are preserved rather than persisting a truncated address
- Return signature of `normalizeStreetAddress()` changed from 4-tuple (including city) to 3-tuple (street components only), since city is already a structured field from EDGAR

https://claude.ai/code/session_01Frvs9m4YyEfAoRVkibYSNN