### PR TITLE
fix(address): make region-nullable migration atomic and self-healing

### DIFF
--- a/src/cli/groups/bootstrap.ts
+++ b/src/cli/groups/bootstrap.ts
@@ -11,7 +11,7 @@ import { BootstrapDownloadTask } from "../../task/bootstrap/BootstrapDownloadTas
 import { FetchAllCikNamesTask } from "../../task/ciknames/FetchAllCikNamesTask";
 import { BootstrapCompanyFactsTask } from "../../task/facts/BootstrapCompanyFactsTask";
 import {
-  addFormsSweepLoop,
+  formsSweepLoop,
   newFormsWorklistTask,
   parseShardOption,
 } from "../../task/forms/formsSweep";
@@ -93,19 +93,19 @@ export function addBootstrapCommands(program: Command): void {
             );
           }
 
-          // The forms producer must be the LAST task so the sweep loop
-          // (spliced in via `addFormsSweepLoop`) auto-connects to its worklist
-          // output arrays. The loop node then lives in the outer workflow, so
-          // the CLI renders live per-iteration progress.
-          if (!options.skipForms) {
-            tasks.push(newFormsWorklistTask(undefined, parseShardOption(options.shard)));
-          }
+          // The forms producer is NOT a member of the flat task list: it is the
+          // body of the sweep's `while` loop, re-run once per batch. The loop
+          // nodes live in the outer workflow, so the CLI renders live
+          // per-iteration progress.
+          const producer = options.skipForms
+            ? undefined
+            : newFormsWorklistTask(undefined, parseShardOption(options.shard));
 
-          if (tasks.length > 0) {
+          if (tasks.length > 0 || producer !== undefined) {
             await runWorkflowCli(
               tasks,
               undefined,
-              options.skipForms ? undefined : addFormsSweepLoop
+              producer === undefined ? undefined : formsSweepLoop(producer)
             );
           }
         },

--- a/src/cli/groups/sync.ts
+++ b/src/cli/groups/sync.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { UpdateAllCompanyFactsTask } from "../../task/facts/UpdateAllCompanyFactsTask";
-import { addFormsSweepLoop, newFormsWorklistTask } from "../../task/forms/formsSweep";
+import { formsSweepLoop, newFormsWorklistTask } from "../../task/forms/formsSweep";
 import { FetchDailyIndexTask } from "../../task/index/FetchDailyIndexTask";
 import { StoreCikLastUpdatedTask } from "../../task/index/StoreCikLastUpdatedTask";
 import { UpdateAllSubmissionsTask } from "../../task/submissions/UpdateAllSubmissionsTask";
@@ -32,11 +32,10 @@ export function addSyncCommand(program: Command): void {
               new StoreCikLastUpdatedTask(),
               new UpdateAllSubmissionsTask({ defaults: { force: options.force } }),
               new UpdateAllCompanyFactsTask({ defaults: { force: options.force } }),
-              // Producer must be last so the sweep loop connects to its worklist.
-              newFormsWorklistTask(formTypes),
             ],
             undefined,
-            addFormsSweepLoop
+            // The producer is the sweep loop's body, not a task ahead of it.
+            formsSweepLoop(newFormsWorklistTask(formTypes))
           );
         },
         { force: options.force }

--- a/src/cli/groups/update.ts
+++ b/src/cli/groups/update.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { UpdateAllCompanyFactsTask } from "../../task/facts/UpdateAllCompanyFactsTask";
 import {
-  addFormsSweepLoop,
+  formsSweepLoop,
   newFormsWorklistTask,
   parseShardOption,
 } from "../../task/forms/formsSweep";
@@ -56,7 +56,8 @@ export function addUpdateCommands(program: Command): void {
       await runCommand(async () => {
         const formTypes = types.split(",");
         const shard = parseShardOption(options.shard);
-        await runWorkflowCli([newFormsWorklistTask(formTypes, shard)], undefined, addFormsSweepLoop);
+        // The producer is the sweep loop's body, not a task ahead of it.
+        await runWorkflowCli([], undefined, formsSweepLoop(newFormsWorklistTask(formTypes, shard)));
       });
     });
 }

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -79,6 +79,7 @@ import { USE_OF_PROCEEDS_REPOSITORY_TOKEN } from "../storage/use-of-proceeds/Use
 import { XBRL_FACT_REPOSITORY_TOKEN } from "../storage/xbrl/XbrlFactSchema";
 import { FORM_8K_EVENT_REPOSITORY_TOKEN } from "../storage/form-8k-event/Form8KEventSchema";
 import { migrateLegacyForm8KEventsTable } from "../storage/form-8k-event/Form8KEventLegacyMigration";
