### PR TITLE
fix(db): restore in-place Postgres column widening + address nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.0.19
+
+### Bug Fixes
+
+#### db
+
+- restore in-place Postgres column widening on `sec db setup` — a data-preserving upgrade path that ALTERs pre-0.0.18 narrow varchar columns (phones.international_number 20→64, filings.form 8→32, filings.file_number 10→255, filings.film_number 10→255, filings.primary_doc 45→128, filings.primary_doc_description 45→255, filings.act 2→16, canonical_person_phone.international_number 20→64, canonical_company_phone.international_number 20→64), plus the earlier company_facts.val_unit / company_facts.grouping / xbrl_fact.context_ref widenings. Idempotent — a fresh or already-wide database is a no-op. SQLite / in-memory backends are unaffected. Without this, an existing Postgres deployment updated to 0.0.18 would begin rejecting inserts with `value too long for type varchar`.
+- relax `addresses.state_or_country` to nullable on pre-existing Postgres deployments (restores the migration deleted in 0.0.18).
+
 ## 0.0.18
 
 ### Chores

--- a/src/config/setupAllDatabases.ts
+++ b/src/config/setupAllDatabases.ts
@@ -7,6 +7,7 @@
 import { globalServiceRegistry, Sqlite } from "workglow";
 import { isDryRun } from "../cli/isDryRun";
 import { ADDRESS_HISTORY_JUNCTION_REPOSITORY_TOKEN } from "../storage/address/AddressHistorySchema";
