### PR TITLE
fix(eval): restore SEC_UNIT_TERMS_REF override with fail-fast on missing path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -793,6 +793,7 @@ Set in `.env.local` (see `.env.test` for test defaults):
 - `SEC_PG_DATABASE` — PostgreSQL database name (default: `edgar`)
 - `SEC_FIXTURES_DIR` — root under which `sec fetch fixtures` / `sec fetch s1-fixtures` write their gitignored cache (default: cwd). Written output goes to `<SEC_FIXTURES_DIR>/.sec-fixtures/exempt-offerings/` and `<SEC_FIXTURES_DIR>/.sec-fixtures/s1/.cache/` — never into the source tree or the bundled `dist/`.
 - `SEC_S1_MOCK_DIR` — override the committed S-1 fixtures directory read by `sec eval s1` and `loadRealS1Sections`. Falls back to the built-tree copy, then the source-tree copy.
+- `SEC_UNIT_TERMS_REF` — override the embarc unit-terms reference CSV read by `sec eval unit-terms` and `loadEmbarcUnitTermsReference` (mirrors `SEC_S1_MOCK_DIR`). A downstream package consuming the published tarball (which ships no `mock_data/`) points this at its own vendored copy. Fail-fast semantics: when the env var is set, a missing file throws (naming the env var and the path) instead of silently falling through to the package-relative default, so a typo cannot masquerade as "fixture missing, using default". When unset, resolves the package-shipped CSV (dist copy in the built tarball, src copy in dev).
 
 ## TypeScript Conventions
 

--- a/src/eval/embarcUnitTermsReference.test.ts
+++ b/src/eval/embarcUnitTermsReference.test.ts
@@ -3,8 +3,12 @@
  * Copyright 2026 Steven Roussey <sroussey@gmail.com>
  * SPDX-License-Identifier: Apache-2.0
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  _resetEmbarcUnitTermsCacheForTesting,
   cikFromFilingName,
   embarcExpectedRow,
   loadEmbarcUnitTermsReference,
@@ -73,5 +77,59 @@ describe("embarc unit-terms reference dataset", () => {
       right_fraction_per_unit: 0.1,
       unit_composition: "one share and one-third of one warrant",
     });
+  });
+});
+
+describe("SEC_UNIT_TERMS_REF override", () => {
+  const CSV_HEADER =
+    "cik,name,unit_common,unit_price,unit_warrant," +
+    "warrant_fraction_per_unit,right_fraction_per_unit," +
+    "right_share_conversion,warrant_ratio,warrant_price";
+  const originalEnv = process.env.SEC_UNIT_TERMS_REF;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    _resetEmbarcUnitTermsCacheForTesting();
+    tmpDir = mkdtempSync(join(tmpdir(), "sec-unit-terms-ref-"));
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.SEC_UNIT_TERMS_REF;
+    else process.env.SEC_UNIT_TERMS_REF = originalEnv;
+    _resetEmbarcUnitTermsCacheForTesting();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("env set + file exists → loads from the override path", () => {
+    const csvPath = join(tmpDir, "override.csv");
+    writeFileSync(
+      csvPath,
+      `${CSV_HEADER}\n` + `9999999,Override SPAC Corp.,1,10,1/2,0.5,,,,11.5\n`,
+      "utf8"
+    );
+    process.env.SEC_UNIT_TERMS_REF = csvPath;
+
+    const ref = loadEmbarcUnitTermsReference();
+    expect(ref.size).toBe(1);
+    const row = ref.get(9999999)!;
+    expect(row.name).toBe("Override SPAC Corp.");
+    expect(row.unit_price).toBe(10);
+    expect(row.warrant_fraction_per_unit).toBeCloseTo(0.5);
+  });
+
+  it("env set + file missing → throws naming the env var and the path (no silent fallback)", () => {
+    const missingPath = join(tmpDir, "does-not-exist.csv");
+    process.env.SEC_UNIT_TERMS_REF = missingPath;
+
+    expect(() => loadEmbarcUnitTermsReference()).toThrow(
+      /SEC_UNIT_TERMS_REF.*does not exist/
+    );
+  });
+
+  it("env unset → falls back to the package-shipped fixture", () => {
+    delete process.env.SEC_UNIT_TERMS_REF;
+
+    const ref = loadEmbarcUnitTermsReference();
+    expect(ref.size).toBeGreaterThan(1200);
   });
 });

--- a/src/eval/embarcUnitTermsReference.ts
+++ b/src/eval/embarcUnitTermsReference.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parse } from "csv-parse/sync";
 import { resolveAsset } from "../util/resolveAsset";
@@ -39,12 +39,29 @@ export interface EmbarcUnitTermsRef {
   readonly warrant_price: number | null;
 }
 