+import { migrateAddressRegionNullable } from "../storage/address/AddressRegionNullableMigration";
 import { widenNarrowColumns } from "./widenNarrowColumnsMigration";
 import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../storage/canonical/CanonicalCompanySchema";
 import {
@@ -127,6 +128,10 @@ export async function setupAllDatabases(): Promise<void> {
   // which reaches setupAllDatabases (via InitApplyTask, after EnvToDI/DefaultDI)
   // without ever running the CLI preAction hook that otherwise registers them.
   runDatabaseSetupHooks();
+  // Relax `addresses.state_or_country` to nullable on a database created before
+  // US-with-unknown-state addresses were kept rather than dropped. Row-preserving
+  // (junction tables reference address_hash_id) and a no-op on a fresh DB.
+  await migrateAddressRegionNullable();
   await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(ADDRESS_JUNCTION_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(ADDRESS_HISTORY_JUNCTION_REPOSITORY_TOKEN).setupDatabase();

--- a/src/storage/address/AddressNormalization.test.ts
+++ b/src/storage/address/AddressNormalization.test.ts
@@ -428,7 +428,7 @@ describe("cleanAddress", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should return undefined when state/country cannot be determined", () => {
+    it("assumes the US, with no state, when state/country cannot be determined", () => {
       const input = {
         street1: "123 Main St",
         city: "Unknown City",
@@ -437,7 +437,10 @@ describe("cleanAddress", () => {
       };
 
       const result = normalizeAddress(input);
-      expect(result).toBeUndefined();
+      expect(result).toBeDefined();
+      expect(result!.country_code).toBe("US");
+      expect(result!.state_or_country).toBeNull();
+      expect(result!.zip).toBe("12345");
     });
 
     it("should handle whitespace-only fields", () => {
@@ -532,9 +535,10 @@ describe("cleanAddress", () => {
       expect(result!.zip).toBe("050001");
     });
 
-    it("drops an address with a street and city but NO resolvable country", () => {
-      // The country code is the discriminator: with no state, no countryCode, no
-      // country, and nothing keyword-detectable, the address is truly bad.
+    it("assumes the US for a street+city address with NO resolvable country", () => {
+      // With no state, no countryCode, no country, and nothing keyword-detectable,
+      // the filer is a domestic one who skipped the fields — keep the address as
+      // US with an unknown region rather than dropping it.
       const result = normalizeAddress({
         street1: "123 Some St",
         city: "Someplace",
@@ -542,7 +546,41 @@ describe("cleanAddress", () => {
         countryCode: null,
         zipCode: "00000",
       });
-      expect(result).toBeUndefined();
+      expect(result).toBeDefined();
+      expect(result!.country_code).toBe("US");
+      expect(result!.state_or_country).toBeNull();
+    });
+
+    it("assumes the US when country, state, and zip are all missing", () => {
+      const result = normalizeAddress({
+        street1: "500 Boylston Street",
+        city: "Boston",
+        stateOrCountry: null,
+        countryCode: null,
+        zipCode: null,
+      });
+      expect(result).toBeDefined();
+      expect(result!.country_code).toBe("US");
+      expect(result!.state_or_country).toBeNull();
+      expect(result!.zip).toBeNull();
+      // The US assumption is made before street normalization, so the US parser
+      // still abbreviates the street type.
+      expect(result!.street1).toBe("500 Boylston St");
+    });
+
+    it("keeps a country-level SEC region rather than an arbitrary subdivision", () => {
+      // Canada's country-level code is Z4; A0 (Alberta) merely sorts first.
+      // (City deliberately not in KEYWORD_STATE_OR_COUNTRY_MAP, so the country
+      // name is the only signal.)
+      const result = normalizeAddress({
+        street1: "100 King Street West",
+        city: "Kingston",
+        stateOrCountry: null,
+        country: "Canada",
+        zipCode: "M5X 1A9",
+      });
+      expect(result!.country_code).toBe("CA");
+      expect(result!.state_or_country).toBe("Z4");
     });
 
     it("resolves a bare SEC country code in countryCode to its ISO country", () => {

--- a/src/storage/address/AddressNormalization.ts
+++ b/src/storage/address/AddressNormalization.ts
@@ -351,6 +351,9 @@ export function normalizeAddress(importAddress: AddressImport | null): Address |
 
   [street1, street2, street3] = consolidateStreetAddresses(street1, street2, street3);
 
+  // `findCountryByKeyword` returns "" on no match — keep the "unknown region"
+  // state as a single value (null) so downstream checks can't see an empty
+  // string where they expect a code.
   state_or_country =
     state_or_country ||
     (findCountryByKeyword([
@@ -359,13 +362,22 @@ export function normalizeAddress(importAddress: AddressImport | null): Address |
       street3,
       city,
       state_or_country,
-    ]) as StateOrCountryCode | null);
+    ]) as StateOrCountryCode) ||
+    null;
 
-  let country_code = findCountryCode(
-    state_or_country,
-    importAddress.country,
-    importAddress.countryCode
-  ) as CountryCode | null;
+  // Nothing identified a country: no state code, no country code, no country
+  // name, and no keyword hit. In EDGAR that overwhelmingly means a domestic
+  // filer who did not bother to fill the field out — a foreign filer fills it in
+  // because the form makes them. Assume the US rather than drop the address, and
+  // assume it *here*, before street/postal normalization, so an unlabeled
+  // address gets the same US street parsing and 5-digit zip treatment as a
+  // labeled one.
+  let country_code =
+    (findCountryCode(
+      state_or_country,
+      importAddress.country,
+      importAddress.countryCode
+    ) as CountryCode | null) ?? "US";
 
   city = normalizeCity(city ?? "");
 
@@ -388,24 +400,26 @@ export function normalizeAddress(importAddress: AddressImport | null): Address |
     city = city || importAddress.city || null;
     state_or_country =
       state_or_country || (importAddress.stateOrCountry as StateOrCountryCode) || null;
-    country_code = country_code || (importAddress.countryCode as CountryCode) || null;
     zip = zip || importAddress.zipCode || null;
   }
 
-  // The schema requires a region, but a foreign address often carries none. When
-  // we resolved a country but no region, use the country's own SEC code as the
-  // region — so a foreign address (e.g. Colombia, country CO / SEC F8) is kept
-  // rather than dropped for lacking a US-style state.
-  if (!state_or_country && country_code) {
-    const secForCountry = COUNTRY_STATE_CODE_ARRAY.find(([iso]) => iso === country_code)?.[1];
+  // A foreign address often carries no region. When we resolved a country but no
+  // region, use the country's own country-level SEC code as the region — so a
+  // foreign address (e.g. Colombia, country CO / SEC F8) keeps a region rather
+  // than borrowing an arbitrary subdivision's code. Country-level rows are the
+  // ones with no state name; the US has none (every US row is a state), so a US
+  // address with no state is stored with a null region, which is the intent —
+  // "United States, state unknown", not a guessed state.
+  if (!state_or_country) {
+    const secForCountry = COUNTRY_STATE_CODE_ARRAY.find(
+      ([iso, sec, state]) => iso === country_code && !state
+    )?.[1];
     if (secForCountry) state_or_country = secForCountry as StateOrCountryCode;
   }
 
-  // The country code is the discriminator for a usable address: without a
-  // resolvable country (or a street/city to place it), the address is truly bad
-  // and dropped. `state_or_country` is guaranteed above whenever a country
-  // resolved, so requiring it here is equivalent to requiring the country.
-  if (!street1 || !city || !country_code || !state_or_country) {
+  // A street and a city are what make an address usable; the country is now
+  // always known (US by assumption above), and the region is optional.
+  if (!street1 || !city) {
     return undefined;
   }
 

--- a/src/storage/address/AddressRegionNullableMigration.test.ts
+++ b/src/storage/address/AddressRegionNullableMigration.test.ts
@@ -41,6 +41,66 @@ function regionColumnIsNullable(): boolean {
   return region!.notnull === 0;
 }
 
+/**
+ * Column-tuple signature (e.g. `"(city)"`) of each user-defined index on
+ * `addresses`, sorted so two equivalent index sets compare equal regardless of
+ * index name or creation order. Auto-indexes (backing PRIMARY KEY / UNIQUE
+ * constraints) carry `sql IS NULL` and are excluded, mirroring the migration's
+ * own use of `sql IS NOT NULL` to decide which indexes it must recreate.
+ */
+function readAddressIndexColumnTuples(): string[] {
+  return getDb()
+    .prepare<
+      [],
+      { name: string; sql: string }
+    >(`SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='addresses' AND sql IS NOT NULL`)
+    .all()
+    .map(({ sql }) => {
+      const match = sql.match(/\(([^)]+)\)/);
+      if (!match) throw new Error(`unexpected index SQL: ${sql}`);
+      return `(${match[1]
+        .split(",")
+        .map((c) => c.trim().replace(/`/g, ""))
+        .join(", ")})`;
+    })
+    .sort();
+}
+
+/**
+ * The exact user-index shape a fresh `setupAllDatabases()` produces on the
+ * `addresses` table — captured once in an isolated scratch DB and reused by the
+ * migrated-shape assertions below. Comparing the exact tuple set (rather than a
+ * threshold like `length > 0`) is what catches a silent unindexed rebuild.
+ */
+let cachedFreshAddressIndexColumns: readonly string[] | null = null;
+async function computeFreshAddressIndexColumns(): Promise<readonly string[]> {
+  if (cachedFreshAddressIndexColumns) return cachedFreshAddressIndexColumns;
+  const scratch = mkdtempSync(join(tmpdir(), "sec-fresh-address-shape-"));
+  try {
+    resetDependencyInjectionsForTesting();
+    closeDb();
+    if (typeof Sqlite.init === "function") {
+      await Sqlite.init();
+    }
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "sqlite");
+    globalServiceRegistry.registerInstance(SEC_DB_FOLDER, scratch);
+    globalServiceRegistry.registerInstance(SEC_DB_NAME, "fresh_addresses_shape");
+    DefaultDI();
+    await setupAllDatabases();
+    const tuples = readAddressIndexColumnTuples();
+    // Guard the guard: if a future refactor drops every user-defined index on
+    // `addresses`, the assertions below would degenerate to comparing empty
+    // arrays. Fail loudly here instead.
+    expect(tuples.length).toBeGreaterThan(0);
+    cachedFreshAddressIndexColumns = tuples;
+    return tuples;
+  } finally {
+    closeDb();
+    rmSync(scratch, { recursive: true, force: true });
+    resetDependencyInjectionsForTesting();
+  }
+}
+
 describe("migrateAddressRegionNullable (sqlite)", () => {
   let tmpDir: string;
 
@@ -63,6 +123,14 @@ describe("migrateAddressRegionNullable (sqlite)", () => {
   });
 
   it("relaxes the NOT NULL region on a legacy table and preserves every row", async () => {
+    const expectedIndexColumns = await computeFreshAddressIndexColumns();
+    // The helper closes the DB and clears DI; re-establish the per-test state.
+    closeDb();
+    resetDependencyInjectionsForTesting();
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "sqlite");
+    globalServiceRegistry.registerInstance(SEC_DB_FOLDER, tmpDir);
+    globalServiceRegistry.registerInstance(SEC_DB_NAME, TEST_DB_NAME);
+
     const db = getDb();
     db.exec(LEGACY_DDL);
     db.exec(`CREATE INDEX IF NOT EXISTS idx_addresses_city ON addresses (city)`);
@@ -85,14 +153,10 @@ describe("migrateAddressRegionNullable (sqlite)", () => {
       .all();
     expect(rows).toEqual([{ address_hash_id: "hash-1", city: "NEW YORK", state_or_country: "NY" }]);
 
-    // The rebuild must not leave the table unindexed, and the scratch table is gone.
-    const indexes = db
-      .prepare<
-        [],
-        { name: string }
-      >(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='addresses' AND sql IS NOT NULL`)
-      .all();
-    expect(indexes.length).toBeGreaterThan(0);
+    // The rebuild must land on the exact index set a fresh DB has — a threshold
+    // like "> 0" would still pass if half the indexes were silently dropped by
+    // a future ALTER path.
+    expect(readAddressIndexColumnTuples()).toEqual(expectedIndexColumns);
     const leftover = db
       .prepare<
         [],
@@ -146,5 +210,146 @@ describe("migrateAddressRegionNullable (sqlite)", () => {
       .get(ADDRESS_REPOSITORY_TOKEN)
       .get({ address_hash_id: "hash-3" });
     expect(stored?.city).toBe("CUPERTINO");
+  });
+
+  it("recovers from an interrupt between RENAME and INSERT", async () => {
+    const expectedIndexColumns = await computeFreshAddressIndexColumns();
+    closeDb();
+    resetDependencyInjectionsForTesting();
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "sqlite");
+    globalServiceRegistry.registerInstance(SEC_DB_FOLDER, tmpDir);
+    globalServiceRegistry.registerInstance(SEC_DB_NAME, TEST_DB_NAME);
+
+    const db = getDb();
+    db.exec(LEGACY_DDL);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_addresses_city ON addresses (city)`);
+    const insert = db.prepare(
+      `INSERT INTO addresses
+         (address_hash_id, street1, street2, street3, city, state_or_country, country_code, zip)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    insert.run("hash-a", "1 First St", null, null, "NEW YORK", "NY", "US", "10001");
+    insert.run("hash-b", "2 Second St", null, null, "BOSTON", "MA", "US", "02116");
+
+    DefaultDI();
+
+    // Simulate the exact stranded state the finding describes: a crash after
+    // the rename + fresh-empty rebuild but before INSERT ran. Rename the legacy
+    // table aside, drop its indexes (so setupDatabase's `CREATE INDEX IF NOT
+    // EXISTS` actually runs), then let the repo recreate an empty `addresses`
+    // at the current (nullable) schema.
+    db.exec(`ALTER TABLE addresses RENAME TO addresses__legacy_region`);
+    const strandedIndexes = db
+      .prepare<
+        [],
+        { name: string }
+      >(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='addresses__legacy_region' AND sql IS NOT NULL`)
+      .all();
+    for (const { name } of strandedIndexes) {
+      db.exec(`DROP INDEX IF EXISTS \`${name}\``);
+    }
+    await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).setupDatabase();
+
+    // Sanity: this is the exact stranded shape — empty `addresses`, all rows
+    // in the legacy table, no way to reach them through the normal repo.
+    const preRows = db
+      .prepare<[], { n: number }>(`SELECT COUNT(*) AS n FROM addresses`)
+      .get();
+    expect(preRows?.n).toBe(0);
+    const preLegacyRows = db
+      .prepare<[], { n: number }>(`SELECT COUNT(*) AS n FROM addresses__legacy_region`)
+      .get();
+    expect(preLegacyRows?.n).toBe(2);
+
+    // Booting into a normal setup pass must recover every stranded row rather
+    // than silently accepting the fresh-empty `addresses` shape.
+    await setupAllDatabases();
+
+    const rows = db
+      .prepare<
+        [],
+        { address_hash_id: string; city: string; state_or_country: string | null }
+      >(`SELECT address_hash_id, city, state_or_country FROM addresses ORDER BY address_hash_id`)
+      .all();
+    expect(rows).toEqual([
+      { address_hash_id: "hash-a", city: "NEW YORK", state_or_country: "NY" },
+      { address_hash_id: "hash-b", city: "BOSTON", state_or_country: "MA" },
+    ]);
+    expect(regionColumnIsNullable()).toBe(true);
+    expect(readAddressIndexColumnTuples()).toEqual(expectedIndexColumns);
+    const leftover = db
+      .prepare<
+        [],
+        { name: string }
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name='addresses__legacy_region'`)
+      .get();
+    expect(leftover).toBeUndefined();
+  });
+
+  it("rolls back a failed migration attempt", async () => {
+    const db = getDb();
+    db.exec(LEGACY_DDL);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_addresses_city ON addresses (city)`);
+    const insert = db.prepare(
+      `INSERT INTO addresses
+         (address_hash_id, street1, street2, street3, city, state_or_country, country_code, zip)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    insert.run("hash-x", "1 First St", null, null, "NEW YORK", "NY", "US", "10001");
+    insert.run("hash-y", "2 Second St", null, null, "BOSTON", "MA", "US", "02116");
+
+    DefaultDI();
+
+    // Force the setupDatabase() inside the migration's rebuild to throw. The
+    // second call (post-migration, from the setupAllDatabases fan-out) is
+    // never reached because the migration itself rejects and cascades out.
+    const realRepo = globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN);
+    let setupCalls = 0;
+    const proxyRepo = new Proxy(realRepo, {
+      get(target, prop, receiver) {
+        if (prop === "setupDatabase") {
+          return async () => {
+            setupCalls += 1;
+            if (setupCalls === 1) {
+              throw new Error("simulated setup failure");
+            }
+            return Reflect.get(target, prop, receiver).call(target);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    globalServiceRegistry.registerInstance(ADDRESS_REPOSITORY_TOKEN, proxyRepo);
+
+    await expect(setupAllDatabases()).rejects.toThrow("simulated setup failure");
+
+    // Every seeded row must still be reachable on the original legacy shape,
+    // and the scratch legacy table must not exist — either would mean the
+    // partial rebuild leaked past the rollback.
+    const columns = db
+      .prepare<[], { name: string; notnull: number }>(`PRAGMA table_info(addresses)`)
+      .all();
+    const region = columns.find((c) => c.name === "state_or_country");
+    expect(region).toBeDefined();
+    expect(region!.notnull).toBe(1);
+
+    const rows = db
+      .prepare<
+        [],
+        { address_hash_id: string; city: string; state_or_country: string | null }
+      >(`SELECT address_hash_id, city, state_or_country FROM addresses ORDER BY address_hash_id`)
+      .all();
+    expect(rows).toEqual([
+      { address_hash_id: "hash-x", city: "NEW YORK", state_or_country: "NY" },
+      { address_hash_id: "hash-y", city: "BOSTON", state_or_country: "MA" },
+    ]);
+
+    const leftover = db
+      .prepare<
+        [],
+        { name: string }
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name='addresses__legacy_region'`)
+      .get();
+    expect(leftover).toBeUndefined();
   });
 });

--- a/src/storage/address/AddressRegionNullableMigration.test.ts
+++ b/src/storage/address/AddressRegionNullableMigration.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { globalServiceRegistry, Sqlite } from "workglow";
+import { DefaultDI } from "../../config/DefaultDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
+import { closeDb, getDb } from "../../util/db";
+import { ADDRESS_REPOSITORY_TOKEN } from "./AddressSchema";
+
+const TEST_DB_NAME = "address_region_nullable_migration_test";
+
+/** The pre-migration shape: `state_or_country` declared NOT NULL. */
+const LEGACY_DDL = `
+  CREATE TABLE addresses (
+    address_hash_id TEXT NOT NULL,
+    street1 TEXT NOT NULL,
+    street2 TEXT NULL,
+    street3 TEXT NULL,
+    city TEXT NOT NULL,
+    state_or_country TEXT NOT NULL,
+    country_code TEXT NOT NULL,
+    zip TEXT NULL,
+    PRIMARY KEY (address_hash_id)
+  )`;
+
+function regionColumnIsNullable(): boolean {
+  const columns = getDb()
+    .prepare<[], { name: string; notnull: number }>(`PRAGMA table_info(addresses)`)
+    .all();
+  const region = columns.find((c) => c.name === "state_or_country");
+  expect(region).toBeDefined();
+  return region!.notnull === 0;
+}
+
+describe("migrateAddressRegionNullable (sqlite)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    closeDb();
+    if (typeof Sqlite.init === "function") {
+      await Sqlite.init();
+    }
+    tmpDir = mkdtempSync(join(tmpdir(), "sec-address-region-migration-"));
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "sqlite");
+    globalServiceRegistry.registerInstance(SEC_DB_FOLDER, tmpDir);
+    globalServiceRegistry.registerInstance(SEC_DB_NAME, TEST_DB_NAME);
+  });
+
+  afterEach(() => {
+    closeDb();
+    rmSync(tmpDir, { recursive: true, force: true });
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("relaxes the NOT NULL region on a legacy table and preserves every row", async () => {
+    const db = getDb();
+    db.exec(LEGACY_DDL);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_addresses_city ON addresses (city)`);
+    db.prepare(
+      `INSERT INTO addresses
+         (address_hash_id, street1, street2, street3, city, state_or_country, country_code, zip)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run("hash-1", "123 Main St", null, null, "NEW YORK", "NY", "US", "10001");
+
+    DefaultDI();
+    await setupAllDatabases();
+
+    expect(regionColumnIsNullable()).toBe(true);
+
+    const rows = db
+      .prepare<
+        [],
+        { address_hash_id: string; city: string; state_or_country: string | null }
+      >(`SELECT address_hash_id, city, state_or_country FROM addresses`)
+      .all();
+    expect(rows).toEqual([{ address_hash_id: "hash-1", city: "NEW YORK", state_or_country: "NY" }]);
+
+    // The rebuild must not leave the table unindexed, and the scratch table is gone.
+    const indexes = db
+      .prepare<
+        [],
+        { name: string }
+      >(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='addresses' AND sql IS NOT NULL`)
+      .all();
+    expect(indexes.length).toBeGreaterThan(0);
+    const leftover = db
+      .prepare<
+        [],
+        { name: string }
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name='addresses__legacy_region'`)
+      .get();
+    expect(leftover).toBeUndefined();
+
+    // A US address with no state now stores rather than failing the constraint.
+    await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).put({
+      address_hash_id: "hash-2",
+      street1: "500 Boylston St",
+      street2: null,
+      street3: null,
+      city: "BOSTON",
+      state_or_country: null,
+      country_code: "US",
+      zip: null,
+    });
+    const stored = await globalServiceRegistry
+      .get(ADDRESS_REPOSITORY_TOKEN)
+      .get({ address_hash_id: "hash-2" });
+    expect(stored?.state_or_country).toBeNull();
+  });
+
+  it("is a no-op on a fresh database", async () => {
+    DefaultDI();
+    await setupAllDatabases();
+    expect(regionColumnIsNullable()).toBe(true);
+  });
+
+  it("is a no-op when the column is already nullable", async () => {
+    DefaultDI();
+    await setupAllDatabases();
+    await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).put({
+      address_hash_id: "hash-3",
+      street1: "1 Infinite Loop",
+      street2: null,
+      street3: null,
+      city: "CUPERTINO",
+      state_or_country: "CA",
+      country_code: "US",
+      zip: "95014",
+    });
+
+    // Second setup pass: the migration must not touch an already-migrated table.
+    await setupAllDatabases();
+
+    expect(regionColumnIsNullable()).toBe(true);
+    const stored = await globalServiceRegistry
+      .get(ADDRESS_REPOSITORY_TOKEN)
+      .get({ address_hash_id: "hash-3" });
+    expect(stored?.city).toBe("CUPERTINO");
+  });
+});

