### PR TITLE
fix(facts): accept real EDGAR company-facts shapes during ingest

### DIFF
--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -79,6 +79,7 @@ import { USE_OF_PROCEEDS_REPOSITORY_TOKEN } from "../storage/use-of-proceeds/Use
 import { XBRL_FACT_REPOSITORY_TOKEN } from "../storage/xbrl/XbrlFactSchema";
 import { FORM_8K_EVENT_REPOSITORY_TOKEN } from "../storage/form-8k-event/Form8KEventSchema";
 import { migrateLegacyForm8KEventsTable } from "../storage/form-8k-event/Form8KEventLegacyMigration";
+import { widenNarrowColumns } from "./widenNarrowColumnsMigration";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
   CANONICAL_COMPANY_ADDRESS_REPOSITORY_TOKEN,
@@ -214,6 +215,11 @@ export async function setupAllDatabases(): Promise<void> {
   for (const token of listDatabaseExtensionTokens()) {
     await globalServiceRegistry.get(token).setupDatabase();
   }
+  // Widen any columns that a pre-widening Postgres database still has at the old
+  // narrow varchar length (fresh DDL above already uses the new widths, so this
+  // is a no-op on a clean DB). Keeps existing Postgres deployments from
+  // re-hitting the original company-facts / XBRL overflow.
+  await widenNarrowColumns();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
   // isn't sqlite). Tests use the in-memory backend where views don't apply.

--- a/src/config/widenNarrowColumnsMigration.ts
+++ b/src/config/widenNarrowColumnsMigration.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { isDryRun } from "../cli/isDryRun";
+import { getPgPool } from "../util/pg";
+import { SEC_DB_TYPE } from "./tokens";
+
+/**
+ * Columns whose TypeBox `maxLength` was widened after real EDGAR data
+ * overflowed the original width. `CREATE TABLE IF NOT EXISTS` never alters an
+ * existing table, so a Postgres database set up before the widening keeps the
+ * narrow `varchar(N)` and re-hits the original overflow (a `STORE_ERROR` that
+ * loses the whole CIK's facts, or a silently dropped XBRL fact). This migration
+ * brings existing columns up to the schema width.
+ *
+ * Postgres-only: SQLite emits `TEXT` (length never enforced) and the in-memory
+ * test backend has no column types, so both are no-ops. Increasing a
+ * `varchar` length in Postgres is a catalog-only change (no table rewrite), and
+ * the guard skips columns already at or above the target, so this is cheap and
+ * idempotent to run on every `db setup`.
+ */
+const WIDENED_COLUMNS: ReadonlyArray<{
+  readonly table: string;
+  readonly column: string;
+  readonly width: number;
+}> = [
+  { table: "company_facts", column: "val_unit", width: 32 },
+  { table: "company_facts", column: "grouping", width: 20 },
+  { table: "xbrl_fact", column: "context_ref", width: 512 },
+];
+
+export async function widenNarrowColumns(): Promise<void> {
+  // DDL through raw SQL reaches around the repository layer, so the dry-run
+  // ReadOnlyTabularStorage wrapper cannot intercept it — bail explicitly.
+  if (isDryRun()) return;
+
+  const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
+    ? globalServiceRegistry.get(SEC_DB_TYPE)
+    : null;
+  if (dbType !== "postgres") return;
+
+  const pool = getPgPool();
+  const client = await pool.connect();
+  try {
+    for (const { table, column, width } of WIDENED_COLUMNS) {
+      const info = await client.query(
+        `SELECT character_maximum_length AS len
+           FROM information_schema.columns
+          WHERE table_name = $1 AND column_name = $2`,
+        [table, column]
+      );
+      const current = info.rows[0]?.len as number | null | undefined;
+      // Column absent (table not created yet) or already wide enough → skip.
+      // A null length means an unbounded text type — never narrow it.
+      if (current === undefined) continue;
+      if (current === null || current >= width) continue;
+      await client.query(
+        `ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE varchar(${width})`
+      );
+    }
+  } finally {
+    client.release();
+  }
+}

--- a/src/sec/facts/CompanyFacts.test.ts
+++ b/src/sec/facts/CompanyFacts.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Value } from "typebox/value";
+import { CompanyFactsSchema } from "../../storage/facts/CompanyFactsSchema";
+import { FactoidSchema, FP, normalizeFp, type Factoid } from "./CompanyFacts";
+
+/**
+ * Regression coverage for the constraint widths that rejected real EDGAR
+ * company-facts during a full bootstrap:
+ *  - `fp` beyond the four quarters + FY (EDGAR emits `CY` / `H1` / `H2`),
+ *  - `val_unit` longer than 12 chars (composite units run to ~20),
+ *  - `grouping` longer than 8 chars (`ifrs-full` is 9).
+ * All three surfaced as `STORE_ERROR`s that lost the whole CIK's facts.
+ */
+
+function factoid(overrides: Partial<Factoid>): Factoid {
+  return {
+    cik: 1018724,
+    grouping: "us-gaap",
+    name: "Revenues",
+    filed_date: "2026-04-15",
+    form: "10-K",
+    val_unit: "USD",
+    val: 12345678,
+    frame: null,
+    accession_number: "0001018724-26-000042",
+    start_date: null,
+    end_date: "2024-12-31",
+    fy: 2024,
+    fp: "FY",
+    ...overrides,
+  };
+}
+
+describe("FP fiscal-period codes", () => {
+  it("includes the EDGAR calendar-year and half-year codes", () => {
+    expect(FP).toEqual(["FY", "Q1", "Q2", "Q3", "Q4", "CY", "H1", "H2"]);
+  });
+});
+
+describe("normalizeFp", () => {
+  for (const code of FP) {
+    it(`passes known code "${code}" through`, () => {
+      expect(normalizeFp(code)).toBe(code);
+    });
+  }
+
+  it("maps EDGAR's empty-string period-agnostic fp to null", () => {
+    expect(normalizeFp("")).toBeNull();
+  });
+
+  it("maps an unrecognized code and non-strings to null", () => {
+    expect(normalizeFp("ZZ")).toBeNull();
+    expect(normalizeFp(null)).toBeNull();
+    expect(normalizeFp(undefined)).toBeNull();
+    expect(normalizeFp(3)).toBeNull();
+  });
+});
+
+describe("FactoidSchema (task-input validation)", () => {
+  for (const fp of ["CY", "H1", "H2"] as const) {
+    it(`accepts fp="${fp}"`, () => {
+      expect(Value.Check(FactoidSchema, factoid({ fp }))).toBe(true);
+    });
+  }
+
+  it("still rejects an unknown fp code", () => {
+    expect(Value.Check(FactoidSchema, factoid({ fp: "ZZ" as never }))).toBe(false);
+  });
+
+  it("accepts a 20-char val_unit (previously capped at 12)", () => {
+    expect(Value.Check(FactoidSchema, factoid({ val_unit: "USD/entity-per-share" }))).toBe(true);
+  });
+
+  it("accepts the 9-char ifrs-full grouping (previously capped at 8)", () => {
+    expect(Value.Check(FactoidSchema, factoid({ grouping: "ifrs-full" }))).toBe(true);
+  });
+});
+
+describe("CompanyFactsSchema (storage validation)", () => {
+  it("accepts a 20-char val_unit", () => {
+    expect(Value.Check(CompanyFactsSchema, factoid({ val_unit: "USD/entity-per-share" }))).toBe(
+      true
+    );
+  });
+
+  it("accepts the 9-char ifrs-full grouping", () => {
+    expect(Value.Check(CompanyFactsSchema, factoid({ grouping: "ifrs-full", fp: "FY" }))).toBe(true);
+  });
+});

