### PR TITLE
fix(migration): per-chunk commits + Postgres bulk insert for person-title backfill (stacked on #217)

### DIFF
--- a/src/storage/observation/PersonObservationTitlesLegacyMigration.test.ts
+++ b/src/storage/observation/PersonObservationTitlesLegacyMigration.test.ts
@@ -10,8 +10,14 @@ import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { globalServiceRegistry, Sqlite } from "workglow";
 import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
-import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
+import {
+  SEC_DB_FOLDER,
+  SEC_DB_NAME,
+  SEC_DB_TYPE,
+  SEC_PG_URL,
+} from "../../config/tokens";
 import { closeDb, getDb } from "../../util/db";
+import { closePgPool, getPgPool } from "../../util/pg";
 import { migrateLegacyPersonObservationTitles } from "./PersonObservationTitlesLegacyMigration";
 
 const TEST_DB_NAME = "person_observation_titles_migration_test";
@@ -277,3 +283,128 @@ describe("migrateLegacyPersonObservationTitles (sqlite)", () => {
     expect(captured).toBe(5000);
   });
 });
+
+describe.skipIf(!process.env.SEC_PG_URL)(
+  "migrateLegacyPersonObservationTitles (postgres)",
+  () => {
+    beforeEach(async () => {
+      resetDependencyInjectionsForTesting();
+      await closePgPool();
+      globalServiceRegistry.registerInstance(SEC_DB_TYPE, "postgres");
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      globalServiceRegistry.registerInstance(SEC_PG_URL, process.env.SEC_PG_URL!);
+
+      const client = await getPgPool().connect();
+      try {
+        // Fresh test DB expected; drop any prior artefacts so the test is
+        // reproducible even if a previous run aborted before cleanup.
+        await client.query(`DROP TABLE IF EXISTS person_observation_titles`);
+        await client.query(`DROP TABLE IF EXISTS person_observations`);
+        await client.query(
+          `CREATE TABLE person_observations (
+             observation_id INTEGER PRIMARY KEY,
+             titles TEXT NULL
+           )`
+        );
+        await client.query(
+          `CREATE TABLE person_observation_titles (
+             observation_id INTEGER NOT NULL,
+             title TEXT NOT NULL,
+             PRIMARY KEY (observation_id, title)
+           )`
+        );
+      } finally {
+        client.release();
+      }
+    });
+
+    afterEach(async () => {
+      const client = await getPgPool().connect();
+      try {
+        await client.query(`DROP TABLE IF EXISTS person_observation_titles`);
+        await client.query(`DROP TABLE IF EXISTS person_observations`);
+      } finally {
+        client.release();
+      }
+      await closePgPool();
+      resetDependencyInjectionsForTesting();
+    });
+
+    it("bulk-inserts titles via UNNEST and is idempotent on a second run", async () => {
+      const client = await getPgPool().connect();
+      try {
+        // 50 rows with a mix of shapes: multi-title arrays, some empty arrays,
+        // one with case-duplicates that normalizeTitles should collapse.
+        for (let i = 1; i <= 50; i += 1) {
+          let titles: string | null;
+          if (i % 10 === 0) {
+            titles = "[]"; // empty
+          } else if (i === 7) {
+            // case-duplicate — normalizeTitles keeps the first casing only
+            titles = JSON.stringify(["Founder", "  founder  ", "Chairman"]);
+          } else if (i % 3 === 0) {
+            titles = JSON.stringify([`Title ${i} A`, `Title ${i} B`]);
+          } else {
+            titles = JSON.stringify([`Title ${i}`]);
+          }
+          await client.query(
+            `INSERT INTO person_observations (observation_id, titles) VALUES ($1, $2)`,
+            [i, titles]
+          );
+        }
+
+        // Sanity: expected observation count is 50.
+        const expectedRows = await client.query<{ c: string }>(
+          `SELECT COUNT(*)::text AS c FROM person_observations WHERE titles IS NOT NULL`
+        );
+        expect(Number(expectedRows.rows[0]!.c)).toBe(50);
+      } finally {
+        client.release();
+      }
+
+      // Expected title-row count matches normalizeTitles' semantics: every
+      // tenth observation has an empty array (rows 10, 20, 30, 40, 50 → 5
+      // empty). Of the 45 non-empty rows, multiples of 3 (except row 7) yield
+      // 2 titles; row 7 yields 2 after case-dup collapse; the rest yield 1.
+      let expected = 0;
+      for (let i = 1; i <= 50; i += 1) {
+        if (i % 10 === 0) continue;
+        if (i === 7) {
+          expected += 2;
+          continue;
+        }
+        expected += i % 3 === 0 ? 2 : 1;
+      }
+
+      await migrateLegacyPersonObservationTitles();
+
+      const check = await getPgPool().connect();
+      try {
+        const total = await check.query<{ c: string }>(
+          `SELECT COUNT(*)::text AS c FROM person_observation_titles`
+        );
+        expect(Number(total.rows[0]!.c)).toBe(expected);
+
+        const row7 = await check.query<{ title: string }>(
+          `SELECT title FROM person_observation_titles WHERE observation_id = 7 ORDER BY title`
+        );
+        expect(row7.rows.map((r) => r.title)).toEqual(["Chairman", "Founder"]);
+      } finally {
+        check.release();
+      }
+
+      // Idempotent: a second run over the same source rows must not throw and
+      // must not change the child-table count.
+      await migrateLegacyPersonObservationTitles();
+      const check2 = await getPgPool().connect();
+      try {
+        const total2 = await check2.query<{ c: string }>(
+          `SELECT COUNT(*)::text AS c FROM person_observation_titles`
+        );
+        expect(Number(total2.rows[0]!.c)).toBe(expected);
+      } finally {
+        check2.release();
+      }
+    });
+  }
+);