--- a/src/storage/address/AddressRegionNullableMigration.ts
+++ b/src/storage/address/AddressRegionNullableMigration.ts
@@ -28,10 +28,15 @@ const COLUMN = "state_or_country";
  * re-extracted: entity/canonical junction rows reference `address_hash_id`.
  * So the rows are preserved on both backends —
  *
- * - Postgres: `ALTER COLUMN ... DROP NOT NULL`, a catalog-only change.
+ * - Postgres: `ALTER COLUMN ... DROP NOT NULL`, a single atomic DDL — no
+ *   transaction wrapping is needed. Do not add one.
  * - SQLite: no ALTER can relax a column constraint, so the table is rebuilt —
  *   rename aside, recreate at the current schema, copy every row back, drop the
  *   old one. The column list comes from `AddressSchema`, so it cannot drift.
+ *   The rebuild is a single atomic `BEGIN IMMEDIATE`/`COMMIT` block, and a
+ *   partial run left behind by a prior interrupt (a stranded
+ *   `addresses__legacy_region`) is self-healed on the next boot before the
+ *   normal flow runs.
  *
  * Idempotent: a fresh DB has no table (no-op), an already-migrated DB has a
  * nullable column (no-op).
@@ -61,6 +66,51 @@ export async function migrateAddressRegionNullable(): Promise<void> {
 async function migrateSqlite(): Promise<void> {
   const db = getDb();
 
+  // Self-heal a prior interrupted run before deciding whether the current-shape
+  // checks below have anything to do. A previous crash between RENAME and the
+  // final DROP would leave `addresses__legacy_region` on disk (with the real
+  // rows), while `addresses` is either missing or an empty rebuilt copy. Without
+  // this, the notnull check further down would short-circuit — a fresh-nullable
+  // `addresses` looks already-migrated — and strand those rows forever.
+  const legacyPresent = db
+    .prepare<[], { name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='${LEGACY_TABLE}'`
+    )
+    .get();
+  if (legacyPresent) {
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      const legacyCount = db
+        .prepare<[], { n: number }>(`SELECT COUNT(*) AS n FROM ${LEGACY_TABLE}`)
+        .get();
+      const currentPresent = db
+        .prepare<[], { name: string }>(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='${TABLE}'`
+        )
+        .get();
+      const currentCount = currentPresent
+        ? db.prepare<[], { n: number }>(`SELECT COUNT(*) AS n FROM ${TABLE}`).get()
+        : { n: 0 };
+      const legacyN = legacyCount?.n ?? 0;
+      const currentN = currentCount?.n ?? 0;
+      if (legacyN > 0 && (!currentPresent || currentN === 0)) {
+        // Legacy carries the data, `addresses` does not — restore the
+        // pre-migration state so the normal flow below rebuilds it from scratch.
+        db.exec(`DROP TABLE IF EXISTS ${TABLE}`);
+        db.exec(`ALTER TABLE ${LEGACY_TABLE} RENAME TO ${TABLE}`);
+      } else {
+        // Current already carries the data (a COMMITted rebuild that died
+        // before the final drop, or an empty legacy from a rerun) — discard
+        // the stale scratch table.
+        db.exec(`DROP TABLE ${LEGACY_TABLE}`);
+      }
+      db.exec("COMMIT");
+    } catch (e) {
+      db.exec("ROLLBACK");
+      throw e;
+    }
+  }
+
   const tableExists = db
     .prepare<[], { name: string }>(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='${TABLE}'`
@@ -76,34 +126,47 @@ async function migrateSqlite(): Promise<void> {
   // nullable → nothing to do.
   if (!region || region.notnull === 0) return;
 
-  // A previous interrupted run could have left the legacy table behind; the
-  // rename below would fail on it.
-  db.exec(`DROP TABLE IF EXISTS ${LEGACY_TABLE}`);
-  db.exec(`ALTER TABLE ${TABLE} RENAME TO ${LEGACY_TABLE}`);
+  // All five DDL steps must succeed or fail as a unit; otherwise an interrupt
+  // between RENAME and INSERT strands historical rows in the legacy table.
+  // A manual `BEGIN IMMEDIATE` (not `db.transaction(...)`) is required because
+  // one of the steps — `addressRepo.setupDatabase()` — is async and the sync
+  // callback form of the wrapper cannot await. Every DDL step below runs on
+  // the single `getDb()` connection, so it is enrolled in this transaction.
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    // The recovery block above should have handled this, but stay defensive:
+    // the rename would fail on any stray legacy table.
+    db.exec(`DROP TABLE IF EXISTS ${LEGACY_TABLE}`);
+    db.exec(`ALTER TABLE ${TABLE} RENAME TO ${LEGACY_TABLE}`);
 
-  // SQLite carries a renamed table's indexes along under their original names,
-  // which would make the `CREATE INDEX IF NOT EXISTS` in setupDatabase() a
-  // silent no-op and leave the rebuilt table unindexed. Drop them first.
-  // (`sql IS NULL` marks auto-indexes, which cannot be dropped directly.)
-  const legacyIndexes = db
-    .prepare<[], { name: string }>(
-      `SELECT name FROM sqlite_master
-        WHERE type='index' AND tbl_name='${LEGACY_TABLE}' AND sql IS NOT NULL`
-    )
-    .all();
-  for (const { name } of legacyIndexes) {
-    db.exec(`DROP INDEX IF EXISTS \`${name}\``);
+    // SQLite carries a renamed table's indexes along under their original names,
+    // which would make the `CREATE INDEX IF NOT EXISTS` in setupDatabase() a
+    // silent no-op and leave the rebuilt table unindexed. Drop them first.
+    // (`sql IS NULL` marks auto-indexes, which cannot be dropped directly.)
+    const legacyIndexes = db
+      .prepare<[], { name: string }>(
+        `SELECT name FROM sqlite_master
+          WHERE type='index' AND tbl_name='${LEGACY_TABLE}' AND sql IS NOT NULL`
+      )
+      .all();
+    for (const { name } of legacyIndexes) {
+      db.exec(`DROP INDEX IF EXISTS \`${name}\``);
+    }
+
+    // Recreate `addresses` at the current schema (nullable region). setupAllDatabases
+    // calls this again right after; the second call is a no-op.
+    await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).setupDatabase();
+
+    const cols = Object.keys(AddressSchema.properties)
+      .map((c) => `\`${c}\``)
+      .join(", ");
+    db.exec(`INSERT INTO ${TABLE} (${cols}) SELECT ${cols} FROM ${LEGACY_TABLE}`);
+    db.exec(`DROP TABLE ${LEGACY_TABLE}`);
+    db.exec("COMMIT");
+  } catch (e) {
+    db.exec("ROLLBACK");
+    throw e;
   }