--- a/src/sec/facts/CompanyFacts.ts
+++ b/src/sec/facts/CompanyFacts.ts
@@ -46,16 +46,33 @@ export interface FactSummary {
   frame?: Frame;
 }
 
-export const FP = ["FY", "Q1", "Q2", "Q3", "Q4"] as const;
+// EDGAR company-facts emit more fiscal-period codes than the four quarters +
+// full year: `CY` (calendar-year facts) and `H1`/`H2` (half-year) appear in the
+// bulk companyfacts dataset. All fit the 2-char `fp` column.
+export const FP = ["FY", "Q1", "Q2", "Q3", "Q4", "CY", "H1", "H2"] as const;
 export type FP = (typeof FP)[number];
+
+const FP_SET: ReadonlySet<string> = new Set(FP);
+
+/**
+ * The raw companyfacts JSON is cast to {@link FactSummary} without runtime
+ * validation, but EDGAR reports period-agnostic facts with `fp` as an empty
+ * string (or, rarely, an unrecognized code) rather than the documented FY/Q1–Q4
+ * set. Map anything outside the known codes to `null` so it flows through the
+ * task-input schema; the storage boundary coalesces `null` to the "" PK
+ * sentinel. Keeps one odd fact from failing a CIK's entire facts batch.
+ */
+export function normalizeFp(fp: unknown): FP | null {
+  return typeof fp === "string" && FP_SET.has(fp) ? (fp as FP) : null;
+}
 
 export const FactoidSchema = Type.Object({
   cik: Type.Number({ format: "cik", minimum: 0 }),
-  grouping: Type.String({ maxLength: 10 }), // dei or us-gaap
+  grouping: Type.String({ maxLength: 20 }), // dei, us-gaap, ifrs-full, srt, invest, ...
   name: Type.String(),
   filed_date: TypeDate(),
   form: TypeSECForm(),
-  val_unit: Type.String({ maxLength: 12 }),
+  val_unit: Type.String({ maxLength: 32 }),
   val: Type.Number(),
   frame: TypeNullable(Type.String({ maxLength: 12 })),
   accession_number: Type.String({ maxLength: 20 }),

--- a/src/storage/facts/CompanyFactsSchema.ts
+++ b/src/storage/facts/CompanyFactsSchema.ts
@@ -15,8 +15,8 @@ export const CompanyFactsSchema = Type.Object({
     description: "Central Index Key (CIK) - unique identifier for entity",
   }),
   grouping: Type.String({
-    maxLength: 8,
-    description: "Facts grouping category",
+    maxLength: 20,
+    description: "Facts grouping category (dei, us-gaap, ifrs-full, srt, invest, ...)",
   }),
   name: Type.String({
     description: "Fact name",
@@ -30,7 +30,7 @@ export const CompanyFactsSchema = Type.Object({
     description: "Form type",
   }),
   val_unit: Type.String({
-    maxLength: 12,
+    maxLength: 32,
     description: "Value unit",
   }),
   frame: TypeNullable(

--- a/src/storage/xbrl/XbrlFactRepo.test.ts
+++ b/src/storage/xbrl/XbrlFactRepo.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
+import { Value } from "typebox/value";
 import { globalServiceRegistry } from "workglow";
 import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
 import { parseInlineXbrl } from "../../sec/xbrl/parseInlineXbrl";
@@ -12,6 +13,7 @@ import { toXbrlFactRows } from "../../sec/xbrl/toFactRows";
 import { XbrlFactRepo } from "./XbrlFactRepo";
 import {
   XBRL_FACT_REPOSITORY_TOKEN,
+  XbrlFactRowSchema,
   type XbrlFactRepositoryStorage,
   type XbrlFactRow,
 } from "./XbrlFactSchema";
@@ -176,5 +178,48 @@ describe("XbrlFactRepo", () => {
     const series = await repo.getByCikConcept(2114227, "spac:SaleOfSecuritiesGrossProceeds");
     expect(series).toHaveLength(2);
     expect(series.map((r) => r.accession_number)).toEqual([ACCESSION, "0001213900-26-047229"]);
+  });
+});
+
+/**
+ * Regression: iXBRL context ids are auto-generated and dimensional contexts can
+ * exceed the original 128-char cap that overflowed on real filings. The schema
+ * (and, via the widening migration, the Postgres column) now allows up to 512.
+ */
+describe("XbrlFactRowSchema context_ref width", () => {
+  function baseRow(overrides: Partial<XbrlFactRow>): XbrlFactRow {
+    return {
+      accession_number: ACCESSION,
+      fact_index: 0,
+      cik: 2114227,
+      concept: "dei:EntityRegistrantName",
+      namespace: "http://xbrl.sec.gov/dei/2025",
+      context_ref: "c1",
+      unit: null,
+      period_start: null,
+      period_end: null,
+      period_instant: "2026-03-31",
+      value_text: "Churchill Capital Corp XII",
+      value_numeric: null,
+      decimals: null,
+      sign: null,
+      format: null,
+      is_numeric: false,
+      is_hidden: false,
+      dimensions_json: null,
+      source: "inline",
+      created_at: "2026-03-31T00:00:00Z",
+      ...overrides,
+    };
+  }
+
+  it("accepts a long dimensional context id (>128 chars, previously rejected)", () => {
+    const longContextRef = `c-${"Axis_Member_".repeat(20)}`; // ~240 chars
+    expect(longContextRef.length).toBeGreaterThan(128);
+    expect(Value.Check(XbrlFactRowSchema, baseRow({ context_ref: longContextRef }))).toBe(true);
+  });
+
+  it("rejects a context id beyond the 512 cap", () => {
+    expect(Value.Check(XbrlFactRowSchema, baseRow({ context_ref: "x".repeat(513) }))).toBe(false);
   });
 });

--- a/src/storage/xbrl/XbrlFactSchema.ts
+++ b/src/storage/xbrl/XbrlFactSchema.ts
@@ -21,7 +21,10 @@ export const XbrlFactRowSchema = Type.Object({
   cik: TypeNullable(TypeSecCik()),
   concept: Type.String({ maxLength: 256 }),
   namespace: TypeNullable(Type.String({ maxLength: 256 })),
-  context_ref: TypeNullable(Type.String({ maxLength: 128 })),
+  // iXBRL context ids are auto-generated and can be long (dimensional contexts
+  // concatenate axis/member segments); 128 overflowed on real filings. Not part
+  // of the PK and only denormalized reference data, so widening is safe.
+  context_ref: TypeNullable(Type.String({ maxLength: 512 })),
   unit: TypeNullable(Type.String({ maxLength: 64 })),
   period_start: TypeNullable(Type.String({ maxLength: 10 })),
   period_end: TypeNullable(Type.String({ maxLength: 10 })),

--- a/src/task/facts/FetchCompanyFactsTask.ts
+++ b/src/task/facts/FetchCompanyFactsTask.ts
@@ -7,7 +7,7 @@
 import { Static, Type } from "typebox";
 import { DataPortSchemaObject, IExecuteContext, Task, TaskAbortedError, TaskError } from "workglow";
 import { SecCachedFetchTask } from "../fetch/SecCachedFetchTask";
-import { CompanyFacts, Factoid, FactoidSchema } from "../../sec/facts/CompanyFacts";
+import { CompanyFacts, Factoid, FactoidSchema, normalizeFp } from "../../sec/facts/CompanyFacts";
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { secDate, TypeOptionalSecDate } from "../../util/parseDate";
 
@@ -109,7 +109,7 @@ export class FetchCompanyFactsTask extends Task<
               end_date: summary.end,
               val: summary.val,
               fy: summary.fy,
-              fp: summary.fp,
+              fp: normalizeFp(summary.fp),
             });
           }
         });