--- a/src/storage/observation/PersonObservationTitlesLegacyMigration.test.ts
+++ b/src/storage/observation/PersonObservationTitlesLegacyMigration.test.ts
@@ -184,4 +184,96 @@ describe("migrateLegacyPersonObservationTitles (sqlite)", () => {
       { observation_id: 1, title: "Director" },
     ]);
   });
+
+  it("an interrupt mid-run preserves prior chunks and a re-run finishes cleanly", async () => {
+    const db = getDb();
+    createLegacyPersonObservationsTable(db);
+    createTitlesTable(db);
+    // 10_001 rows — chunk 1 covers observation_ids 1..5000, chunk 2 covers
+    // 5001..10_000, chunk 3 covers 10_001. We arrange for chunk 2's insert to
+    // throw at observation_id 7500 so chunk 1 must survive independently and
+    // chunk 3 must not have started.
+    for (let i = 1; i <= 10_001; i += 1) {
+      insertLegacyObservation(db, i, JSON.stringify([`Title ${i}`]));
+    }
+
+    const originalPrepare = db.prepare.bind(db);
+    let interceptActive = true;
+    (db as { prepare: unknown }).prepare = ((sql: string) => {
+      const stmt = originalPrepare(sql);
+      if (interceptActive && sql.includes("INSERT OR IGNORE INTO person_observation_titles")) {
+        const originalRun = stmt.run.bind(stmt);
+        stmt.run = (...params: unknown[]) => {
+          if (params[0] === 7500) {
+            throw new Error("simulated insert failure at observation_id 7500");
+          }
+          return originalRun(...(params as never[]));
+        };
+      }
+      return stmt;
+    }) as typeof db.prepare;
+
+    await expect(migrateLegacyPersonObservationTitles()).rejects.toThrow(
+      /simulated insert failure/
+    );
+
+    const count = db
+      .prepare<[], { c: number }>(`SELECT COUNT(*) AS c FROM person_observation_titles`)
+      .get();
+    expect(count?.c).toBe(5000);
+
+    // Remove the intercept and re-run — should finish cleanly, no PK violation
+    // (INSERT OR IGNORE elides chunk 1's already-committed pairs) and every
+    // observation is now covered.
+    interceptActive = false;
+    await migrateLegacyPersonObservationTitles();
+
+    const finalCount = db
+      .prepare<[], { c: number }>(`SELECT COUNT(*) AS c FROM person_observation_titles`)
+      .get();
+    expect(finalCount?.c).toBe(10_001);
+  });
+
+  it("prior chunk is visible to a separate connection before the next chunk starts", async () => {
+    const db = getDb();
+    createLegacyPersonObservationsTable(db);
+    createTitlesTable(db);
+    for (let i = 1; i <= 10_001; i += 1) {
+      insertLegacyObservation(db, i, JSON.stringify([`Title ${i}`]));
+    }
+
+    const dbPath = join(tmpDir, `${TEST_DB_NAME}.sqlite`);
+    let captured: number | null = null;
+
+    const originalPrepare = db.prepare.bind(db);
+    (db as { prepare: unknown }).prepare = ((sql: string) => {
+      const stmt = originalPrepare(sql);
+      if (sql.includes("INSERT OR IGNORE INTO person_observation_titles")) {
+        const originalRun = stmt.run.bind(stmt);
+        stmt.run = (...params: unknown[]) => {
+          // First insert of chunk 2 — chunk 1 has just committed. A separate
+          // connection must be able to observe the 5000 rows chunk 1 wrote.
+          if (params[0] === 5001 && captured === null) {
+            const second = new Sqlite.Database(dbPath);
+            try {
+              const row = second
+                .prepare<[], { c: number }>(
+                  `SELECT COUNT(*) AS c FROM person_observation_titles`
+                )
+                .get();
+              captured = row?.c ?? 0;
+            } finally {
+              second.close();
+            }
+          }
+          return originalRun(...(params as never[]));
+        };
+      }
+      return stmt;
+    }) as typeof db.prepare;
+
+    await migrateLegacyPersonObservationTitles();
+
+    expect(captured).toBe(5000);
+  });
 });