-
-  // Recreate `addresses` at the current schema (nullable region). setupAllDatabases
-  // calls this again right after; the second call is a no-op.
-  await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).setupDatabase();
-
-  const cols = Object.keys(AddressSchema.properties)
-    .map((c) => `\`${c}\``)
-    .join(", ");
-  db.exec(`INSERT INTO ${TABLE} (${cols}) SELECT ${cols} FROM ${LEGACY_TABLE}`);
-  db.exec(`DROP TABLE ${LEGACY_TABLE}`);
 }
 
 async function migratePostgres(): Promise<void> {

--- a/src/storage/address/AddressRegionNullableMigration.ts
+++ b/src/storage/address/AddressRegionNullableMigration.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { isDryRun } from "../../cli/isDryRun";
+import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
+import { getDb } from "../../util/db";
+import { getPgPool } from "../../util/pg";
+import { ADDRESS_REPOSITORY_TOKEN, AddressSchema } from "./AddressSchema";
+
+const TABLE = "addresses";
+const LEGACY_TABLE = "addresses__legacy_region";
+const COLUMN = "state_or_country";
+
+/**
+ * Relaxes `addresses.state_or_country` from NOT NULL to nullable.
+ *
+ * A US address whose filer left the state blank is now kept as
+ * `country_code: "US"` with a null region instead of being dropped (see
+ * `normalizeAddress`), so the column has to accept null. `CREATE TABLE IF NOT
+ * EXISTS` never alters an existing table, so a database set up before that
+ * change keeps the NOT NULL column and every such address fails to store.
+ *
+ * Unlike the legacy 8-K events table, addresses cannot simply be dropped and
+ * re-extracted: entity/canonical junction rows reference `address_hash_id`.
+ * So the rows are preserved on both backends —
+ *
+ * - Postgres: `ALTER COLUMN ... DROP NOT NULL`, a catalog-only change.
+ * - SQLite: no ALTER can relax a column constraint, so the table is rebuilt —
+ *   rename aside, recreate at the current schema, copy every row back, drop the
+ *   old one. The column list comes from `AddressSchema`, so it cannot drift.
+ *
+ * Idempotent: a fresh DB has no table (no-op), an already-migrated DB has a
+ * nullable column (no-op).
+ */
+export async function migrateAddressRegionNullable(): Promise<void> {
+  // Raw-SQL DDL reaches around the repository layer, so the dry-run
+  // ReadOnlyTabularStorage wrapper cannot intercept it — bail explicitly.
+  if (isDryRun()) return;
+
+  const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
+    ? globalServiceRegistry.get(SEC_DB_TYPE)
+    : null;
+
+  if (
+    dbType === "sqlite" &&
+    globalServiceRegistry.has(SEC_DB_FOLDER) &&
+    globalServiceRegistry.has(SEC_DB_NAME)
+  ) {
+    return migrateSqlite();
+  }
+  if (dbType === "postgres") {
+    return migratePostgres();
+  }
+  // In-memory backend: no column types, nothing to migrate.
+}
+
+async function migrateSqlite(): Promise<void> {
+  const db = getDb();
+
+  const tableExists = db
+    .prepare<[], { name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='${TABLE}'`
+    )
+    .get();
+  if (!tableExists) return;
+
+  const columns = db
+    .prepare<[], { name: string; notnull: number }>(`PRAGMA table_info(${TABLE})`)
+    .all();
+  const region = columns.find((c) => c.name === COLUMN);
+  // Column absent entirely (older shape than this migration knows) or already
+  // nullable → nothing to do.
+  if (!region || region.notnull === 0) return;
+
+  // A previous interrupted run could have left the legacy table behind; the
+  // rename below would fail on it.
+  db.exec(`DROP TABLE IF EXISTS ${LEGACY_TABLE}`);
+  db.exec(`ALTER TABLE ${TABLE} RENAME TO ${LEGACY_TABLE}`);
+
+  // SQLite carries a renamed table's indexes along under their original names,
+  // which would make the `CREATE INDEX IF NOT EXISTS` in setupDatabase() a
+  // silent no-op and leave the rebuilt table unindexed. Drop them first.
+  // (`sql IS NULL` marks auto-indexes, which cannot be dropped directly.)
+  const legacyIndexes = db
+    .prepare<[], { name: string }>(
+      `SELECT name FROM sqlite_master
+        WHERE type='index' AND tbl_name='${LEGACY_TABLE}' AND sql IS NOT NULL`
+    )
+    .all();
+  for (const { name } of legacyIndexes) {
+    db.exec(`DROP INDEX IF EXISTS \`${name}\``);
+  }
+
+  // Recreate `addresses` at the current schema (nullable region). setupAllDatabases
+  // calls this again right after; the second call is a no-op.
+  await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).setupDatabase();
+
+  const cols = Object.keys(AddressSchema.properties)
+    .map((c) => `\`${c}\``)
+    .join(", ");
+  db.exec(`INSERT INTO ${TABLE} (${cols}) SELECT ${cols} FROM ${LEGACY_TABLE}`);
+  db.exec(`DROP TABLE ${LEGACY_TABLE}`);
+}
+
+async function migratePostgres(): Promise<void> {
+  const pool = getPgPool();
+  const client = await pool.connect();
+  try {
+    const info = await client.query(
+      `SELECT is_nullable
+         FROM information_schema.columns
+        WHERE table_name = $1 AND column_name = $2`,
+      [TABLE, COLUMN]
+    );
+    // Table/column absent (nothing created yet) or already nullable → skip.
+    if (info.rowCount === 0 || info.rows[0]?.is_nullable !== "NO") return;
+    await client.query(`ALTER TABLE "${TABLE}" ALTER COLUMN "${COLUMN}" DROP NOT NULL`);
+  } finally {
+    client.release();
+  }
+}

--- a/src/storage/address/AddressSchema.ts
+++ b/src/storage/address/AddressSchema.ts
@@ -31,7 +31,10 @@ export const AddressSchema = Type.Object({
   street2: TypeNullable(Type.String({ description: "Second line of the address" })),
   street3: TypeNullable(Type.String({ description: "Third line of the address" })),
   city: Type.String({ description: "City of the address" }),
-  state_or_country: STATE_COUNTRY_CODE,
+  // Nullable: a US address whose filer left the state blank is kept as
+  // `country_code: "US"` with no region rather than dropped — see
+  // `normalizeAddress`.
+  state_or_country: TypeNullable(STATE_COUNTRY_CODE),
   country_code: COUNTRY_CODE,
   zip: TypeNullable(Type.String({ description: "Zip code of the address" })),
 });