--- a/src/task/facts/UpdateAllCompanyFactsTask.test.ts
+++ b/src/task/facts/UpdateAllCompanyFactsTask.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { globalServiceRegistry, type IExecuteContext } from "workglow";
+import { SEC_DRY_RUN } from "../../config/tokens";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { CIK_LAST_UPDATE_REPOSITORY_TOKEN } from "../../storage/processing/CikLastUpdateSchema";
+import { PROCESSED_FACTS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedFactsSchema";
+import { UpdateAllCompanyFactsTask } from "./UpdateAllCompanyFactsTask";
+
+function ctx(): IExecuteContext {
+  const controller = new AbortController();
+  return {
+    signal: controller.signal,
+    updateProgress: async () => {},
+    own: <T>(v: T): T => v,
+    registry: {
+      has: () => false,
+      get: () => {
+        throw new Error("not registered");
+      },
+    } as any,
+    resourceScope: {
+      register: (_k: string, _fn: () => Promise<void>) => {},
+      dispose: async () => {},
+    } as any,
+  } as IExecuteContext;
+}
+
+/**
+ * The all-CIK read at the top of the task used `query({}, …)`, which the tabular
+ * backend rejects ("Query criteria must not be empty. Use getAll()"). Only the
+ * `update facts` path hits it (bootstrap uses a different task), so it stayed
+ * hidden until a `--retry-failed` run. These dry-run tests exercise that read.
+ */
+describe("UpdateAllCompanyFactsTask all-CIK read", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+    globalServiceRegistry.registerInstance(SEC_DRY_RUN, true);
+  });
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("does not throw on an empty cik_last_update table", async () => {
+    const out = await new UpdateAllCompanyFactsTask().execute({ retryFailed: true }, ctx());
+    expect(out.success).toBe(true);
+  });
+
+  it("reads all CIKs and selects previously failed ones for retry", async () => {
+    await globalServiceRegistry
+      .get(CIK_LAST_UPDATE_REPOSITORY_TOKEN)
+      .put({ cik: 1018724, last_update: "2026-01-01" });
+    await globalServiceRegistry.get(PROCESSED_FACTS_REPOSITORY_TOKEN).put({
+      cik: 1018724,
+      last_processed: "2026-01-02",
+      success: false,
+      reason_code: "STORE_ERROR",
+      detail: "val_unit too long",
+      attempts: 1,
+    });
+
+    const out = await new UpdateAllCompanyFactsTask().execute({ retryFailed: true }, ctx());
+    expect(out.success).toBe(true);
+  });
+});