-// `importMetaDir` resolves to `src/eval/` in dev and `dist/eval/` after the
-// build (the build-js script copies mock_data alongside), so the first
-// candidate covers both. The second candidate is a safety fallback if the
-// module ever moves relative to its assets. Resolved lazily so a missing
-// CSV doesn't crash unrelated code paths at import time.
+// `$SEC_UNIT_TERMS_REF` overrides the reference CSV path (mirrors
+// `$SEC_S1_MOCK_DIR` for the S-1 oracle) — a downstream package consuming the
+// published @workglow/sec, whose tarball ships no mock_data, points this at its
+// own vendored copy. When the env var is set, its path is honored strictly: a
+// missing file throws (naming the env var and the path) rather than silently
+// falling through to the package-relative default, so a typo in a downstream
+// caller's env cannot masquerade as "fixture missing, using default". When
+// unset, `importMetaDir` resolves to `src/eval/` in dev and `dist/eval/` after
+// the build (the build-js script copies mock_data alongside), so the first
+// candidate covers both; the second is a safety fallback if the module ever
+// moves relative to its assets. Resolved lazily so a missing CSV doesn't crash
+// unrelated code paths at import time.
 function resolveReferencePath(): string {
+  const envPath = process.env.SEC_UNIT_TERMS_REF;
+  if (envPath !== undefined && envPath !== "") {
+    if (!existsSync(envPath)) {
+      throw new Error(
+        `SEC_UNIT_TERMS_REF points at ${envPath}, which does not exist. ` +
+          `Unset the env var to use the package-shipped default, or fix the path.`
+      );
+    }
+    return envPath;
+  }
   return resolveAsset([
     join(importMetaDir, "mock_data/embarc-spac-unit-terms.csv"),
     join(importMetaDir, "../eval/mock_data/embarc-spac-unit-terms.csv"),
@@ -55,6 +72,15 @@ const toNum = (v: string): number | null => (v === "" ? null : Number(v));
 const toStr = (v: string): string | null => (v === "" ? null : v);
 
 let cache: Map<number, EmbarcUnitTermsRef> | undefined;
+
+/**
+ * Test-only: clear the memoized reference so the next load re-resolves the
+ * path (honoring any `SEC_UNIT_TERMS_REF` change) and re-parses the CSV. Avoids
+ * needing `vi.resetModules()` to exercise the env-override branches.
+ */
+export function _resetEmbarcUnitTermsCacheForTesting(): void {
+  cache = undefined;
+}
 
 /** Load (and memoize) the reference set, keyed by SPAC origin CIK. */
 export function loadEmbarcUnitTermsReference(): Map<number, EmbarcUnitTermsRef> {


### PR DESCRIPTION
## Finding

PR #211 (this branch's parent) silently removed the `SEC_UNIT_TERMS_REF` env override from `src/eval/embarcUnitTermsReference.ts` when the module was refactored to use `resolveAsset()` and `fileURLToPath`. The pre-#211 `resolveReferencePath()` began with:

```ts
const envPath = process.env.SEC_UNIT_TERMS_REF;
return resolveAsset([
  ...(envPath ? [envPath] : []),
  join(import.meta.dir, "mock_data/embarc-spac-unit-terms.csv"),
  ...
]);
```

That override is the seam **downstream packages depend on** — the published `@workglow/sec` tarball does not ship `mock_data/`, so `embarc-data` (and any future consumer of `loadEmbarcUnitTermsReference()`) points `SEC_UNIT_TERMS_REF` at its own vendored copy of the CSV. Without it, `loadEmbarcUnitTermsReference()` throws at any consumer that doesn't have the source-tree layout on disk.

## Fix

1. **Restore the override.** Re-add the `process.env.SEC_UNIT_TERMS_REF` check in `resolveReferencePath()`.
2. **Strengthen the semantics.** When the env var is set, honor it strictly: a missing file throws a clear error naming the env var and the path, rather than silently falling through to the package-relative default. A typo in a downstream caller's env cannot masquerade as "fixture missing, using default" anymore — this is the improvement over pre-#211 behavior.
3. **Restore & update the explanatory docstring** above the resolver.
4. **Add `existsSync` to the `node:fs` import** for the file-exists check.
5. **Export `_resetEmbarcUnitTermsCacheForTesting()`** so tests can force reload without `vi.resetModules()`.
6. **Tests** (`src/eval/embarcUnitTermsReference.test.ts`): a new `describe("SEC_UNIT_TERMS_REF override")` block with three cases, wrapping `process.env.SEC_UNIT_TERMS_REF` in `beforeEach`/`afterEach` restore and calling the reset helper:
   - env set + file exists → loader returns the row from the override CSV;
   - env set + file missing → loader throws matching `/SEC_UNIT_TERMS_REF.*does not exist/`;
   - env unset → committed fixture still loads (`> 1200` rows, mirroring the existing baseline test).
7. **Docs**: added a `SEC_UNIT_TERMS_REF` bullet next to `SEC_S1_MOCK_DIR` in `CLAUDE.md`.

## Verification

- `bun x vitest run src/eval/embarcUnitTermsReference.test.ts` → **10 passed** (7 existing + 3 new).
- `bun x tsc --noEmit -p tsconfig.json` → clean.

Only `src/eval/embarcUnitTermsReference.ts`, its test file, and the `CLAUDE.md` bullet are touched. No unrelated changes; no version bump.

## Stacking

This PR stacks on top of #211 (base = `claude/beautiful-archimedes-o87xem`). Merge #211 first; this PR should then rebase cleanly onto `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuvVE7bUyy4gB7Cbnyr3cn)_