--- a/src/storage/versioning/ExtractorRunRepo.ts
+++ b/src/storage/versioning/ExtractorRunRepo.ts
@@ -155,6 +155,28 @@ export class ExtractorRunRepo {
     extractor_version: string,
     form?: string
   ): Promise<T[]> {
+    const successfulKeys = await this.successfulRunKeys(extractor_id, extractor_version, form);
+    return filings.filter((f) => !successfulKeys.has(filingRunKey(f)));
+  }
+
+  /**
+   * The `cik::accession_number` keys of every filing already processed
+   * successfully at (extractor_id, major.minor of extractor_version[, form]).
+   *
+   * Split out of {@link listFilingsWithoutSuccessfulRun} so a caller streaming
+   * a large candidate set can build this set ONCE and test each page against
+   * it, rather than re-running the query per page. Test membership with
+   * {@link filingRunKey} so both sides agree on the key format.
+   *
+   * Sized by the extractor's successful-run count, not by the candidate
+   * filings — bounded by the extractor_runs table, so it stays modest even
+   * when the candidate set runs to millions of filings.
+   */
+  async successfulRunKeys(
+    extractor_id: string,
+    extractor_version: string,
+    form?: string
+  ): Promise<Set<string>> {
     // Patch-ceremony reading-side gating: match on major.minor
     // prefix so a row at "1.0.0" satisfies the gate for any "1.0.x" current.
     // A row at "1.1.0" or "2.0.0" does NOT satisfy a "1.0.x" gate.
@@ -181,14 +203,18 @@ export class ExtractorRunRepo {
             form,
           });
 
-    const successfulKeys = new Set(
+    return new Set(
       (successful ?? [])
         .filter((r) => r.extractor_version.startsWith(prefix))
         // Partial rows have success=true but outcome="partial"; they are NOT
         // "successful enough" — retry-dead-letters should still pick them up.
         .filter((r) => inferOutcome(r) === "success")
-        .map((r) => `${r.cik}::${r.accession_number}`)
+        .map((r) => filingRunKey(r))
     );
-    return filings.filter((f) => !successfulKeys.has(`${f.cik}::${f.accession_number}`));
   }
+}
+
+/** Key format shared by {@link ExtractorRunRepo.successfulRunKeys} and its callers. */
+export function filingRunKey(f: FilingKey): string {
+  return `${f.cik}::${f.accession_number}`;
 }

--- a/src/task/forms/ComputeFormsWorklistTask.ts
+++ b/src/task/forms/ComputeFormsWorklistTask.ts
@@ -9,7 +9,11 @@ import { globalServiceRegistry, IExecuteContext, Task } from "workglow";
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { TypeAccessionNumber } from "../../sec/edgar/accessionNumber";
 import { isDryRun } from "../../cli/isDryRun";
-import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
+import {
+  FILING_REPOSITORY_TOKEN,
+  type Filing,
+  type FilingRepositoryStorage,
+} from "../../storage/filing/FilingSchema";
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../storage/versioning/ComponentVersionSchema";
 import { FORM_TO_EXTRACTOR_ID, formToExtractorId } from "../../storage/versioning/extractorIds";
 import { ExtractorRunRepo, filingRunKey } from "../../storage/versioning/ExtractorRunRepo";
@@ -31,21 +35,44 @@ export type ComputeFormsWorklistTaskInput = {
    */
   readonly shardIndex?: number;
   readonly shardCount?: number;
+  /**
+   * Filings emitted per batch. Defaults to {@link WORKLIST_BATCH_SIZE}; exposed
+   * mainly so tests can drive the batching/resume path with a handful of rows
+   * instead of thousands.
+   */
+  readonly batchSize?: number;
 };
 
 /**
- * Rows pulled per `queryPage` call while scanning a form's filings.
+ * Rows read per query while scanning a form's filings.
  *
  * The candidate set is far too large to materialize: form 4 alone is ~4.6M
  * filings and the full 55-form worklist ~6.4M, at a measured ~460 bytes per
  * 15-column row — ~3 GB per process, multiplied again by every `--shard`
- * process, since each one scans the whole set. Paging keeps the resident cost
- * at one page of rows plus the four scalar output arrays.
+ * process, since each one scans the whole set.
  *
- * 10k trades round trips against that resident page: ~5 MB in flight, ~460
- * pages for the largest form and ~640 for the whole worklist.
+ * Must also stay above the largest single (form, cik) group, currently 4,628,
+ * so the last-key resume in {@link ComputeFormsWorklistTask.readPage} can
+ * always advance past a group. 10k gives ~2x headroom on that and holds ~5 MB
+ * in flight.
  */
 const FILING_PAGE_SIZE = 10_000;
+
+/**
+ * Filings emitted per batch — the ceiling on what the producer holds and hands
+ * to one fan-out iteration.
+ *
+ * The sweep processes FORMS_SWEEP_CONCURRENCY_LIMIT (10) filings at a time, so
+ * the worklist never needed to exist in full: it previously materialized every
+ * matching filing before the first fetch, ~1M entries and 158 MB for one shard
+ * of today's corpus, and growing without bound. Batching caps that at ~5k
+ * entries (~0.8 MB) and, more importantly, starts real work immediately
+ * instead of after a multi-minute scan.
+ *
+ * Large enough to amortize the batch barrier: at 10-way concurrency a batch is
+ * ~500 waves, so the workers draining at each batch tail cost well under 1%.
+ */
+const WORKLIST_BATCH_SIZE = 5_000;
 
 /**
  * Deterministic 32-bit FNV-1a hash of the accession number, used only to
@@ -99,6 +126,7 @@ export class ComputeFormsWorklistTask extends Task<
       form: Type.Optional(Type.Array(Type.String())),
       shardIndex: Type.Optional(Type.Integer({ minimum: 0 })),
       shardCount: Type.Optional(Type.Integer({ minimum: 1 })),
+      batchSize: Type.Optional(Type.Integer({ minimum: 1 })),
     });
   }
 
@@ -116,6 +144,27 @@ export class ComputeFormsWorklistTask extends Task<
       count: Type.Integer(),
     });
   }
+
+  /**
+   * Resume state, held on the instance rather than chained through output
+   * ports. The `while` loop's body ends in the `forEach` fan-out, so the
+   * merged body output the loop chains forward is the fan-out's, not this
+   * task's — a resume key routed through ports would silently arrive stale
+   * and the loop would never advance. The loop condition instead closes over
+   * {@link exhausted} directly (see `formsSweepLoop`), and the subgraph is
+   * built once so this instance survives every iteration.
+   */
+  private forms: string[] | undefined;
+  private formPos = 0;
+  /** Last filing emitted for the current form; the resume point within it. */
+  private lastCik: number | undefined;
+  private lastAccession: string | undefined;
+  /** Successful-run keys for the current form, rebuilt when the form advances. */
+  private successfulKeys: Set<string> | undefined;
+  private extractorVersion: string | undefined;
+
+  /** True once every requested form has been drained. Read by the loop condition. */
+  public exhausted = false;
 
   async execute(
     input: ComputeFormsWorklistTaskInput,
@@ -142,28 +191,21 @@ export class ComputeFormsWorklistTask extends Task<
     }
     const sharding = shardCount > 1;
     const dryRun = isDryRun();
+    const batchSize = input.batchSize ?? WORKLIST_BATCH_SIZE;
 
-    // The worklist is accumulated straight into the output arrays — four
-    // scalars per surviving filing — rather than into an intermediate
-    // Filing[]. A candidate set of millions of 15-column rows does not fit in
-    // memory (see the streaming note on FILING_PAGE_SIZE), and only these four
-    // fields are ever read downstream.
+    // One batch's worth of worklist — four scalars per filing, never an
+    // intermediate Filing[]. Bounded by WORKLIST_BATCH_SIZE regardless of how
+    // large the corpus grows, which is the whole point of the batching.
     const accessionNumber: string[] = [];
     const cik: number[] = [];
     const formOut: string[] = [];
     const fileName: string[] = [];
-    let count = 0;
 
     // Cache active-slot lookups per extractor_id. Active slot is "next if a
     // dev version exists, else current" — shared across every form that maps
     // to the same extractor id so we don't re-resolve it per form.
     const slotCache = new Map<string, Awaited<ReturnType<typeof getActiveSlot>>>();