--- a/src/task/facts/UpdateAllCompanyFactsTask.test.ts
+++ b/src/task/facts/UpdateAllCompanyFactsTask.test.ts
@@ -45,6 +45,11 @@ describe("UpdateAllCompanyFactsTask all-CIK read", () => {
     globalServiceRegistry.registerInstance(SEC_DRY_RUN, true);
   });
   afterEach(() => {
+    // Clear the dry-run flag we set in beforeEach. resetDependencyInjectionsForTesting()
+    // only re-registers repos, not SEC_DRY_RUN, so leaving it true leaks into later
+    // test files that share the global registry (e.g. SecFetchFileOutputCache, whose
+    // saveOutput no-ops under dry-run).
+    globalServiceRegistry.registerInstance(SEC_DRY_RUN, false);
     resetDependencyInjectionsForTesting();
   });
 

--- a/src/task/facts/UpdateAllCompanyFactsTask.ts
+++ b/src/task/facts/UpdateAllCompanyFactsTask.ts
@@ -56,11 +56,13 @@ export class UpdateAllCompanyFactsTask extends Task<
     const cikLastUpdateRepo = globalServiceRegistry.get(CIK_LAST_UPDATE_REPOSITORY_TOKEN);
     const processedFactsRepo = globalServiceRegistry.get(PROCESSED_FACTS_REPOSITORY_TOKEN);
 