--- a/src/storage/observation/PersonObservationTitlesLegacyMigration.ts
+++ b/src/storage/observation/PersonObservationTitlesLegacyMigration.ts
@@ -207,28 +207,32 @@ async function migratePostgres(): Promise<void> {
       );
       if (res.rows.length === 0) break;
 
-      const chunkPairs: [number, string][] = [];
+      const obsIds: number[] = [];
+      const titles: string[] = [];
       for (const row of res.rows) {
         cursor = row.observation_id;
         // `titles::text` serializes a jsonb array to the same JSON literal a
         // text-typed column carries, so `normalizeTitles` handles both.
         const parsed = normalizeTitles(row.titles);
         for (const title of parsed) {
-          chunkPairs.push([row.observation_id, title]);
+          obsIds.push(row.observation_id);
+          titles.push(title);
         }
       }
 
-      if (chunkPairs.length > 0) {
+      if (titles.length > 0) {
         await client.query("BEGIN");
         try {
-          for (const [id, title] of chunkPairs) {
-            await client.query(
-              `INSERT INTO person_observation_titles (observation_id, title)
-               VALUES ($1, $2)
-               ON CONFLICT DO NOTHING`,
-              [id, title]
-            );
-          }
+          // Single per-chunk bulk insert: node-postgres serializes number[] as
+          // int[] and string[] as text[] natively, and UNNEST zips the two flat
+          // arrays into rows so the whole chunk is one round-trip instead of
+          // one RTT per title.
+          await client.query(
+            `INSERT INTO person_observation_titles (observation_id, title)
+             SELECT * FROM UNNEST($1::int[], $2::text[])
+             ON CONFLICT DO NOTHING`,
+            [obsIds, titles]
+          );
           await client.query("COMMIT");
         } catch (err) {
           await client.query("ROLLBACK");
@@ -240,8 +244,8 @@ async function migratePostgres(): Promise<void> {
         }
         // Count attempted pairs, not res.rowCount — a re-run over already-
         // migrated rows returns rowCount 0 despite doing the right thing.
-        migrated += chunkPairs.length;
-        sinceLastLog += chunkPairs.length;
+        migrated += titles.length;
+        sinceLastLog += titles.length;
         if (sinceLastLog >= PROGRESS_INTERVAL) {
           console.log(
             `[migrate person_observation_titles] wrote ${migrated} title rows so far`

--- a/src/storage/observation/PersonObservationTitlesLegacyMigration.ts
+++ b/src/storage/observation/PersonObservationTitlesLegacyMigration.ts
@@ -22,6 +22,12 @@ import { getPgPool } from "../../util/pg";
  * safe to re-run: `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` on the child
  * table's `(observation_id, title)` PK skips rows already present, so replays
  * (or partial prior runs) do not disturb existing rows.
+ *
+ * The backfill is **chunked into per-commit batches** so an interrupt only
+ * loses the in-flight chunk. Prior successful chunks stay committed; a re-run
+ * resumes by re-scanning from `observation_id > 0` and the PK guard silently
+ * skips already-written rows. The Postgres branch additionally holds row locks
+ * only for the duration of a single chunk, not the whole run.
  */
 export async function migrateLegacyPersonObservationTitles(): Promise<void> {
   // This backfill writes rows through raw SQL, reaching around the repository
@@ -46,6 +52,7 @@ export async function migrateLegacyPersonObservationTitles(): Promise<void> {
   // In-memory backend: nothing to migrate (tests start with a clean store).
 }
 
+// per-commit batch size — an interrupt loses at most one chunk
 const CHUNK_SIZE = 5000;
 const TITLE_MAX_LENGTH = 256;
 const PROGRESS_INTERVAL = 100_000;
@@ -112,38 +119,58 @@ function migrateSqlite(): void {
     `INSERT OR IGNORE INTO person_observation_titles (observation_id, title) VALUES (?, ?)`
   );
 
-  db.exec("BEGIN");
-  try {
-    let cursor = 0;
-    let migrated = 0;
-    let sinceLastLog = 0;
-    for (;;) {
-      const rows = select.all(cursor, CHUNK_SIZE);
-      if (rows.length === 0) break;
-      for (const row of rows) {
-        cursor = row.observation_id;
-        const titles = normalizeTitles(row.titles);
-        for (const title of titles) {
-          insert.run(row.observation_id, title);
-          migrated += 1;
-          sinceLastLog += 1;
-          if (sinceLastLog >= PROGRESS_INTERVAL) {
-            console.log(
-              `[migrate person_observation_titles] wrote ${migrated} title rows so far`
-            );
-            sinceLastLog = 0;
-          }
-        }
+  // better-sqlite3's transaction() wraps its callback in BEGIN/COMMIT with an
+  // automatic ROLLBACK on throw — so we get per-chunk atomicity without the
+  // outer-run transaction that previously kept a mid-run interrupt from
+  // preserving any successful chunk.
+  const insertChunk = db.transaction((pairs: readonly (readonly [number, string])[]) => {
+    for (const [id, title] of pairs) {
+      insert.run(id, title);
+    }
+  });
+
+  let cursor = 0;
+  let lastCommittedObservationId = 0;
+  let migrated = 0;
+  let sinceLastLog = 0;
+  for (;;) {
+    const rows = select.all(cursor, CHUNK_SIZE);
+    if (rows.length === 0) break;
+
+    const pairs: [number, string][] = [];
+    for (const row of rows) {
+      cursor = row.observation_id;
+      const titles = normalizeTitles(row.titles);
+      for (const title of titles) {
+        pairs.push([row.observation_id, title]);
       }
-      if (rows.length < CHUNK_SIZE) break;
     }
-    db.exec("COMMIT");
-    if (migrated > 0) {
-      console.log(`[migrate person_observation_titles] wrote ${migrated} title rows total`);
+
+    if (pairs.length > 0) {
+      try {
+        insertChunk(pairs);
+      } catch (err) {
+        console.warn(
+          `[migrate person_observation_titles] chunk rolled back after observation_id ` +
+            `${lastCommittedObservationId}; re-run resumes from there`
+        );
+        throw err;
+      }
+      migrated += pairs.length;
+      sinceLastLog += pairs.length;
+      if (sinceLastLog >= PROGRESS_INTERVAL) {
+        console.log(
+          `[migrate person_observation_titles] wrote ${migrated} title rows so far`
+        );
+        sinceLastLog = 0;
+      }
     }
-  } catch (err) {
-    db.exec("ROLLBACK");
-    throw err;
+    lastCommittedObservationId = cursor;
+
+    if (rows.length < CHUNK_SIZE) break;
+  }
+  if (migrated > 0) {
+    console.log(`[migrate person_observation_titles] wrote ${migrated} title rows total`);
   }
 }
 
@@ -161,56 +188,73 @@ async function migratePostgres(): Promise<void> {
     );
     if (cols.rowCount === 0) return;
 
-    await client.query("BEGIN");
-    try {
-      let cursor = 0;
-      let migrated = 0;
-      let sinceLastLog = 0;
-      for (;;) {
-        // Bring rows back as text either way so the JS normalizer sees a
-        // uniform shape; jsonb is serialized deterministically by pg.
-        const res = await client.query<{ observation_id: number; titles: string | null }>(
-          `SELECT observation_id, titles::text AS titles
-             FROM person_observations
-            WHERE titles IS NOT NULL
-              AND titles::text NOT IN ('[]', 'null')
-              AND observation_id > $1
-            ORDER BY observation_id
-            LIMIT $2`,
-          [cursor, CHUNK_SIZE]
-        );
-        if (res.rows.length === 0) break;
-        for (const row of res.rows) {
-          cursor = row.observation_id;
-          // `titles::text` serializes a jsonb array to the same JSON literal a
-          // text-typed column carries, so `normalizeTitles` handles both.
-          const titles = normalizeTitles(row.titles);
-          for (const title of titles) {
+    let cursor = 0;
+    let lastCommittedObservationId = 0;
+    let migrated = 0;
+    let sinceLastLog = 0;
+    for (;;) {
+      // Plain SELECT — no transaction needed, and holding one across every
+      // chunk was the source of the multi-hour row-lock hold.
+      const res = await client.query<{ observation_id: number; titles: string | null }>(
+        `SELECT observation_id, titles::text AS titles
+           FROM person_observations
+          WHERE titles IS NOT NULL
+            AND titles::text NOT IN ('[]', 'null')
+            AND observation_id > $1
+          ORDER BY observation_id
+          LIMIT $2`,
+        [cursor, CHUNK_SIZE]
+      );
+      if (res.rows.length === 0) break;
+
+      const chunkPairs: [number, string][] = [];
+      for (const row of res.rows) {
+        cursor = row.observation_id;
+        // `titles::text` serializes a jsonb array to the same JSON literal a
+        // text-typed column carries, so `normalizeTitles` handles both.
+        const parsed = normalizeTitles(row.titles);
+        for (const title of parsed) {
+          chunkPairs.push([row.observation_id, title]);
+        }
+      }
+
+      if (chunkPairs.length > 0) {
+        await client.query("BEGIN");
+        try {
+          for (const [id, title] of chunkPairs) {
             await client.query(
               `INSERT INTO person_observation_titles (observation_id, title)
                VALUES ($1, $2)
                ON CONFLICT DO NOTHING`,
-              [row.observation_id, title]
+              [id, title]
             );
-            migrated += 1;
-            sinceLastLog += 1;
-            if (sinceLastLog >= PROGRESS_INTERVAL) {
-              console.log(
-                `[migrate person_observation_titles] wrote ${migrated} title rows so far`
-              );
-              sinceLastLog = 0;
-            }
           }
+          await client.query("COMMIT");
+        } catch (err) {
+          await client.query("ROLLBACK");
+          console.warn(
+            `[migrate person_observation_titles] chunk rolled back after observation_id ` +
+              `${lastCommittedObservationId}; re-run resumes from there`
+          );
+          throw err;
         }
-        if (res.rows.length < CHUNK_SIZE) break;
+        // Count attempted pairs, not res.rowCount — a re-run over already-
+        // migrated rows returns rowCount 0 despite doing the right thing.
+        migrated += chunkPairs.length;
+        sinceLastLog += chunkPairs.length;
+        if (sinceLastLog >= PROGRESS_INTERVAL) {
+          console.log(
+            `[migrate person_observation_titles] wrote ${migrated} title rows so far`
+          );
+          sinceLastLog = 0;
+        }
       }
-      await client.query("COMMIT");
-      if (migrated > 0) {
-        console.log(`[migrate person_observation_titles] wrote ${migrated} title rows total`);
-      }
-    } catch (err) {
-      await client.query("ROLLBACK");
-      throw err;
+      lastCommittedObservationId = cursor;
+
+      if (res.rows.length < CHUNK_SIZE) break;
+    }
+    if (migrated > 0) {
+      console.log(`[migrate person_observation_titles] wrote ${migrated} title rows total`);
     }
   } finally {
     client.release();


### PR DESCRIPTION
Stacked on top of #217. Addresses the two HIGH-severity findings from the code review of that PR's `PersonObservationTitlesLegacyMigration.ts`. Base is `claude/beautiful-archimedes-vr1yck` (PR #217's head), not `main`, so the diff shows only the follow-up fixes and not #217's own changes.

## HIGH #1 — single outer transaction wrapped the whole backfill

The prior code opened `BEGIN` once, iterated every page, then `COMMIT`. On a 10M-title production DB this meant:

- A kill at 90% wall-clock lost every already-written row (nothing was committed until the very end).
- Postgres held row locks on `person_observation_titles` for the entire multi-hour runtime, blocking concurrent writers.
- The "wrote N so far" progress log was a lie: those rows were pending, not durable.

**Fix (commit 1, `fix(migration): commit person-title backfill per chunk, not per run`).** Each 5000-observation page now commits independently:

- SQLite branch wraps the per-chunk insert in `db.transaction(pairs => …)(pairs)` — better-sqlite3's idiomatic BEGIN/COMMIT with automatic ROLLBACK-on-throw.
- Postgres branch issues `BEGIN`/`COMMIT` inside the paging loop, one pair per chunk; the paging `SELECT` moved out of any transaction (plain reads don't need one, and holding one across chunks was itself the row-lock source).
- The PK on `(observation_id, title)` plus `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` keeps re-runs idempotent — an interrupt resumes cleanly by re-scanning from `observation_id > 0`; committed chunks are silently skipped.
- Progress log now fires after commit (truthful) and a ROLLBACK path warns the last successful `observation_id` so re-runs are unambiguous.

## HIGH #2 — Postgres branch did one RTT per title

The chunk was already 5000 observations, but inside each chunk transaction the loop issued one `INSERT` per title — ~10M network round-trips for a full backfill (~1.4h just in network on a 5ms-RTT link) despite already batching commits.

**Fix (commit 2, `perf(migration): bulk-insert per chunk on Postgres via UNNEST`).** Build two flat arrays (`obsIds: number[]`, `titles: string[]`) as we iterate the chunk's SELECT results, then issue one query per chunk:

```sql
INSERT INTO person_observation_titles (observation_id, title)
SELECT * FROM UNNEST($1::int[], $2::text[])
ON CONFLICT DO NOTHING
```

`node-postgres` serializes `number[]` → `int[]` and `string[]` → `text[]` natively, so the whole chunk lands in one RTT and matches the SQLite path's per-chunk shape. `migrated` counts attempted pairs (not `res.rowCount`, which drops to 0 on re-runs).

## Verification

- `bun test src/storage/observation/PersonObservationTitlesLegacyMigration.test.ts` — 7 pass, 1 skip (Postgres test skipped without `SEC_PG_URL`), 0 fail.
- `bun test src/storage/observation/` — 31 pass, 1 skip, 0 fail.
- `npx tsc --noEmit -p .` — clean.
- `bun test` (full suite) — 2013 pass, 1 skip, 7 fail. All 7 failures are preexisting `FetchQuarterlyIndexTask` / `FetchDailyIndexTask` network-timeout tests (SEC EDGAR unreachable from the sandbox); they were failing on `claude/beautiful-archimedes-vr1yck` before this PR and are unrelated.

Three new tests added (existing five unchanged):

1. **`an interrupt mid-run preserves prior chunks and a re-run finishes cleanly`** (SQLite) — seeds 10,001 legacy rows, intercepts the insert so it throws at `observation_id === 7500`. Asserts exactly 5000 rows survive in the child table (chunk 1 committed, chunk 2 rolled back, chunk 3 never started). Removes the intercept and re-runs; asserts final count 10,001 with no PK violation.
2. **`prior chunk is visible to a separate connection before the next chunk starts`** (SQLite) — opens an independent read connection when the first `INSERT` of chunk 2 fires (chunk 1 has just committed) and captures the row count. Asserts captured = 5000, i.e. commit visibility across connections mid-run.
3. **`bulk-inserts titles via UNNEST and is idempotent on a second run`** (Postgres, `describe.skipIf(!process.env.SEC_PG_URL)`) — seeds 50 rows with multi-title arrays, empty arrays, and case-duplicate titles; verifies the UNNEST path produces the correct row count, collapses case duplicates, and is idempotent on a second run.

## Explicitly out of scope (follow-ups)

- **MEDIUM #3** — SQLite `INSERT OR IGNORE` uses default binary collation while the JSON parse in `normalizeTitles` de-dupes case-insensitively, so a prior partial run could leave rows the migration considers "already there" under a different case. Follow-up.
- **MEDIUM #4** — `information_schema.tables WHERE table_name = 'person_observations'` isn't schema-qualified, so under a non-default `search_path` the migration can match a wrong-schema table. Follow-up.

The legacy `titles` column stays in place (SQLite can't drop it without a full table rebuild) and `CHUNK_SIZE` stays at 5000.

---
_Generated by [Claude Code](https://claude.ai/code/session_011g9zy47YKk2gtbBRng9W9Q)_