-    for (const form of formSet) {
-      const extractorId = formToExtractorId(form);
-      if (!extractorId) {
-        console.warn(`update-forms: form '${form}' has no registered extractor; skipping`);
-        continue;
-      }
+    const resolveVersion = async (extractorId: string): Promise<string> => {
       let active = slotCache.get(extractorId);
       if (active === undefined) {
         const resolved = await getActiveSlot(versionRegistry, "extractor", extractorId);
@@ -175,62 +217,194 @@ export class ComputeFormsWorklistTask extends Task<
         active = resolved;
         slotCache.set(extractorId, active);
       }
-      const extractorVersion = active.semver;
+      return active.semver;
+    };
 
-      // Built once per form, then tested per page. Sized by this extractor's
-      // successful runs, not by the form's filing count.
-      const successfulKeys = await runRepo.successfulRunKeys(extractorId, extractorVersion, form);
-
-      // Page through the form's filings instead of materializing them all.
-      // Termination follows the Page contract: stop on an empty page as well
-      // as on an absent cursor, so a concurrent delete can't spin this loop.
-      // `workglow` does not re-export PageCursor, so the opaque cursor type is
-      // inferred from the call it round-trips through.
-      let cursor: Awaited<ReturnType<typeof filingRepo.queryPage>>["nextCursor"];
-      do {
-        const page = await filingRepo.queryPage({ form }, { limit: FILING_PAGE_SIZE, cursor });
-        for (const f of page.items) {
-          // Shard first: it is a pure hash over a field already in hand and
-          // discards (shardCount-1)/shardCount of the candidates, so every
-          // later test runs on this shard's slice only.
-          if (sharding && accessionShard(f.accession_number, shardCount) !== shardIndex) {
-            continue;
-          }
-          if (successfulKeys.has(filingRunKey(f))) continue;
-          count++;
-          if (dryRun) continue;
-          accessionNumber.push(f.accession_number);
-          cik.push(f.cik);
-          formOut.push(f.form!);
-          // Strip the EDGAR inline-XBRL viewer prefix ("xslF345X02/…") so the
-          // fetch resolves the raw primary document, mirroring the prior map
-          // input mapping.
-          fileName.push(f.primary_doc.replaceAll(/^(xsl[^/]+\/)/g, ""));
-        }
-        if (page.items.length === 0) break;
-        cursor = page.nextCursor;
-      } while (cursor);
+    // Forms with a registered extractor, in a stable order so the resume
+    // position (formPos) means the same thing on every iteration.
+    if (this.forms === undefined) {
+      this.forms = [...formSet].filter((form) => {
+        if (formToExtractorId(form)) return true;
+        console.warn(`update-forms: form '${form}' has no registered extractor; skipping`);
+        return false;
+      });
     }
 
+    // Dry run reports the full total, so it scans everything in one pass and
+    // retains nothing — there is no fan-out to feed and no reason to batch.
     if (dryRun) {
-      const forms = [...formSet].join(", ");
-      // Display 1-based to match the `--shard i/N` the operator typed.
+      let total = 0;
+      for (const form of this.forms) {
+        const extractorId = formToExtractorId(form)!;
+        const keys = await runRepo.successfulRunKeys(
+          extractorId,
+          await resolveVersion(extractorId),
+          form
+        );
+        let from: number | undefined;
+        let seen: string | undefined;
+        for (;;) {
+          const { rows, full } = await this.readPage(filingRepo, form, from, seen);
+          for (const f of rows) {
+            if (sharding && accessionShard(f.accession_number, shardCount) !== shardIndex) continue;
+            if (keys.has(filingRunKey(f))) continue;
+            total++;
+          }
+          if (!full) break;
+          const last = rows[rows.length - 1]!;
+          from = last.cik;
+          seen = last.accession_number;
+        }
+      }
+      this.exhausted = true;
       const shardNote = sharding ? ` (shard ${shardIndex + 1}/${shardCount})` : "";
-      console.log(`Would process ${count} unprocessed filings for forms: ${forms}${shardNote}`);
+      console.log(
+        `Would process ${total} unprocessed filings for forms: ${[...formSet].join(", ")}${shardNote}`
+      );
       return { accessionNumber: [], cik: [], form: [], fileName: [], count: 0 };
     }
 
-    // Startup banner — one line per process so each shard's terminal shows
-    // exactly what it's doing: the forms, its shard, the worklist size, and the
-    // shared fetch ceiling (the fetch budget is cluster-wide across all shards,
-    // not per-process).
-    const shardNote = sharding ? ` · shard ${shardIndex + 1}/${shardCount}` : "";
-    console.log(
-      `▶ forms sweep · form(s): ${[...formSet].join(",")}${shardNote} · ` +
-        `${count} filing(s) to process · ` +
-        `fetch ≤${SecFetchMaxPerSec} req/s (shared across shards)`
-    );
+    if (this.formPos === 0 && this.lastCik === undefined) {
+      // Startup banner — one line per process so each shard's terminal shows
+      // what it is doing: the forms, its shard, and the shared fetch ceiling
+      // (the fetch budget is cluster-wide across all shards, not per-process).
+      // The worklist size is deliberately absent: it is no longer computed up
+      // front, which is what removes the multi-minute stall before any work.
+      const shardNote = sharding ? ` · shard ${shardIndex + 1}/${shardCount}` : "";
+      console.log(
+        `▶ forms sweep · form(s): ${[...formSet].join(",")}${shardNote} · ` +
+          `batches of ≤${batchSize} · ` +
+          `fetch ≤${SecFetchMaxPerSec} req/s (shared across shards)`
+      );
+    }
 
-    return { accessionNumber, cik, form: formOut, fileName, count };
+    // Fill one batch, advancing through forms as each drains. Filings that
+    // fall outside this shard or already have a successful run are skipped
+    // here, so a batch always arrives at the fan-out full of real work.
+    while (accessionNumber.length < batchSize && this.formPos < this.forms.length) {
+      const form = this.forms[this.formPos]!;
+      const extractorId = formToExtractorId(form)!;
+
+      if (this.successfulKeys === undefined) {
+        this.extractorVersion = await resolveVersion(extractorId);
+        this.successfulKeys = await runRepo.successfulRunKeys(
+          extractorId,
+          this.extractorVersion,
+          form
+        );
+      }
+
+      const { rows, full } = await this.readPage(filingRepo, form, this.lastCik, this.lastAccession);
+      if (rows.length === 0 && !full) {
+        // Form drained — advance and reset its per-form resume state.
+        this.formPos++;
+        this.lastCik = undefined;
+        this.lastAccession = undefined;
+        this.successfulKeys = undefined;
+        continue;
+      }
+
+      // Resume must advance past every row EXAMINED, not every row emitted —
+      // rows dropped by the shard or already-processed tests are consumed too
+      // and must not be re-read. Rows left unexamined because the batch filled
+      // are deliberately not covered, so the next batch re-reads them.
+      let lastExamined: Filing | undefined;
+      let examinedAll = true;
+      for (const f of rows) {
+        if (accessionNumber.length >= batchSize) {
+          examinedAll = false;
+          break;
+        }
+        lastExamined = f;
+        // Shard first: a pure hash over a field already in hand, discarding
+        // (shardCount-1)/shardCount of candidates before any other test.
+        if (sharding && accessionShard(f.accession_number, shardCount) !== shardIndex) continue;
+        if (this.successfulKeys.has(filingRunKey(f))) continue;
+        accessionNumber.push(f.accession_number);
+        cik.push(f.cik);
+        formOut.push(f.form!);
+        // Strip the EDGAR inline-XBRL viewer prefix ("xslF345X02/…") so the
+        // fetch resolves the raw primary document.
+        fileName.push(f.primary_doc.replaceAll(/^(xsl[^/]+\/)/g, ""));
+      }
+
+      if (lastExamined !== undefined) {
+        this.lastCik = lastExamined.cik;
+        this.lastAccession = lastExamined.accession_number;
+      }
+      // A short page means the form has no more rows — but only once this
+      // batch actually reached the end of it.
+      if (examinedAll && !full) {
+        this.formPos++;
+        this.lastCik = undefined;
+        this.lastAccession = undefined;
+        this.successfulKeys = undefined;
+      }
+    }
+
+    // Setting this on the batch that drains the last form (rather than on a
+    // subsequent empty one) lets the loop stop without a wasted iteration —
+    // WhileTask evaluates the condition after running the body, so this final
+    // partial batch is still fanned out.
+    if (this.formPos >= this.forms.length) this.exhausted = true;
+
+    return { accessionNumber, cik, form: formOut, fileName, count: accessionNumber.length };
+  }
+
+  /**
+   * One page of a form's filings at or after the resume point, in primary-key
+   * order.
+   *
+   * Resume is a plain last-key, not an opaque cursor: the key is two ordinary
+   * scalars that can be logged, asserted on in tests, and (unlike a cursor)
+   * would survive being persisted across a process restart.
+   *
+   * `SearchCriteria` allows one condition per column and has no OR, so the
+   * exact keyset predicate `(cik, accession) > (lastCik, lastAccession)` is
+   * not expressible. Resuming at `cik >= lastCik` and dropping the already-
+   * emitted head of that cik in memory is equivalent, and the re-read is
+   * bounded by the largest single (form, cik) group — 4,628 rows at the
+   * extreme, ~19 typical.
+   */
+  private async readPage(
+    filingRepo: FilingRepositoryStorage,
+    form: string,
+    fromCik: number | undefined,
+    afterAccession: string | undefined
+  ): Promise<{ rows: Filing[]; full: boolean }> {
+    const criteria =
+      fromCik === undefined
+        ? { form }
+        : { form, cik: { value: fromCik, operator: ">=" as const } };
+    const page =
+      ((await filingRepo.query(criteria as never, {
+        orderBy: [
+          { column: "cik", direction: "ASC" },
+          { column: "accession_number", direction: "ASC" },
+        ],
+        limit: FILING_PAGE_SIZE,
+      })) ?? []) as Filing[];
+
+    // `full` reports whether the DATABASE returned a full page, which is what
+    // says more rows may exist. It must not be derived from the returned row
+    // count: the resume head is trimmed below, so a full page routinely yields
+    // fewer rows and would otherwise read as "form drained" — silently ending
+    // the scan after a couple of pages.
+    const full = page.length === FILING_PAGE_SIZE;
+
+    if (fromCik === undefined || afterAccession === undefined) return { rows: page, full };
+
+    const fresh = page.filter((f) => f.cik !== fromCik || f.accession_number > afterAccession);
+    // A full page consumed entirely by the resume head would leave the scan
+    // unable to advance. FILING_PAGE_SIZE is chosen to exceed the largest
+    // (form, cik) group precisely so this cannot happen; fail loudly rather
+    // than spin if that assumption ever stops holding.
+    if (fresh.length === 0 && full) {
+      throw new Error(
+        `Forms worklist cannot advance: form '${form}' has more than ${FILING_PAGE_SIZE} filings ` +
+          `for cik ${fromCik}. Raise FILING_PAGE_SIZE above that group's size.`
+      );
+    }
+    return { rows: fresh, full };
   }
 }

--- a/src/task/forms/ComputeFormsWorklistTask.ts
+++ b/src/task/forms/ComputeFormsWorklistTask.ts
@@ -9,10 +9,10 @@ import { globalServiceRegistry, IExecuteContext, Task } from "workglow";
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { TypeAccessionNumber } from "../../sec/edgar/accessionNumber";
 import { isDryRun } from "../../cli/isDryRun";
-import { FILING_REPOSITORY_TOKEN, type Filing } from "../../storage/filing/FilingSchema";
+import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../storage/versioning/ComponentVersionSchema";
 import { FORM_TO_EXTRACTOR_ID, formToExtractorId } from "../../storage/versioning/extractorIds";
-import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
+import { ExtractorRunRepo, filingRunKey } from "../../storage/versioning/ExtractorRunRepo";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
 import { getActiveSlot } from "../../storage/versioning/getActiveSlot";
 import { VersionRegistry } from "../../storage/versioning/VersionRegistry";
@@ -32,6 +32,20 @@ export type ComputeFormsWorklistTaskInput = {
   readonly shardIndex?: number;
   readonly shardCount?: number;
 };