+import { migrateAddressRegionNullable } from "../storage/address/AddressRegionNullableMigration";
 import {
   ADDRESS_JUNCTION_REPOSITORY_TOKEN,
   ADDRESS_REPOSITORY_TOKEN,
@@ -104,6 +105,7 @@ import { bootstrapComponentVersions } from "../storage/versioning/bootstrapCompo
 import { registerSecResolvers } from "./registerResolvers";
 import { listDatabaseExtensionTokens, runDatabaseSetupHooks } from "./databaseExtensions";
 import { SEC_DB_FOLDER, SEC_DB_TYPE } from "./tokens";
+import { widenNarrowColumns } from "./widenNarrowColumnsMigration";
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../storage/versioning/ComponentVersionSchema";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../storage/versioning/ExtractorRunSchema";
 import { VERSION_EVENT_REPOSITORY_TOKEN } from "../storage/versioning/VersionEventSchema";
@@ -127,6 +129,11 @@ export async function setupAllDatabases(): Promise<void> {
   // which reaches setupAllDatabases (via InitApplyTask, after EnvToDI/DefaultDI)
   // without ever running the CLI preAction hook that otherwise registers them.
   runDatabaseSetupHooks();
+  // In-place Postgres upgrade path — no-op on fresh installs and on
+  // SQLite/in-memory. Relaxes `addresses.state_or_country` to nullable before
+  // any DDL touches that column, so the current schema can insert rows a
+  // pre-existing NOT NULL column would otherwise reject. Data-preserving.
+  await migrateAddressRegionNullable();
   await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(ADDRESS_JUNCTION_REPOSITORY_TOKEN).setupDatabase();
   await globalServiceRegistry.get(ADDRESS_HISTORY_JUNCTION_REPOSITORY_TOKEN).setupDatabase();
@@ -214,6 +221,13 @@ export async function setupAllDatabases(): Promise<void> {
   for (const token of listDatabaseExtensionTokens()) {
     await globalServiceRegistry.get(token).setupDatabase();
   }
+  // In-place Postgres upgrade path — no-op on fresh installs and on
+  // SQLite/in-memory. Converges narrow varchar columns (widened after real
+  // EDGAR data overflowed them) to their current schema widths without data
+  // loss. Runs after every table has been created above so a `CREATE TABLE`
+  // for a genuinely new table cannot race the migration's information_schema
+  // probe.
+  await widenNarrowColumns();
   // View DDL is created here only on the SQLite path; the Postgres backend
   // owns its own view bootstrap (and getDb() now throws when SEC_DB_TYPE
   // isn't sqlite). Tests use the in-memory backend where views don't apply.

--- a/src/config/widenNarrowColumnsMigration.test.ts
+++ b/src/config/widenNarrowColumnsMigration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "./TestingDI";
+import { SEC_DB_TYPE, SEC_DRY_RUN } from "./tokens";
+import { shouldWidenColumn, widenNarrowColumns } from "./widenNarrowColumnsMigration";
+
+describe("shouldWidenColumn", () => {
+  it("skips an absent column (undefined length)", () => {
+    expect(shouldWidenColumn(undefined, 64)).toBe(false);
+  });
+
+  it("skips an unbounded text column (null length)", () => {
+    expect(shouldWidenColumn(null, 64)).toBe(false);
+  });
+
+  it("widens a narrower column", () => {
+    expect(shouldWidenColumn(20, 64)).toBe(true);
+  });
+
+  it("skips a column already at target width", () => {
+    expect(shouldWidenColumn(64, 64)).toBe(false);
+  });
+
+  it("skips a column wider than target", () => {
+    expect(shouldWidenColumn(128, 64)).toBe(false);
+  });
+});
+
+describe("widenNarrowColumns", () => {
+  beforeEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+  afterEach(() => {
+    // Clear tokens the individual cases set; resetDependencyInjectionsForTesting
+    // only re-registers repos, so a `SEC_DRY_RUN = true` or `SEC_DB_TYPE =
+    // "postgres"` binding would leak into later tests otherwise.
+    globalServiceRegistry.registerInstance(SEC_DRY_RUN, false);
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("is a no-op on the in-memory / unset backend (no SEC_DB_TYPE bound)", async () => {
+    // No SEC_DB_TYPE registered → dbType branch resolves to null → returns
+    // without touching pg. If it tried, no pg pool is configured and it would
+    // throw.
+    await expect(widenNarrowColumns()).resolves.toBeUndefined();
+  });
+
+  it("is a no-op on the SQLite backend", async () => {
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "sqlite");
+    await expect(widenNarrowColumns()).resolves.toBeUndefined();
+  });
+
+  it("bails under --dry-run before touching the database", async () => {
+    // Register postgres AND dry-run — the dry-run bail must fire first, so
+    // this must not attempt to open a pg connection.
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "postgres");
+    globalServiceRegistry.registerInstance(SEC_DRY_RUN, true);
+    await expect(widenNarrowColumns()).resolves.toBeUndefined();
+  });
+});

--- a/src/config/widenNarrowColumnsMigration.ts
+++ b/src/config/widenNarrowColumnsMigration.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { isDryRun } from "../cli/isDryRun";
+import { getPgPool } from "../util/pg";
+import { SEC_DB_TYPE } from "./tokens";
+
+/**
+ * Columns whose TypeBox `maxLength` was widened after real EDGAR data
+ * overflowed the original width. `CREATE TABLE IF NOT EXISTS` never alters an
+ * existing table, so a Postgres database set up before the widening keeps the
+ * narrow `varchar(N)` and re-hits the original overflow (a `STORE_ERROR` that
+ * loses the whole CIK's facts, or a silently dropped XBRL fact, or a rejected
+ * filings row that fails an entire submission). This migration brings existing
+ * columns up to the current schema width.
+ *
+ * Postgres-only: SQLite emits `TEXT` (length never enforced) and the in-memory
+ * test backend has no column types, so both are no-ops. Increasing a
+ * `varchar` length in Postgres is a catalog-only change (no table rewrite), and
+ * the guard skips columns already at or above the target, so this is cheap and
+ * idempotent to run on every `db setup`.
+ */
+const WIDENED_COLUMNS: ReadonlyArray<{
+  readonly table: string;
+  readonly column: string;
+  readonly width: number;
+}> = [
+  { table: "company_facts", column: "val_unit", width: 32 },
+  { table: "company_facts", column: "grouping", width: 20 },
+  { table: "xbrl_fact", column: "context_ref", width: 512 },
+  { table: "phones", column: "international_number", width: 64 },
+  { table: "canonical_person_phone", column: "international_number", width: 64 },
+  { table: "canonical_company_phone", column: "international_number", width: 64 },
+  { table: "filings", column: "form", width: 32 },
+  { table: "filings", column: "file_number", width: 255 },
+  { table: "filings", column: "film_number", width: 255 },
+  { table: "filings", column: "primary_doc", width: 128 },
+  { table: "filings", column: "primary_doc_description", width: 255 },
+  { table: "filings", column: "act", width: 16 },
+];
+
+/**
+ * Decide whether a column's current `character_maximum_length` needs to widen
+ * to `target`. Extracted for unit testing.
+ *
+ * - `undefined` (column absent — table not created yet) → skip.
+ * - `null` (unbounded text type) → skip; never narrow.
+ * - `current >= target` → already wide enough, skip.
+ * - `current < target` → widen.
+ */
+export function shouldWidenColumn(current: number | null | undefined, target: number): boolean {
+  if (current === undefined) return false;
+  if (current === null) return false;
+  return current < target;
+}
+
+export async function widenNarrowColumns(): Promise<void> {
+  // DDL through raw SQL reaches around the repository layer, so the dry-run
+  // ReadOnlyTabularStorage wrapper cannot intercept it — bail explicitly.
+  if (isDryRun()) return;
+
+  const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
+    ? globalServiceRegistry.get(SEC_DB_TYPE)
+    : null;
+  if (dbType !== "postgres") return;
+
+  const pool = getPgPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    try {
+      for (const { table, column, width } of WIDENED_COLUMNS) {
+        const info = await client.query(
+          `SELECT character_maximum_length AS len
+             FROM information_schema.columns
+            WHERE table_name = $1 AND column_name = $2`,
+          [table, column]
+        );
+        const current = info.rows[0]?.len as number | null | undefined;
+        if (!shouldWidenColumn(current, width)) continue;
+        await client.query(
+          `ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE varchar(${width})`
+        );
+      }
+      await client.query("COMMIT");
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    }
+  } finally {
+    client.release();
+  }
+}

--- a/src/storage/address/AddressRegionNullableMigration.test.ts
+++ b/src/storage/address/AddressRegionNullableMigration.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { SEC_DB_TYPE, SEC_DRY_RUN } from "../../config/tokens";
+import { migrateAddressRegionNullable } from "./AddressRegionNullableMigration";
+
+describe("migrateAddressRegionNullable", () => {
+  beforeEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+  afterEach(() => {
+    // Clear tokens; resetDependencyInjectionsForTesting only re-registers
+    // repos, so token bindings leak across test files otherwise.
+    globalServiceRegistry.registerInstance(SEC_DRY_RUN, false);
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("is a no-op on the SQLite backend", async () => {
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "sqlite");
+    await expect(migrateAddressRegionNullable()).resolves.toBeUndefined();
+  });
+
+  it("is a no-op on an unknown / in-memory backend (no SEC_DB_TYPE bound)", async () => {
+    // No SEC_DB_TYPE registered → dbType branch resolves to null → returns
+    // without touching pg. If it tried, no pg pool is configured and it would
+    // throw.
+    await expect(migrateAddressRegionNullable()).resolves.toBeUndefined();
+  });
+
+  it("bails under --dry-run before touching the database", async () => {
+    // Register postgres AND dry-run — the dry-run bail must fire first, so
+    // this must not attempt to open a pg connection.
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "postgres");
+    globalServiceRegistry.registerInstance(SEC_DRY_RUN, true);
+    await expect(migrateAddressRegionNullable()).resolves.toBeUndefined();
+  });
+});

--- a/src/storage/address/AddressRegionNullableMigration.ts
+++ b/src/storage/address/AddressRegionNullableMigration.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { globalServiceRegistry } from "workglow";
+import { isDryRun } from "../../cli/isDryRun";
+import { SEC_DB_TYPE } from "../../config/tokens";
+import { getPgPool } from "../../util/pg";
+
+const TABLE = "addresses";
+const COLUMN = "state_or_country";
+
+/**
+ * Relaxes `addresses.state_or_country` from NOT NULL to nullable on an
+ * existing Postgres deployment.
+ *
+ * A US address whose filer left the state blank is now kept as
+ * `country_code: "US"` with a null region instead of being dropped (see
+ * `normalizeAddress`), so the column has to accept null. `CREATE TABLE IF NOT
+ * EXISTS` never alters an existing table, so a database set up before that
+ * change keeps the NOT NULL column and every such address fails to store.
+ *
+ * Postgres-only: SQLite's TEXT columns have no persistent NOT NULL that
+ * survives a schema-level widen, and the current `AddressSchema` is the
+ * authoritative source for the SQLite table (a fresh DB comes up nullable
+ * automatically); the in-memory backend has no column types at all. Both are
+ * no-ops.
+ *
+ * `ALTER COLUMN ... DROP NOT NULL` is a catalog-only change and cheap;
+ * idempotent — a fresh DB has no table (no-op), an already-migrated DB has a
+ * nullable column (no-op).
+ */
+export async function migrateAddressRegionNullable(): Promise<void> {
+  // Raw-SQL DDL reaches around the repository layer, so the dry-run
+  // ReadOnlyTabularStorage wrapper cannot intercept it — bail explicitly.
+  if (isDryRun()) return;
+
+  const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
+    ? globalServiceRegistry.get(SEC_DB_TYPE)
+    : null;
+  if (dbType !== "postgres") return;
+
+  const pool = getPgPool();
+  const client = await pool.connect();
+  try {
+    const info = await client.query(
+      `SELECT is_nullable
+         FROM information_schema.columns
+        WHERE table_name = $1 AND column_name = $2`,
+      [TABLE, COLUMN]
+    );
+    // Table/column absent (nothing created yet) or already nullable → skip.
+    if (info.rowCount === 0 || info.rows[0]?.is_nullable !== "NO") return;
+    await client.query(`ALTER TABLE "${TABLE}" ALTER COLUMN "${COLUMN}" DROP NOT NULL`);
+  } finally {
+    client.release();
+  }
+}


### PR DESCRIPTION
## Root cause

Commit `dc16c1f` deleted the two in-place Postgres migrations (`widenNarrowColumnsMigration.ts`, `AddressRegionNullableMigration.ts`) in favour of a `sec db reset --confirm` recovery path. Chronologically later the same day, commit `8c85d0c` widened multiple Postgres varchar columns.

`CREATE TABLE IF NOT EXISTS` never alters an existing table, so a Postgres deployment set up before 0.0.18 now hits `value too long for type varchar` on the first insert of new-wider data (a `STORE_ERROR` that fails the whole CIK's submission). The only recovery path — `db reset --confirm` — DROPs the schema and destroys weeks of EDGAR ingestion.

## Fix

Restore both migrations as idempotent, in-place, data-preserving upgrades:

**`widenNarrowColumns()`** — Postgres-only, no-op on fresh installs and non-Postgres backends. Queries `information_schema.columns.character_maximum_length` per column and emits `ALTER TABLE "<t>" ALTER COLUMN "<c>" TYPE varchar(<n>)` only when the current width is a finite number strictly less than the target. Wrapped in a single `BEGIN`/`COMMIT` on a pooled client. Widened columns:

| Table | Column | Old | New |
|---|---|---:|---:|
| `phones` | `international_number` | 20 | 64 |
| `canonical_person_phone` | `international_number` | 20 | 64 |
| `canonical_company_phone` | `international_number` | 20 | 64 |
| `filings` | `form` | 8 | 32 |
| `filings` | `file_number` | 10 | 255 |
| `filings` | `film_number` | 10 | 255 |
| `filings` | `primary_doc` | 45 | 128 |
| `filings` | `primary_doc_description` | 45 | 255 |
| `filings` | `act` | 2 | 16 |
| `company_facts` | `val_unit` | (narrow) | 32 |
| `company_facts` | `grouping` | (narrow) | 20 |
| `xbrl_fact` | `context_ref` | (narrow) | 512 |

All widths were cross-checked against `PhoneSchema`, `FilingSchema`, and `CanonicalJunctionSchemas` — the schemas, not the plan's numbers, are authoritative. The last three entries are the earlier widenings kept so a `0.0.13 → 0.0.19` upgrade converges in one hop.

**`migrateAddressRegionNullable()`** — Postgres-only, no-op on fresh installs and non-Postgres backends. Queries `information_schema.columns.is_nullable` and emits `ALTER TABLE "addresses" ALTER COLUMN "state_or_country" DROP NOT NULL` only when the column exists and is `NO`. SQLite has no persistent NOT NULL that survives a schema-level widen (a fresh SQLite DB comes up nullable from the current `AddressSchema` automatically), so the deleted file's SQLite rebuild branch is intentionally not restored.

## Wiring (`setupAllDatabases.ts`)

- `migrateAddressRegionNullable()` runs **after** `runDatabaseSetupHooks()` and **before** `ADDRESS_REPOSITORY_TOKEN.setupDatabase()` so the column relaxation lands before any DDL touches the table.
- `widenNarrowColumns()` runs at the very end of the DDL block (**after** the `listDatabaseExtensionTokens()` loop and **before** the SQLite view / rate-limiter blocks) so no `CREATE TABLE` can race the migration's `information_schema` probe.

## Idempotency guarantees

- Both migrations bail under `isDryRun()` before opening a pg connection (raw-SQL DDL reaches around the repositories' `ReadOnlyTabularStorage` wrapper).
- Both migrations gate on `SEC_DB_TYPE === "postgres"`, so SQLite / in-memory / unset backends are pure no-ops.
- `widenNarrowColumns` skips columns absent (`character_maximum_length === undefined`), unbounded (`=== null`), or already at/above the target (`current >= width`) — so a fresh Postgres DB, an already-migrated Postgres DB, and one already ahead of the target width all no-op.
- `migrateAddressRegionNullable` skips a missing column and an already-nullable column.
- Increasing a Postgres `varchar` length and dropping a NOT NULL are both catalog-only changes — no table rewrite.

## Tests added

- `src/config/widenNarrowColumnsMigration.test.ts` — pinned truth table for the exported `shouldWidenColumn` predicate (`undefined` / `null` / `current < target` / `current === target` / `current > target`), plus SQLite / unbound / dry-run no-op paths for `widenNarrowColumns`.
- `src/storage/address/AddressRegionNullableMigration.test.ts` — SQLite / unset-backend / dry-run no-op paths for `migrateAddressRegionNullable`. Each dry-run test registers `postgres` AND `SEC_DRY_RUN`, verifying the dry-run bail fires before pg is touched.

## Not restored

`Form8KEventLegacyMigration.ts` — the legacy `form_8k_events` shape predates versioned-PK from 0.0.10 and does not exist on any Postgres deployment. Intentionally out of scope.

## Verification

- `bunx vitest run src/config/widenNarrowColumnsMigration.test.ts src/storage/address/AddressRegionNullableMigration.test.ts` — 11/11 pass.
- `bunx vitest run src/config/` — 37/37 pass (regression: `setupAllDatabases` still boots cleanly on the in-memory backend used by every other test file, and `resetAllDatabases`' token-coverage drift guard still holds).
- `bun test src/task/facts/StoreCompanyFactsTask.test.ts` — 7/7 pass (regression: a real task that calls `setupAllDatabases` in `beforeEach` still succeeds).
- `bun test src/task/facts/UpdateAllCompanyFactsTask.test.ts` — 2/2 pass (regression: setup under `SEC_DRY_RUN = true` still succeeds).
- `bun run build` — clean build, tsc passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_018J4raxRKq12RLwudeGWvXx)_