+    // getAll() rather than query({}, …): the tabular backend rejects an empty
+    // criteria object ("Query criteria must not be empty. Use getAll()"), which
+    // is exactly the all-rows read we want here.
     const allCikUpdates =
-      (await cikLastUpdateRepo.query(
-        {},
-        { orderBy: [{ column: "last_update", direction: "DESC" }] }
-      )) ?? [];
+      (await cikLastUpdateRepo.getAll({
+        orderBy: [{ column: "last_update", direction: "DESC" }],
+      })) ?? [];
 
     // Stream rather than getAll() — see UpdateAllSubmissionsTask for the
     // same pattern. We need both cik and last_processed for freshness,


### PR DESCRIPTION
A full bootstrap flooded with STORE_ERRORs that lost whole CIKs' facts because the company-facts constraints were tighter than real EDGAR data:

- fp: EDGAR emits CY / H1 / H2 (calendar-year, half-year) beyond FY/Q1-Q4, and an empty string "" for period-agnostic facts. Widen the FP enum and add normalizeFp() to map "" / unknown codes to null at parse time (the storage boundary already coalesces null to the "" PK sentinel), so one odd fact can't fail a CIK's entire batch.
- val_unit: composite units run to ~20 chars; bump 12 -> 32.
- grouping: ifrs-full is 9 chars; bump 8/10 -> 20. (Existing Postgres company_facts columns widened separately via ALTER.)

Also fix `update facts --retry-failed`, which crashed with "Query criteria must not be empty" — the all-CIK read used query({}, ...); switch to getAll({ orderBy }). This path is only reached by `update facts`, not `bootstrap`, so it stayed hidden until a retry run.

Adds regression tests for the widened fp/val_unit/grouping schemas, normalizeFp, and the getAll retry-lane read.


Claude-Session: https://claude.ai/code/session_019ZKz3adGzMpEdy9jJ3HNXu