+
+/**
+ * Rows pulled per `queryPage` call while scanning a form's filings.
+ *
+ * The candidate set is far too large to materialize: form 4 alone is ~4.6M
+ * filings and the full 55-form worklist ~6.4M, at a measured ~460 bytes per
+ * 15-column row — ~3 GB per process, multiplied again by every `--shard`
+ * process, since each one scans the whole set. Paging keeps the resident cost
+ * at one page of rows plus the four scalar output arrays.
+ *
+ * 10k trades round trips against that resident page: ~5 MB in flight, ~460
+ * pages for the largest form and ~640 for the whole worklist.
+ */
+const FILING_PAGE_SIZE = 10_000;
 
 /**
  * Deterministic 32-bit FNV-1a hash of the accession number, used only to
@@ -127,8 +141,18 @@ export class ComputeFormsWorklistTask extends Task<
       );
     }
     const sharding = shardCount > 1;
+    const dryRun = isDryRun();
 
-    const formsToProcess: Filing[] = [];
+    // The worklist is accumulated straight into the output arrays — four
+    // scalars per surviving filing — rather than into an intermediate
+    // Filing[]. A candidate set of millions of 15-column rows does not fit in
+    // memory (see the streaming note on FILING_PAGE_SIZE), and only these four
+    // fields are ever read downstream.
+    const accessionNumber: string[] = [];
+    const cik: number[] = [];
+    const formOut: string[] = [];
+    const fileName: string[] = [];
+    let count = 0;
 
     // Cache active-slot lookups per extractor_id. Active slot is "next if a
     // dev version exists, else current" — shared across every form that maps
@@ -153,28 +177,46 @@ export class ComputeFormsWorklistTask extends Task<
       }
       const extractorVersion = active.semver;
 
-      const _filings = (await filingRepo.query({ form })) ?? [];
-      const unprocessed = await runRepo.listFilingsWithoutSuccessfulRun(
-        _filings,
-        extractorId,
-        extractorVersion,
-        form
-      );
-      for (const f of unprocessed) {
-        if (sharding && accessionShard(f.accession_number, shardCount) !== shardIndex) {
-          continue;
+      // Built once per form, then tested per page. Sized by this extractor's
+      // successful runs, not by the form's filing count.
+      const successfulKeys = await runRepo.successfulRunKeys(extractorId, extractorVersion, form);
+
+      // Page through the form's filings instead of materializing them all.
+      // Termination follows the Page contract: stop on an empty page as well
+      // as on an absent cursor, so a concurrent delete can't spin this loop.
+      // `workglow` does not re-export PageCursor, so the opaque cursor type is
+      // inferred from the call it round-trips through.
+      let cursor: Awaited<ReturnType<typeof filingRepo.queryPage>>["nextCursor"];
+      do {
+        const page = await filingRepo.queryPage({ form }, { limit: FILING_PAGE_SIZE, cursor });
+        for (const f of page.items) {
+          // Shard first: it is a pure hash over a field already in hand and
+          // discards (shardCount-1)/shardCount of the candidates, so every
+          // later test runs on this shard's slice only.
+          if (sharding && accessionShard(f.accession_number, shardCount) !== shardIndex) {
+            continue;
+          }
+          if (successfulKeys.has(filingRunKey(f))) continue;
+          count++;
+          if (dryRun) continue;
+          accessionNumber.push(f.accession_number);
+          cik.push(f.cik);
+          formOut.push(f.form!);
+          // Strip the EDGAR inline-XBRL viewer prefix ("xslF345X02/…") so the
+          // fetch resolves the raw primary document, mirroring the prior map
+          // input mapping.
+          fileName.push(f.primary_doc.replaceAll(/^(xsl[^/]+\/)/g, ""));
         }
-        formsToProcess.push(f);
-      }
+        if (page.items.length === 0) break;
+        cursor = page.nextCursor;
+      } while (cursor);
     }
 
-    if (isDryRun()) {
+    if (dryRun) {
       const forms = [...formSet].join(", ");
       // Display 1-based to match the `--shard i/N` the operator typed.
       const shardNote = sharding ? ` (shard ${shardIndex + 1}/${shardCount})` : "";
-      console.log(
-        `Would process ${formsToProcess.length} unprocessed filings for forms: ${forms}${shardNote}`
-      );
+      console.log(`Would process ${count} unprocessed filings for forms: ${forms}${shardNote}`);
       return { accessionNumber: [], cik: [], form: [], fileName: [], count: 0 };
     }
 
@@ -185,18 +227,10 @@ export class ComputeFormsWorklistTask extends Task<
     const shardNote = sharding ? ` · shard ${shardIndex + 1}/${shardCount}` : "";
     console.log(
       `▶ forms sweep · form(s): ${[...formSet].join(",")}${shardNote} · ` +
-        `${formsToProcess.length} filing(s) to process · ` +
+        `${count} filing(s) to process · ` +
         `fetch ≤${SecFetchMaxPerSec} req/s (shared across shards)`
     );
 
-    return {
-      accessionNumber: formsToProcess.map((f) => f.accession_number),
-      cik: formsToProcess.map((f) => f.cik),
-      form: formsToProcess.map((f) => f.form!),
-      // Strip the EDGAR inline-XBRL viewer prefix ("xslF345X02/…") so the fetch
-      // resolves the raw primary document, mirroring the prior map input mapping.
-      fileName: formsToProcess.map((f) => f.primary_doc.replaceAll(/^(xsl[^/]+\/)/g, "")),
-      count: formsToProcess.length,
-    };
+    return { accessionNumber, cik, form: formOut, fileName, count };
   }
 }

--- a/src/task/forms/formsSweep.test.ts
+++ b/src/task/forms/formsSweep.test.ts
@@ -17,7 +17,7 @@ import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
 import { setupAllDatabases } from "../../config/setupAllDatabases";
 import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
 import { ComputeFormsWorklistTask } from "./ComputeFormsWorklistTask";
-import { addFormsSweepLoop, parseShardOption } from "./formsSweep";
+import { formsSweepLoop, parseShardOption } from "./formsSweep";
 import {
   ProcessAccessionDocFormTask,
   type ProcessAccessionDocFormTaskInput,
@@ -127,51 +127,65 @@ describe("forms sweep wiring", () => {
     expect(new Set(rerun.accessionNumber)).toEqual(new Set(perShard[0]));
   });
 
-  it("streams each form by bounded page instead of materializing the whole form", async () => {
+  it("reads each form in bounded pages instead of materializing the whole form", async () => {
     // Regression guard for the worklist OOM: the producer used to call
     // `filingRepo.query({ form })`, pulling every filing of a form into one
     // array (~4.6M rows for form 4, ~3 GB per process — and every `--shard`
     // process paid it in full, because the shard filter ran afterwards).
-    // The scan must stay paged and bounded no matter how large the form is.
+    // Every read must stay bounded no matter how large the form is.
     await seed({ cik: 111, accession_number: "0000000001-26-000001", form: "3", primary_doc: "a.xml" });
     await seed({ cik: 222, accession_number: "0000000002-26-000002", form: "3", primary_doc: "b.xml" });
 
     const repo = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
-    const bareQueries: unknown[] = [];
-    const pageLimits: Array<number | undefined> = [];
+    const limits: Array<number | undefined> = [];
     const realQuery = repo.query.bind(repo);
-    const realQueryPage = repo.queryPage.bind(repo);
-    repo.query = ((criteria: never, options: never) => {
-      // The regressed call was a bare `query({ form })` with no second
-      // argument. Storage's own generic pager also reaches `query`, but always
-      // with options (orderBy, and a limit unless it is over-fetching to
-      // filter in memory), so the missing-options case isolates the producer.
-      if (options === undefined) bareQueries.push(criteria);
-      return realQuery(criteria, options);
+    repo.query = ((criteria: never, options: { limit?: number } | undefined) => {
+      limits.push(options?.limit);
+      return realQuery(criteria, options as never);
     }) as typeof repo.query;
-    repo.queryPage = ((criteria: never, request: { limit?: number } | undefined) => {
-      pageLimits.push(request?.limit);
-      return realQueryPage(criteria, request as never);
-    }) as typeof repo.queryPage;
 
     try {
       const out = await new ComputeFormsWorklistTask({ defaults: { form: ["3"] } }).run({});
       expect(out.count).toBe(2);
 
-      // No whole-form read: every filing read goes through the pager.
-      expect(bareQueries).toEqual([]);
-      expect(pageLimits.length).toBeGreaterThan(0);
-      // Every page the producer requests is bounded — an undefined limit would
-      // leave the page size to a default the producer does not control.
-      for (const limit of pageLimits) {
+      expect(limits.length).toBeGreaterThan(0);
+      // A bare `query({ form })` — the regressed call — has no options at all,
+      // so an undefined limit is exactly the failure this guards against.
+      for (const limit of limits) {
         expect(limit).toBeTypeOf("number");
         expect(limit!).toBeGreaterThan(0);
         expect(limit!).toBeLessThanOrEqual(10_000);
       }
     } finally {
       repo.query = realQuery;
-      repo.queryPage = realQueryPage;
     }
+  });
+
+  it("emits bounded batches and resumes across them, covering every filing once", async () => {
+    // The batch ceiling is what keeps the producer's memory independent of the
+    // corpus: it must hand out at most `batchSize` per call and pick up exactly
+    // where it left off, with no filing dropped or repeated across batches.
+    const accessions: string[] = [];
+    for (let i = 1; i <= 7; i++) {
+      const acc = `0000000${String(i).padStart(3, "0")}-26-000001`;
+      accessions.push(acc);
+      await seed({ cik: 100 + i, accession_number: acc, form: "3", primary_doc: "a.xml" });
+    }
+
+    const producer = new ComputeFormsWorklistTask({ defaults: { form: ["3"], batchSize: 3 } });
+    const batches: string[][] = [];
+    while (!producer.exhausted) {
+      const out = await producer.run({});
+      batches.push(out.accessionNumber);
+      expect(out.accessionNumber.length).toBeLessThanOrEqual(3);
+      expect(out.count).toBe(out.accessionNumber.length);
+      expect(batches.length).toBeLessThanOrEqual(10); // guard against a non-advancing loop
+    }
+
+    expect(batches.length).toBeGreaterThan(1); // actually batched, not one big list
+    const emitted = batches.flat();
+    expect(emitted.length).toBe(accessions.length); // no duplicates across batches
+    expect(new Set(emitted)).toEqual(new Set(accessions)); // and none dropped
   });
 
   it("parseShardOption converts 1-based i/N to a 0-based shard and rejects bad input", () => {
@@ -245,7 +259,7 @@ describe("forms sweep wiring", () => {
     expect(messages).toContain("3 0000000001-26-000001 · working");
   });
 
-  it("addFormsSweepLoop builds a runnable loop over the producer's worklist", async () => {
+  it("formsSweepLoop builds a runnable while+forEach sweep over the batches", async () => {
     // Exercises the exact production helper (not a hand-rolled copy) end to end.
     // ProcessAccessionDocFormTask has no primary_doc match here, so it
     // dead-letters PRIMARY_DOC_UNRESOLVED and returns {success:false} per
@@ -255,8 +269,7 @@ describe("forms sweep wiring", () => {
     await seed({ cik: 222, accession_number: "0000000002-26-000002", form: "3", primary_doc: "" });
 
     const wf = new Workflow();
-    wf.pipe(new ComputeFormsWorklistTask({ defaults: { form: ["3"] } }) as ITask<DataPorts, DataPorts>);
-    addFormsSweepLoop(wf);
+    formsSweepLoop(new ComputeFormsWorklistTask({ defaults: { form: ["3"] } }))(wf);
     wf.pipe(new OutputTask() as ITask<DataPorts, DataPorts>);
 
     await expect(wf.run({})).resolves.toBeDefined();

--- a/src/task/forms/formsSweep.test.ts
+++ b/src/task/forms/formsSweep.test.ts
@@ -127,6 +127,53 @@ describe("forms sweep wiring", () => {
     expect(new Set(rerun.accessionNumber)).toEqual(new Set(perShard[0]));
   });
 
+  it("streams each form by bounded page instead of materializing the whole form", async () => {
+    // Regression guard for the worklist OOM: the producer used to call
+    // `filingRepo.query({ form })`, pulling every filing of a form into one
+    // array (~4.6M rows for form 4, ~3 GB per process — and every `--shard`
+    // process paid it in full, because the shard filter ran afterwards).
+    // The scan must stay paged and bounded no matter how large the form is.
+    await seed({ cik: 111, accession_number: "0000000001-26-000001", form: "3", primary_doc: "a.xml" });
+    await seed({ cik: 222, accession_number: "0000000002-26-000002", form: "3", primary_doc: "b.xml" });
+
+    const repo = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
+    const bareQueries: unknown[] = [];
+    const pageLimits: Array<number | undefined> = [];
+    const realQuery = repo.query.bind(repo);
+    const realQueryPage = repo.queryPage.bind(repo);
+    repo.query = ((criteria: never, options: never) => {
+      // The regressed call was a bare `query({ form })` with no second
+      // argument. Storage's own generic pager also reaches `query`, but always
+      // with options (orderBy, and a limit unless it is over-fetching to
+      // filter in memory), so the missing-options case isolates the producer.
+      if (options === undefined) bareQueries.push(criteria);
+      return realQuery(criteria, options);
+    }) as typeof repo.query;
+    repo.queryPage = ((criteria: never, request: { limit?: number } | undefined) => {
+      pageLimits.push(request?.limit);
+      return realQueryPage(criteria, request as never);
+    }) as typeof repo.queryPage;
+
+    try {
+      const out = await new ComputeFormsWorklistTask({ defaults: { form: ["3"] } }).run({});
+      expect(out.count).toBe(2);
+
+      // No whole-form read: every filing read goes through the pager.
+      expect(bareQueries).toEqual([]);
+      expect(pageLimits.length).toBeGreaterThan(0);
+      // Every page the producer requests is bounded — an undefined limit would
+      // leave the page size to a default the producer does not control.
+      for (const limit of pageLimits) {
+        expect(limit).toBeTypeOf("number");
+        expect(limit!).toBeGreaterThan(0);
+        expect(limit!).toBeLessThanOrEqual(10_000);
+      }
+    } finally {
+      repo.query = realQuery;
+      repo.queryPage = realQueryPage;
+    }
+  });
+
   it("parseShardOption converts 1-based i/N to a 0-based shard and rejects bad input", () => {
     expect(parseShardOption(undefined)).toBeUndefined();
     expect(parseShardOption("")).toBeUndefined();

--- a/src/task/forms/formsSweep.ts
+++ b/src/task/forms/formsSweep.ts
@@ -59,21 +59,43 @@ export function parseShardOption(value: string | undefined): FormsShard | undefi
 }
 
 /**
- * Splices the forms fan-out loop onto a workflow whose current tail is a
- * {@link ComputeFormsWorklistTask}. The `.forEach()` loop node auto-connects
- * the producer's `accessionNumber` / `cik` / `form` / `fileName` array output
- * ports and runs one {@link ProcessAccessionDocFormTask} per filing, up to
- * {@link FORMS_SWEEP_CONCURRENCY_LIMIT} concurrently. `maxIterations` is left
- * to default to "unbounded" so the loop iterates the full worklist length,
- * which is only known at run time. Results are discarded (`forEach`), so no
- * per-iteration output is retained for a worklist that can be millions long.
+ * Builds the forms sweep: a `while` loop whose body is the batch producer
+ * followed by a `.forEach()` fan-out over the batch it just emitted.
  *
- * Because the loop is added to the OUTER workflow (not a task-private nested
- * one), it is a first-class node in the graph the CLI run renderer subscribes
- * to, so the sweep shows live per-worker iteration rows.
+ * The producer used to sit in the flat task list and compute the entire
+ * worklist once, before the first filing was fetched. It now runs once per
+ * `while` iteration and yields a bounded batch, so memory is capped by the
+ * batch rather than the corpus and work starts immediately. Pass the result to
+ * `runWorkflowCli`'s `buildAfter` and leave the producer out of the task list —
+ * it belongs to the loop body, not the graph ahead of it.
+ *
+ * The loop condition closes over the producer instance instead of reading a
+ * chained output port. The body's merged output is the fan-out's, not the
+ * producer's, so a resume key routed through ports would arrive stale on the
+ * next iteration and the loop would never advance. `maxIterations` is
+ * "unbounded" because the batch count is only known at run time; the producer's
+ * `exhausted` flag is the real terminator.
+ *
+ * The fan-out auto-connects the producer's `accessionNumber` / `cik` / `form` /
+ * `fileName` array ports by name and runs one
+ * {@link ProcessAccessionDocFormTask} per filing, up to
+ * {@link FORMS_SWEEP_CONCURRENCY_LIMIT} concurrently. Results are discarded
+ * (`forEach`), so no per-iteration output accumulates.
+ *
+ * Both loop nodes live in the OUTER workflow rather than a task-private nested
+ * one, so they stay first-class nodes in the graph the CLI renderer subscribes
+ * to and the sweep still shows live per-worker iteration rows.
  */
-export function addFormsSweepLoop(wf: Workflow): void {
-  const loop = wf.forEach({ concurrencyLimit: FORMS_SWEEP_CONCURRENCY_LIMIT });
-  loop.pipe(new ProcessAccessionDocFormTask() as ITask<DataPorts, DataPorts>);
-  loop.endForEach();
+export function formsSweepLoop(producer: ComputeFormsWorklistTask): (wf: Workflow) => void {
+  return (wf: Workflow) => {
+    const batches = wf.while({
+      condition: () => !producer.exhausted,
+      maxIterations: "unbounded",
+    });
+    batches.pipe(producer as ITask<DataPorts, DataPorts>);
+    const fanOut = batches.forEach({ concurrencyLimit: FORMS_SWEEP_CONCURRENCY_LIMIT });
+    fanOut.pipe(new ProcessAccessionDocFormTask() as ITask<DataPorts, DataPorts>);
+    fanOut.endForEach();
+    batches.endWhile();
+  };
 }


### PR DESCRIPTION
## Summary

The SQLite branch of `migrateAddressRegionNullable` (added in the parent PR #213 base branch) ran the five rebuild DDL steps at the top level with no transaction boundary — `DROP legacy` / `RENAME` / drop-per-index / async `setupDatabase()` / `INSERT ... SELECT` / `DROP legacy`. An interrupt between the RENAME and the final INSERT strands every historical address in `addresses__legacy_region`, and the migration's own early-return guards (`tableExists`, `notnull === 0`) then treat the freshly rebuilt (empty, nullable) `addresses` as already-migrated on the next boot — so the stranded rows are never recovered. Junction tables reference `address_hash_id`, so the data cannot simply be re-extracted.

This PR closes both ends of that failure mode without changing the postgres path (already atomic — one `DROP NOT NULL` DDL).

## Changes

- **Atomic rebuild.** Wrap the five SQLite mutations in a single `BEGIN IMMEDIATE` / `COMMIT` block, with a matching `ROLLBACK` on any thrown error. The block is manual rather than `db.transaction(...)` because one of the enclosed steps (`ADDRESS_REPOSITORY_TOKEN.setupDatabase()`) is async and the wrapper's sync-callback form cannot `await`. Every DDL step runs on the single `getDb()` connection, so it enrolls in the transaction.
- **Self-heal a stranded prior interrupt.** Ahead of the notnull-shape check, probe `sqlite_master` for `addresses__legacy_region`; if present, choose in an atomic block based on the two row counts:
  - legacy has rows AND `addresses` is missing/empty → restore the pre-migration state (drop the empty `addresses`, rename legacy back) so the normal flow below rebuilds it,
  - otherwise → drop the stale scratch table.
- **Postgres path unchanged**, but the JSDoc now states explicitly that the single-DDL `DROP NOT NULL` is atomic and does not need wrapping, so a future reader does not add redundant ceremony.

## Test plan

- `bun run test src/storage/address/AddressRegionNullableMigration.test.ts` — 5 passed (existing 3 preserved, 2 added).
- `bun run test src/storage/address/` — 69 passed across 4 files (regression sweep on the address tier).
- Tightened the existing "relaxes NOT NULL" test: replaced `expect(indexes.length).toBeGreaterThan(0)` with an equality check against the exact user-index tuple set a fresh `setupAllDatabases()` produces on `addresses` (memoized helper, reused across the two migrated-shape assertions). A silent unindexed rebuild now fails the assertion; the previous threshold would not.
- Added **"recovers from an interrupt between RENAME and INSERT"** — seeds the legacy shape with two rows, manually simulates the exact stranded state (rename aside, drop indexes, `setupDatabase()` a fresh empty `addresses`), then asserts the next boot reaches every seeded row, has the correct index set, and cleared the legacy table.
- Added **"rolls back a failed migration attempt"** — proxies `ADDRESS_REPOSITORY_TOKEN` so its first `setupDatabase()` call throws, expects `setupAllDatabases()` to reject, and asserts the legacy shape (`notnull === 1`) plus every seeded row still exist, with no `addresses__legacy_region` leftover.

Stacks on top of #213 (`forms-worklist-streaming`); rebase after that lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVYgNUoS8194CMP9fDCQLL)_