### PR TITLE
fix: crash-safe addresses rebuild, SPAC candidate classifier/scan fixes, single-valued name history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -654,13 +654,19 @@ Three signals, each kept as its own column so a consumer can re-derive its own
 rule: `entities.sic = 6770`, a blank-check-shaped current name, and a
 blank-check-shaped _former_ name. Graded into `confidence`:
 
-- **high** — registered on the S-1 family (`S-1`/`F-1`/`DRS` + amendments) while
-  still carrying a blank-check name. Survives the de-SPAC, which is exactly
-  where `sic = 6770` fails: DraftKings reads 7990 today, Lucid 3711.
-- **medium** — 6770 plus a registration, no name evidence.
+- **high** — an S-1-family registration (`S-1`/`F-1`/`DRS` + amendments) plus
+  either a blank-check name (current or former) or EDGAR's 6770 coding, with
+  nothing arguing against it. The name half survives the de-SPAC, which is
+  exactly where `sic = 6770` fails: DraftKings reads 7990 today, Lucid 3711.
+  6770-plus-registration sits here on measurement (150 of 168 such 2019-2024
+  registrants appear in embarc's curated list, 89%).
+- **medium** — one weakened or contradicted signal: a weak-class name with a
+  registration and nothing else, or a 6770 filer that registered only AFTER
+  shedding a blank-check name.
 - **low** — a blank-check name only in history with the registration filed
-  _after_ the rename. That is the Form 10 shell pattern (register on 10-12G,
-  reverse-merge, then S-1 for the operating company's resale), not a SPAC.
+  after the rename (the Form 10 shell pattern: register on 10-12G,
+  reverse-merge, then S-1 for the operating company's resale), OR 6770 with no
+  registration on file at all.
 
 Why the screen is worth having at all: `entities.sic` is the _current_ code, and
 it drifts off 6770 at the de-SPAC — sometimes before the rename (Melar
@@ -695,6 +701,8 @@ modern era (29/32, 37/40, 5/5 among 2019-2024 registrants) and near-worthless
 before it — "Capital Corp" is what SPRINT CAPITAL CORP, BBX CAPITAL CORP and
 EVEREN CAPITAL CORP called themselves, and over all vintages the pattern
 collapses to 33/103. SIC 6770 or a strong name is what lifts them to `high`.
+
+The recall/precision tables below were measured on this rule.
 
 **Validation against embarc's curated list** (`embarc/data/generated/spacs.json`,
 1,476 SPACs, S-1 dates 2006-03 → 2025-05):

--- a/src/cli/GlobalOptions.test.ts
+++ b/src/cli/GlobalOptions.test.ts
@@ -1,6 +1,11 @@
 import { Command, InvalidArgumentError } from "commander";
 import { describe, expect, it } from "vitest";
-import { applyGlobalOptions, parseGlobalOptions, parseIntOption } from "./GlobalOptions";
+import {
+  applyGlobalOptions,
+  parseGlobalOptions,
+  parseIntOption,
+  parseOutputFormat,
+} from "./GlobalOptions";
 
 function createProgram(): Command {
   const program = new Command();
@@ -95,6 +100,34 @@ describe("GlobalOptions", () => {
           expect(err).toBeInstanceOf(InvalidArgumentError);
           expect((err as Error).message).toContain(`"${input}"`);
           expect((err as Error).message).toContain("non-negative integer");
+        }
+      });
+    }
+  });
+
+  describe("parseOutputFormat", () => {
+    it("accepts each supported format", () => {
+      expect(parseOutputFormat("table")).toBe("table");
+      expect(parseOutputFormat("csv")).toBe("csv");
+      expect(parseOutputFormat("json")).toBe("json");
+    });
+
+    it("normalizes surrounding whitespace and case", () => {
+      expect(parseOutputFormat("  JSON ")).toBe("json");
+      expect(parseOutputFormat("Csv")).toBe("csv");
+    });
+
+    const rejected: readonly string[] = ["jsonl", "", "  ", "tsv", "TABLE!", "json5"];
+
+    for (const input of rejected) {
+      it(`rejects ${JSON.stringify(input)} rather than silently falling back to a table`, () => {
+        try {
+          parseOutputFormat(input);
+          throw new Error("expected parseOutputFormat to throw");
+        } catch (err) {
+          expect(err).toBeInstanceOf(InvalidArgumentError);
+          expect((err as Error).message).toContain(`"${input}"`);
+          expect((err as Error).message).toContain("table | csv | json");
         }
       });
     }

--- a/src/cli/GlobalOptions.ts
+++ b/src/cli/GlobalOptions.ts
@@ -30,3 +30,21 @@ export function parseIntOption(value: string): number {
   }
   return Number(trimmed);
 }
+
+/** The output formats `renderTable` understands. */
+export const OUTPUT_FORMATS = ["table", "csv", "json"] as const;
+export type OutputFormat = (typeof OUTPUT_FORMATS)[number];
+
+/**
+ * Commander parser for a `--format` option. Rejects an unrecognised value at
+ * parse time rather than silently rendering a table — a `--format jsonl` that
+ * quietly produced a table would look like the command ignoring the flag, and
+ * a script piping the output would only find out downstream.
+ */
+export function parseOutputFormat(value: string): OutputFormat {
+  const trimmed = value.trim().toLowerCase();
+  if (!(OUTPUT_FORMATS as readonly string[]).includes(trimmed)) {
+    throw new InvalidArgumentError(`"${value}" is not one of: ${OUTPUT_FORMATS.join(" | ")}.`);
+  }
+  return trimmed as OutputFormat;
+}

--- a/src/commands/spac.ts
+++ b/src/commands/spac.ts
@@ -6,6 +6,7 @@
 
 import { Command } from "commander";
 import { globalServiceRegistry } from "workglow";
+import { parseIntOption, parseOutputFormat, type OutputFormat } from "../cli/GlobalOptions";
 import { isDryRun } from "../cli/isDryRun";
 import { renderTable, type ColumnDef } from "../cli/output/TableRenderer";
 import { runWorkflowCli } from "../cli/runWorkflow";
@@ -148,11 +149,16 @@ export function registerSpacCommands(program: Command): void {
       "List SPAC candidates identified from submissions metadata (populated by `sec update spacs`)"
     )
     .option("--confidence <tier>", "Filter to one tier: high | medium | low")
-    .option("--limit <n>", "Rows to show (default 50)")
-    .option("--offset <n>", "Rows to skip")
-    .option("--format <format>", "output format: table | csv | json", "table")
+    .option("--limit <n>", "Rows to show", parseIntOption, 50)
+    .option("--offset <n>", "Rows to skip", parseIntOption, 0)
+    .option("--format <format>", "output format: table | csv | json", parseOutputFormat, "table")
     .action(
-      async (opts: { confidence?: string; limit?: string; offset?: string; format: string }) => {
+      async (opts: {
+        confidence?: string;
+        limit: number;
+        offset: number;
+        format: OutputFormat;
+      }) => {
         if (
           opts.confidence !== undefined &&
           !SPAC_CANDIDATE_CONFIDENCES.includes(opts.confidence as SpacCandidateConfidence)
@@ -163,24 +169,21 @@ export function registerSpacCommands(program: Command): void {
           process.exitCode = 1;
           return;
         }
-        const limit = opts.limit === undefined ? undefined : Number(opts.limit);
-        const offset = opts.offset === undefined ? undefined : Number(opts.offset);
         const { rows, total } = await runWorkflowCli<ListSpacCandidatesTaskOutput>([
           new ListSpacCandidatesTask({
             defaults: {
               confidence: opts.confidence as SpacCandidateConfidence | undefined,
-              limit,
-              offset,
+              limit: opts.limit,
+              offset: opts.offset,
             },
           }),
         ]);
-        const format = opts.format === "csv" || opts.format === "json" ? opts.format : "table";
         console.log(
           renderTable(rows as unknown as Record<string, unknown>[], SPAC_CANDIDATE_COLUMNS, {
-            format,
+            format: opts.format,
             total,
-            offset: offset ?? 0,
-            limit: limit ?? 50,
+            offset: opts.offset,
+            limit: opts.limit,
           })
         );
       }

--- a/src/storage/address/AddressRegionNullableMigration.test.ts
+++ b/src/storage/address/AddressRegionNullableMigration.test.ts
@@ -32,12 +32,10 @@ const LEGACY_DDL = `
     PRIMARY KEY (address_hash_id)
   )`;
 
-function insertLegacyRow(
-  table: string,
-  hashId: string,
-  city: string,
-  region: string | null
-): void {
+/** The post-migration shape: `state_or_country` nullable. */
+const REBUILT_DDL = LEGACY_DDL.replace("state_or_country TEXT NOT NULL", "state_or_country TEXT");
+
+function insertLegacyRow(table: string, hashId: string, city: string, region: string | null): void {
   getDb()
     .prepare(
       `INSERT INTO ${table}
@@ -58,9 +56,10 @@ function addressHashIds(): string[] {
 
 function tableExists(name: string): boolean {
   const row = getDb()
-    .prepare<[], { name: string }>(
-      `SELECT name FROM sqlite_master WHERE type='table' AND name='${name}'`
-    )
+    .prepare<
+      [],
+      { name: string }
+    >(`SELECT name FROM sqlite_master WHERE type='table' AND name='${name}'`)
     .get();
   return Boolean(row);
 }
@@ -194,18 +193,7 @@ describe("migrateAddressRegionNullable (sqlite)", () => {
     insertLegacyRow("addresses", "hash-1", "NEW YORK", "NY");
     insertLegacyRow("addresses", "hash-2", "BOSTON", "MA");
     db.exec(`ALTER TABLE addresses RENAME TO addresses__legacy_region`);
-    db.exec(`
-      CREATE TABLE addresses (
-        address_hash_id TEXT NOT NULL,
-        street1 TEXT NOT NULL,
-        street2 TEXT NULL,
-        street3 TEXT NULL,
-        city TEXT NOT NULL,
-        state_or_country TEXT NULL,
-        country_code TEXT NOT NULL,
-        zip TEXT NULL,
-        PRIMARY KEY (address_hash_id)
-      )`);
+    db.exec(REBUILT_DDL);
 
     DefaultDI();
     await setupAllDatabases();
@@ -213,6 +201,74 @@ describe("migrateAddressRegionNullable (sqlite)", () => {
     expect(regionColumnIsNullable()).toBe(true);
     expect(addressHashIds()).toEqual(["hash-1", "hash-2"]);
     expect(tableExists("addresses__legacy_region")).toBe(false);
+  });
+
+  it("resumes when the copy finished but the legacy DROP did not", async () => {
+    const db = getDb();
+    // The old build's LAST statement was `DROP TABLE addresses__legacy_region`,
+    // so a crash immediately before it left the rows in BOTH tables. The old
+    // code then reported success forever after (it probed a nullable column and
+    // returned early), so this state can have been serving traffic for months.
+    // A blind copy back would fail the primary key and roll back, making
+    // `db setup` fail on every run from here on.
+    db.exec(LEGACY_DDL);
+    insertLegacyRow("addresses", "hash-1", "NEW YORK", "NY");
+    insertLegacyRow("addresses", "hash-2", "BOSTON", "MA");
+    db.exec(`ALTER TABLE addresses RENAME TO addresses__legacy_region`);
+    db.exec(REBUILT_DDL);
+    insertLegacyRow("addresses", "hash-1", "NEW YORK", "NY");
+    insertLegacyRow("addresses", "hash-2", "BOSTON", "MA");
+
+    DefaultDI();
+    await setupAllDatabases();
+
+    expect(regionColumnIsNullable()).toBe(true);
+    expect(addressHashIds()).toEqual(["hash-1", "hash-2"]);
+    expect(tableExists("addresses__legacy_region")).toBe(false);
+  });
+
+  it("keeps rows written after an older build reported success", async () => {
+    const db = getDb();
+    // Same stranded state, but the database went on being written to: the live
+    // table holds rows the legacy snapshot has never seen. Dropping the live
+    // table to make room for the copy would discard exactly those.
+    db.exec(LEGACY_DDL);
+    insertLegacyRow("addresses", "hash-1", "NEW YORK", "NY");
+    db.exec(`ALTER TABLE addresses RENAME TO addresses__legacy_region`);
+    db.exec(REBUILT_DDL);
+    insertLegacyRow("addresses", "hash-1", "NEW YORK", "NY");
+    insertLegacyRow("addresses", "hash-9", "SEATTLE", null);
+
+    DefaultDI();
+    await setupAllDatabases();
+
+    expect(regionColumnIsNullable()).toBe(true);
+    expect(addressHashIds()).toEqual(["hash-1", "hash-9"]);
+    expect(tableExists("addresses__legacy_region")).toBe(false);
+    // The live row won its primary-key collision — it is the current state,
+    // while the legacy table is a pre-rebuild snapshot.
+    const kept = db
+      .prepare<[], { city: string }>(`SELECT city FROM addresses WHERE address_hash_id = 'hash-9'`)
+      .get();
+    expect(kept?.city).toBe("SEATTLE");
+  });
+
+  it("refuses rather than dropping a populated legacy-shaped live table", async () => {
+    const db = getDb();
+    db.exec(LEGACY_DDL);
+    insertLegacyRow("addresses", "hash-1", "NEW YORK", "NY");
+    db.exec(`ALTER TABLE addresses RENAME TO addresses__legacy_region`);
+    // A second NOT NULL table, populated: two copies and no way to tell which
+    // rows are current. Tidying up the shape by dropping rows is the failure
+    // this whole rebuild exists to prevent.
+    db.exec(LEGACY_DDL);
+    insertLegacyRow("addresses", "hash-7", "AUSTIN", "TX");
+
+    DefaultDI();
+    await expect(setupAllDatabases()).rejects.toThrow(/two populated copies/);
+
+    expect(addressHashIds()).toEqual(["hash-7"]);
+    expect(tableExists("addresses__legacy_region")).toBe(true);
   });
 
   it("refuses to destroy a stranded legacy table when the live table is unusable", async () => {

--- a/src/storage/address/AddressRegionNullableMigration.test.ts
+++ b/src/storage/address/AddressRegionNullableMigration.test.ts
@@ -7,7 +7,7 @@
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { globalServiceRegistry, Sqlite } from "workglow";
 import { DefaultDI } from "../../config/DefaultDI";
 import { setupAllDatabases } from "../../config/setupAllDatabases";
@@ -31,6 +31,39 @@ const LEGACY_DDL = `
     zip TEXT NULL,
     PRIMARY KEY (address_hash_id)
   )`;
+
+function insertLegacyRow(
+  table: string,
+  hashId: string,
+  city: string,
+  region: string | null
+): void {
+  getDb()
+    .prepare(
+      `INSERT INTO ${table}
+         (address_hash_id, street1, street2, street3, city, state_or_country, country_code, zip)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(hashId, "123 Main St", null, null, city, region, "US", "10001");
+}
+
+function addressHashIds(): string[] {
+  return getDb()
+    .prepare<[], { address_hash_id: string }>(
+      `SELECT address_hash_id FROM addresses ORDER BY address_hash_id`
+    )
+    .all()
+    .map((r) => r.address_hash_id);
+}
+
+function tableExists(name: string): boolean {
+  const row = getDb()
+    .prepare<[], { name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='${name}'`
+    )
+    .get();
+  return Boolean(row);
+}
 
 function regionColumnIsNullable(): boolean {
   const columns = getDb()
@@ -116,6 +149,88 @@ describe("migrateAddressRegionNullable (sqlite)", () => {
       .get(ADDRESS_REPOSITORY_TOKEN)
       .get({ address_hash_id: "hash-2" });
     expect(stored?.state_or_country).toBeNull();
+  });
+
+  it("an interrupted copy leaves every row recoverable", async () => {
+    const db = getDb();
+    db.exec(LEGACY_DDL);
+    insertLegacyRow("addresses", "hash-1", "NEW YORK", "NY");
+    insertLegacyRow("addresses", "hash-2", "BOSTON", "MA");
+
+    DefaultDI();
+
+    // Simulate the copy failing mid-rebuild (disk full / SIGINT / OOM). Every
+    // other statement runs for real, so the rest of the rebuild is genuine.
+    const realExec = db.exec.bind(db);
+    const spy = vi.spyOn(db, "exec").mockImplementation((sql: string, ...rest: unknown[]) => {
+      if (sql.trimStart().startsWith("INSERT INTO addresses")) {
+        throw new Error("database or disk is full");
+      }
+      return (realExec as (s: string, ...r: unknown[]) => unknown)(sql, ...rest);
+    });
+
+    await expect(setupAllDatabases()).rejects.toThrow(/database or disk is full/);
+
+    spy.mockRestore();
+
+    // The rollback must have put the table back exactly as it was: still the
+    // legacy NOT NULL shape, with both rows present.
+    expect(regionColumnIsNullable()).toBe(false);
+    expect(addressHashIds()).toEqual(["hash-1", "hash-2"]);
+    expect(tableExists("addresses__legacy_region")).toBe(false);
+
+    // And a re-run completes the rebuild, still with both rows.
+    await setupAllDatabases();
+    expect(regionColumnIsNullable()).toBe(true);
+    expect(addressHashIds()).toEqual(["hash-1", "hash-2"]);
+    expect(tableExists("addresses__legacy_region")).toBe(false);
+  });
+
+  it("resumes a rebuild stranded by an older build", async () => {
+    const db = getDb();
+    // Hand-construct the state an older, non-transactional build could leave:
+    // rows stranded in the legacy table beside an empty new-shape `addresses`.
+    db.exec(LEGACY_DDL);
+    insertLegacyRow("addresses", "hash-1", "NEW YORK", "NY");
+    insertLegacyRow("addresses", "hash-2", "BOSTON", "MA");
+    db.exec(`ALTER TABLE addresses RENAME TO addresses__legacy_region`);
+    db.exec(`
+      CREATE TABLE addresses (
+        address_hash_id TEXT NOT NULL,
+        street1 TEXT NOT NULL,
+        street2 TEXT NULL,
+        street3 TEXT NULL,
+        city TEXT NOT NULL,
+        state_or_country TEXT NULL,
+        country_code TEXT NOT NULL,
+        zip TEXT NULL,
+        PRIMARY KEY (address_hash_id)
+      )`);
+
+    DefaultDI();
+    await setupAllDatabases();
+
+    expect(regionColumnIsNullable()).toBe(true);
+    expect(addressHashIds()).toEqual(["hash-1", "hash-2"]);
+    expect(tableExists("addresses__legacy_region")).toBe(false);
+  });
+
+  it("refuses to destroy a stranded legacy table when the live table is unusable", async () => {
+    const db = getDb();
+    // Crash between the rename and the recreate: no `addresses` at all, rows
+    // only in the legacy table. The plain `!tableExists` early return would
+    // skip the migration and let the caller create an empty table over it.
+    db.exec(LEGACY_DDL);
+    insertLegacyRow("addresses", "hash-1", "NEW YORK", "NY");
+    insertLegacyRow("addresses", "hash-2", "BOSTON", "MA");
+    db.exec(`ALTER TABLE addresses RENAME TO addresses__legacy_region`);
+
+    DefaultDI();
+    await setupAllDatabases();
+
+    expect(regionColumnIsNullable()).toBe(true);
+    expect(addressHashIds()).toEqual(["hash-1", "hash-2"]);
+    expect(tableExists("addresses__legacy_region")).toBe(false);
   });
 
   it("is a no-op on a fresh database", async () => {

--- a/src/storage/address/AddressRegionNullableMigration.ts
+++ b/src/storage/address/AddressRegionNullableMigration.ts
@@ -33,8 +33,21 @@ const COLUMN = "state_or_country";
  *   rename aside, recreate at the current schema, copy every row back, drop the
  *   old one. The column list comes from `AddressSchema`, so it cannot drift.
  *
+ * The SQLite rebuild runs inside one `BEGIN IMMEDIATE` transaction, and every
+ * step of it (`CREATE TABLE`, `CREATE INDEX`, `ALTER TABLE ... RENAME`,
+ * `DROP TABLE`, the copy) rolls back on failure. That matters because the
+ * failure modes are real — the copy transiently doubles the table on disk, and
+ * a SIGINT or an OOM lands wherever it lands. Without the transaction an
+ * interrupted copy would commit an *empty* `addresses` at the new schema: the
+ * next run would see a nullable column, return at the idempotency probe and
+ * report success, while every `address_hash_id` referenced from
+ * `addresses_entity_junction`, `canonical_person_address` and
+ * `canonical_company_address` silently dangled.
+ *
  * Idempotent: a fresh DB has no table (no-op), an already-migrated DB has a
- * nullable column (no-op).
+ * nullable column (no-op). Recoverable: a database still carrying a stranded
+ * `addresses__legacy_region` from an older, non-transactional build resumes the
+ * copy rather than dropping it.
  *
  * The Postgres arm overlaps with the generic `alignPostgresColumnTypes()` pass,
  * which reaches the same column from the declared schema; both are catalog
@@ -64,19 +77,147 @@ export async function migrateAddressRegionNullable(): Promise<void> {
   // In-memory backend: no column types, nothing to migrate.
 }
 
+type SqliteDb = ReturnType<typeof getDb>;
+
+function tableExists(db: SqliteDb, name: string): boolean {
+  const row = db
+    .prepare<[], { name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='${name}'`
+    )
+    .get();
+  return Boolean(row);
+}
+
+function columnsOf(db: SqliteDb, table: string): { name: string; notnull: number }[] {
+  return db.prepare<[], { name: string; notnull: number }>(`PRAGMA table_info(${table})`).all();
+}
+
+function rowCount(db: SqliteDb, table: string): number {
+  const row = db.prepare<[], { n: number }>(`SELECT COUNT(*) AS n FROM ${table}`).get();
+  return Number(row?.n ?? 0);
+}
+
+/** The current schema's column list, backtick-quoted, in declaration order. */
+function schemaColumnList(): string {
+  return Object.keys(AddressSchema.properties)
+    .map((c) => `\`${c}\``)
+    .join(", ");
+}
+
+/**
+ * SQLite carries a renamed table's indexes along under their original names,
+ * which would make the `CREATE INDEX IF NOT EXISTS` in setupDatabase() a silent
+ * no-op and leave the rebuilt table unindexed. Drop them first.
+ * (`sql IS NULL` marks auto-indexes, which cannot be dropped directly.)
+ */
+function dropCarriedOverIndexes(db: SqliteDb): void {
+  const legacyIndexes = db
+    .prepare<[], { name: string }>(
+      `SELECT name FROM sqlite_master
+        WHERE type='index' AND tbl_name='${LEGACY_TABLE}' AND sql IS NOT NULL`
+    )
+    .all();
+  for (const { name } of legacyIndexes) {
+    db.exec(`DROP INDEX IF EXISTS \`${name}\``);
+  }
+}
+
+/**
+ * Copies every row out of the legacy table into the rebuilt one and drops the
+ * legacy table. Must be called inside the caller's transaction.
+ *
+ * The row-count check is the safety net that makes the transaction meaningful:
+ * a copy that silently moved fewer rows (a unique-index violation swallowed by
+ * a future `INSERT OR IGNORE`, a partially applied statement) throws here, so
+ * the whole rebuild rolls back rather than committing a short table.
+ */
+function copyBackAndDropLegacy(db: SqliteDb): number {
+  const cols = schemaColumnList();
+  const expected = rowCount(db, LEGACY_TABLE);
+  db.exec(`INSERT INTO ${TABLE} (${cols}) SELECT ${cols} FROM ${LEGACY_TABLE}`);
+  const copied = rowCount(db, TABLE);
+  if (copied !== expected) {
+    throw new Error(
+      `db setup: rebuilding \`${TABLE}\` copied ${copied} of ${expected} rows — ` +
+        `rolling back, no rows were lost.`
+    );
+  }
+  db.exec(`DROP TABLE ${LEGACY_TABLE}`);
+  return copied;
+}
+
 async function migrateSqlite(): Promise<void> {
   const db = getDb();
 
-  const tableExists = db
-    .prepare<[], { name: string }>(
-      `SELECT name FROM sqlite_master WHERE type='table' AND name='${TABLE}'`
-    )
-    .get();
-  if (!tableExists) return;
+  // `PRAGMA foreign_keys` and `PRAGMA legacy_alter_table` are both no-ops once a
+  // transaction is open, so they are set outside it and restored in the finally.
+  // `legacy_alter_table` matters beyond compatibility: on SQLite >= 3.25 an
+  // `ALTER TABLE ... RENAME TO` rewrites references to the table inside views,
+  // so an operator's (or a downstream superset's) view over `addresses` would be
+  // silently repointed at the legacy table and then broken when it is dropped.
+  const priorForeignKeys = db
+    .prepare<[], { foreign_keys: number }>(`PRAGMA foreign_keys`)
+    .get()?.foreign_keys;
+  const priorLegacyAlter = db
+    .prepare<[], { legacy_alter_table: number }>(`PRAGMA legacy_alter_table`)
+    .get()?.legacy_alter_table;
 
-  const columns = db
-    .prepare<[], { name: string; notnull: number }>(`PRAGMA table_info(${TABLE})`)
-    .all();
+  db.exec(`PRAGMA foreign_keys = OFF`);
+  db.exec(`PRAGMA legacy_alter_table = ON`);
+  try {
+    await rebuildSqlite(db);
+  } finally {
+    db.exec(`PRAGMA foreign_keys = ${priorForeignKeys ? "ON" : "OFF"}`);
+    db.exec(`PRAGMA legacy_alter_table = ${priorLegacyAlter ? "ON" : "OFF"}`);
+  }
+}
+
+async function rebuildSqlite(db: SqliteDb): Promise<void> {
+  // Probe for a stranded legacy table FIRST. A database left mid-rebuild by an
+  // older, non-transactional build holds every row there, and the two early
+  // returns below would both mis-handle it: an empty new-shape `addresses`
+  // passes the nullable-column probe, and a missing `addresses` (crash between
+  // the rename and the recreate) trips the `!tableExists` return. Either way the
+  // rows would be abandoned and `db setup` would report success. Resume instead
+  // — and never DROP the legacy table outside the rebuild transaction, since on
+  // this path it is the only surviving copy.
+  if (tableExists(db, LEGACY_TABLE)) {
+    const stranded = rowCount(db, LEGACY_TABLE);
+    console.warn(
+      `db setup: resuming an interrupted \`${TABLE}\` rebuild from ` +
+        `\`${LEGACY_TABLE}\` (${stranded} rows)`
+    );
+    db.exec(`BEGIN IMMEDIATE`);
+    try {
+      // The live table may be absent, or present but still legacy-shaped (the
+      // rename never happened for it). Either way, replace it with a fresh
+      // table at the current schema before copying back.
+      const liveRegion = tableExists(db, TABLE)
+        ? columnsOf(db, TABLE).find((c) => c.name === COLUMN)
+        : undefined;
+      if (!tableExists(db, TABLE) || (liveRegion && liveRegion.notnull !== 0)) {
+        db.exec(`DROP TABLE IF EXISTS ${TABLE}`);
+      }
+      dropCarriedOverIndexes(db);
+      // Safe to call inside the transaction: `createStorage` passes no
+      // `tabularMigrations`, so setupDatabase() is only CREATE TABLE IF NOT
+      // EXISTS + createIndexes() — it opens no transaction of its own. Threading
+      // `tabularMigrations` through `createStorage` later would make this a
+      // nested BEGIN and throw.
+      await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).setupDatabase();
+      const copied = copyBackAndDropLegacy(db);
+      db.exec(`COMMIT`);
+      console.warn(`db setup: recovered ${copied} \`${TABLE}\` rows`);
+    } catch (err) {
+      rollbackQuietly(db);
+      throw wrapRebuildError(err);
+    }
+    return;
+  }
+
+  if (!tableExists(db, TABLE)) return;
+
+  const columns = columnsOf(db, TABLE);
   const region = columns.find((c) => c.name === COLUMN);
   // Column absent entirely (older shape than this migration knows) or already
   // nullable → nothing to do.
@@ -84,10 +225,10 @@ async function migrateSqlite(): Promise<void> {
 
   // The copy below selects the CURRENT schema's column list out of the renamed
   // table, so a column added to `AddressSchema` after this database was created
-  // would make it fail — after the rename, leaving an empty `addresses` beside
-  // the stranded legacy table. The next run would then see a nullable column
-  // and return early, so the rows would never come back. Refuse before touching
-  // anything instead, and say exactly what is missing.
+  // would make it fail. The rebuild transaction would roll that back cleanly,
+  // but the operator would just hit the same failure on every subsequent run
+  // with no explanation. Refuse before touching anything instead, and say
+  // exactly what is missing.
   const existing = new Set(columns.map((c) => c.name));
   const missing = Object.keys(AddressSchema.properties).filter((c) => !existing.has(c));
   if (missing.length > 0) {
@@ -98,34 +239,47 @@ async function migrateSqlite(): Promise<void> {
     );
   }
 
-  // A previous interrupted run could have left the legacy table behind; the
-  // rename below would fail on it.
-  db.exec(`DROP TABLE IF EXISTS ${LEGACY_TABLE}`);
-  db.exec(`ALTER TABLE ${TABLE} RENAME TO ${LEGACY_TABLE}`);
-
-  // SQLite carries a renamed table's indexes along under their original names,
-  // which would make the `CREATE INDEX IF NOT EXISTS` in setupDatabase() a
-  // silent no-op and leave the rebuilt table unindexed. Drop them first.
-  // (`sql IS NULL` marks auto-indexes, which cannot be dropped directly.)
-  const legacyIndexes = db
-    .prepare<[], { name: string }>(
-      `SELECT name FROM sqlite_master
-        WHERE type='index' AND tbl_name='${LEGACY_TABLE}' AND sql IS NOT NULL`
-    )
-    .all();
-  for (const { name } of legacyIndexes) {
-    db.exec(`DROP INDEX IF EXISTS \`${name}\``);
+  // BEGIN IMMEDIATE, not plain BEGIN: a deferred transaction takes a read lock
+  // and then fails the write upgrade with SQLITE_BUSY straight away, which
+  // `busy_timeout` does not cover.
+  db.exec(`BEGIN IMMEDIATE`);
+  try {
+    db.exec(`ALTER TABLE ${TABLE} RENAME TO ${LEGACY_TABLE}`);
+    dropCarriedOverIndexes(db);
+    // Recreate `addresses` at the current schema (nullable region).
+    // setupAllDatabases calls this again right after; the second call is a
+    // no-op. Safe inside the transaction — see the note on the resume path.
+    await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).setupDatabase();
+    const copied = copyBackAndDropLegacy(db);
+    db.exec(`COMMIT`);
+    console.warn(`db setup: rebuilt \`${TABLE}\` with a nullable \`${COLUMN}\` (${copied} rows)`);
+  } catch (err) {
+    rollbackQuietly(db);
+    throw wrapRebuildError(err);
   }
+}
 
-  // Recreate `addresses` at the current schema (nullable region). setupAllDatabases
-  // calls this again right after; the second call is a no-op.
-  await globalServiceRegistry.get(ADDRESS_REPOSITORY_TOKEN).setupDatabase();
+/**
+ * Rolls back, swallowing a rollback failure. The original error is what the
+ * caller needs to see; a "cannot rollback - no transaction is active" on top of
+ * it would only hide the cause.
+ */
+function rollbackQuietly(db: SqliteDb): void {
+  try {
+    db.exec(`ROLLBACK`);
+  } catch {
+    // already rolled back, or the transaction never opened
+  }
+}
 
-  const cols = Object.keys(AddressSchema.properties)
-    .map((c) => `\`${c}\``)
-    .join(", ");
-  db.exec(`INSERT INTO ${TABLE} (${cols}) SELECT ${cols} FROM ${LEGACY_TABLE}`);
-  db.exec(`DROP TABLE ${LEGACY_TABLE}`);
+function wrapRebuildError(err: unknown): Error {
+  const msg = err instanceof Error ? err.message : String(err);
+  const wrapped = new Error(
+    `db setup: rebuilding \`${TABLE}\` to relax \`${COLUMN}\` failed and was rolled back — ` +
+      `no rows were lost, \`${TABLE}\` is unchanged. Cause: ${msg}`
+  );
+  if (err instanceof Error) wrapped.cause = err;
+  return wrapped;
 }
 
 async function migratePostgres(): Promise<void> {

--- a/src/storage/address/AddressRegionNullableMigration.ts
+++ b/src/storage/address/AddressRegionNullableMigration.ts
@@ -9,11 +9,13 @@ import { isDryRun } from "../../cli/isDryRun";
 import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
 import { getDb } from "../../util/db";
 import { getPgPool } from "../../util/pg";
-import { ADDRESS_REPOSITORY_TOKEN, AddressSchema } from "./AddressSchema";
+import { ADDRESS_REPOSITORY_TOKEN, AddressPrimaryKeyNames, AddressSchema } from "./AddressSchema";
 
 const TABLE = "addresses";
 const LEGACY_TABLE = "addresses__legacy_region";
 const COLUMN = "state_or_country";
+/** Single-column PK, so the resume-path merge can anti-join on it. */
+const PRIMARY_KEY = AddressPrimaryKeyNames[0];
 
 /**
  * Relaxes `addresses.state_or_country` from NOT NULL to nullable.
@@ -81,9 +83,10 @@ type SqliteDb = ReturnType<typeof getDb>;
 
 function tableExists(db: SqliteDb, name: string): boolean {
   const row = db
-    .prepare<[], { name: string }>(
-      `SELECT name FROM sqlite_master WHERE type='table' AND name='${name}'`
-    )
+    .prepare<
+      [],
+      { name: string }
+    >(`SELECT name FROM sqlite_master WHERE type='table' AND name='${name}'`)
     .get();
   return Boolean(row);
 }
@@ -123,27 +126,79 @@ function dropCarriedOverIndexes(db: SqliteDb): void {
 }
 
 /**
- * Copies every row out of the legacy table into the rebuilt one and drops the
- * legacy table. Must be called inside the caller's transaction.
+ * Refuses unless `table` carries every column the current schema declares.
+ *
+ * The copy selects the CURRENT schema's column list out of the table being
+ * copied FROM, so a column added to `AddressSchema` after this database was
+ * created would make it fail. The rebuild transaction rolls that back cleanly,
+ * but the operator would just hit the same failure on every subsequent run with
+ * no explanation. Refuse before touching anything instead, and say exactly what
+ * is missing — on the resume path too, where the source is the legacy table and
+ * a bare "no such column" would be the only clue.
+ */
+function assertCopyableColumns(db: SqliteDb, table: string): void {
+  const existing = new Set(columnsOf(db, table).map((c) => c.name));
+  const missing = Object.keys(AddressSchema.properties).filter((c) => !existing.has(c));
+  if (missing.length > 0) {
+    throw new Error(
+      `db setup: cannot rebuild \`${TABLE}\` to relax \`${COLUMN}\` — \`${table}\` is ` +
+        `missing column(s) ${missing.join(", ")} that the current schema declares. ` +
+        `Add them (or drop and re-ingest \`${TABLE}\`) before re-running \`sec db setup\`.`
+    );
+  }
+}
+
+/**
+ * Copies the legacy table's rows into the rebuilt one and drops the legacy
+ * table. Must be called inside the caller's transaction.
+ *
+ * Only rows the live table does not already hold are copied. On the normal
+ * rebuild path the live table was just recreated and is empty, so that is every
+ * legacy row and the count check below is exactly as strict as a blind copy.
+ * The distinction matters on the resume path, where the live table can already
+ * be populated: the older, non-transactional build's LAST step was
+ * `DROP TABLE addresses__legacy_region`, so a crash immediately before it —
+ * SIGINT, OOM, power loss — left the rows in BOTH tables. That state is not
+ * hypothetical: the old code then reported success on every subsequent run (it
+ * probed a nullable column and returned early), so a database can have been
+ * serving traffic in it for months, accumulating live rows the legacy snapshot
+ * has never seen. A blind copy would fail the primary key and roll back,
+ * turning a database the old build tolerated into one where `db setup` fails
+ * forever; dropping the live table instead would discard everything written
+ * since. Merging keeps both.
+ *
+ * The live row wins a primary-key collision: it is the current state, while the
+ * legacy table is a pre-rebuild snapshot. Legacy's own primary key is unique,
+ * so no row inserted here can change the verdict for another — the anti-join
+ * holds however SQLite chooses to evaluate it.
  *
  * The row-count check is the safety net that makes the transaction meaningful:
- * a copy that silently moved fewer rows (a unique-index violation swallowed by
- * a future `INSERT OR IGNORE`, a partially applied statement) throws here, so
- * the whole rebuild rolls back rather than committing a short table.
+ * a copy that silently moved fewer rows (a partially applied statement) throws
+ * here, so the whole rebuild rolls back rather than committing a short table.
  */
 function copyBackAndDropLegacy(db: SqliteDb): number {
   const cols = schemaColumnList();
-  const expected = rowCount(db, LEGACY_TABLE);
-  db.exec(`INSERT INTO ${TABLE} (${cols}) SELECT ${cols} FROM ${LEGACY_TABLE}`);
-  const copied = rowCount(db, TABLE);
-  if (copied !== expected) {
+  const notAlreadyPresent = `WHERE \`${PRIMARY_KEY}\` NOT IN (SELECT \`${PRIMARY_KEY}\` FROM ${TABLE})`;
+  const liveBefore = rowCount(db, TABLE);
+  const incoming = Number(
+    db
+      .prepare<[], { n: number }>(`SELECT COUNT(*) AS n FROM ${LEGACY_TABLE} ${notAlreadyPresent}`)
+      .get()?.n ?? 0
+  );
+  const expected = liveBefore + incoming;
+  db.exec(
+    `INSERT INTO ${TABLE} (${cols}) SELECT ${cols} FROM ${LEGACY_TABLE} ${notAlreadyPresent}`
+  );
+  const total = rowCount(db, TABLE);
+  if (total !== expected) {
     throw new Error(
-      `db setup: rebuilding \`${TABLE}\` copied ${copied} of ${expected} rows — ` +
+      `db setup: rebuilding \`${TABLE}\` ended with ${total} rows, expected ${expected} ` +
+        `(${liveBefore} already live + ${incoming} from \`${LEGACY_TABLE}\`) — ` +
         `rolling back, no rows were lost.`
     );
   }
   db.exec(`DROP TABLE ${LEGACY_TABLE}`);
-  return copied;
+  return total;
 }
 
 async function migrateSqlite(): Promise<void> {
@@ -187,17 +242,33 @@ async function rebuildSqlite(db: SqliteDb): Promise<void> {
       `db setup: resuming an interrupted \`${TABLE}\` rebuild from ` +
         `\`${LEGACY_TABLE}\` (${stranded} rows)`
     );
+    assertCopyableColumns(db, LEGACY_TABLE);
     db.exec(`BEGIN IMMEDIATE`);
     try {
       // The live table may be absent, or present but still legacy-shaped (the
-      // rename never happened for it). Either way, replace it with a fresh
-      // table at the current schema before copying back.
-      const liveRegion = tableExists(db, TABLE)
-        ? columnsOf(db, TABLE).find((c) => c.name === COLUMN)
-        : undefined;
-      if (!tableExists(db, TABLE) || (liveRegion && liveRegion.notnull !== 0)) {
-        db.exec(`DROP TABLE IF EXISTS ${TABLE}`);
+      // rename never happened for it). Either way it has to be replaced with a
+      // fresh table at the current schema before copying back — but only an
+      // EMPTY one may be dropped to get there. A populated legacy-shaped table
+      // beside a stranded legacy table is a state no build in this file
+      // produces (`setupDatabase()` only ever creates the current, nullable
+      // schema), and dropping rows to tidy up a shape is the very failure this
+      // rebuild exists to prevent, so refuse and let an operator reconcile.
+      const live = tableExists(db, TABLE) ? columnsOf(db, TABLE) : undefined;
+      const liveRegion = live?.find((c) => c.name === COLUMN);
+      if (live !== undefined && liveRegion !== undefined && liveRegion.notnull !== 0) {
+        const liveRows = rowCount(db, TABLE);
+        if (liveRows > 0) {
+          throw new Error(
+            `\`${TABLE}\` still declares \`${COLUMN}\` NOT NULL and holds ${liveRows} row(s) ` +
+              `while \`${LEGACY_TABLE}\` holds ${stranded} — two populated copies, and no way ` +
+              `to tell which rows are current. Reconcile them by hand, then re-run ` +
+              `\`sec db setup\`.`
+          );
+        }
+        db.exec(`DROP TABLE ${TABLE}`);
       }
+      // A live table at the current schema is KEPT, populated or not:
+      // `copyBackAndDropLegacy` merges the legacy rows into it.
       dropCarriedOverIndexes(db);
       // Safe to call inside the transaction: `createStorage` passes no
       // `tabularMigrations`, so setupDatabase() is only CREATE TABLE IF NOT
@@ -223,21 +294,7 @@ async function rebuildSqlite(db: SqliteDb): Promise<void> {
   // nullable → nothing to do.
   if (!region || region.notnull === 0) return;
 
-  // The copy below selects the CURRENT schema's column list out of the renamed
-  // table, so a column added to `AddressSchema` after this database was created
-  // would make it fail. The rebuild transaction would roll that back cleanly,
-  // but the operator would just hit the same failure on every subsequent run
-  // with no explanation. Refuse before touching anything instead, and say
-  // exactly what is missing.
-  const existing = new Set(columns.map((c) => c.name));
-  const missing = Object.keys(AddressSchema.properties).filter((c) => !existing.has(c));
-  if (missing.length > 0) {
-    throw new Error(
-      `db setup: cannot rebuild \`${TABLE}\` to relax \`${COLUMN}\` — the existing table is ` +
-        `missing column(s) ${missing.join(", ")} that the current schema declares. ` +
-        `Add them (or drop and re-ingest \`${TABLE}\`) before re-running \`sec db setup\`.`
-    );
-  }
+  assertCopyableColumns(db, TABLE);
 
   // BEGIN IMMEDIATE, not plain BEGIN: a deferred transaction takes a read lock
   // and then fails the write upgrade with SQLITE_BUSY straight away, which

--- a/src/storage/observation/PersonObservationTitleSchema.ts
+++ b/src/storage/observation/PersonObservationTitleSchema.ts
@@ -36,8 +36,9 @@ export type PersonObservationTitle = Static<typeof PersonObservationTitleSchema>
 export const PersonObservationTitlePrimaryKeyNames = ["observation_id", "title"] as const;
 
 /**
- * Physical table name. Shared by the DI registration and by the raw-SQL bulk
- * reader, which names the table directly and would otherwise drift from it.
+ * Physical table name. Shared by the DI registration that creates the storage
+ * and by `PersonObservationTitleRepo`'s integrity-check error message, which
+ * names the table to the operator and would otherwise drift from it.
  */
 export const PersonObservationTitleTable = "person_observation_titles";
 

--- a/src/storage/spac/SpacCandidateSchema.ts
+++ b/src/storage/spac/SpacCandidateSchema.ts
@@ -11,13 +11,21 @@ import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { TypeNullable, TypeStringEnum } from "../../util/TypeBoxUtil";
 
 /**
- * How strongly the submissions metadata alone says "SPAC". See
- * `classifySpacCandidate` for the ladder; in short:
+ * How strongly the submissions metadata alone says "SPAC".
+ * `classifySpacCandidate` is the authoritative statement of the ladder; this is
+ * the same rule in short:
  *
- * - `high`   — registered on the S-1 family *while* carrying a blank-check name
- * - `medium` — SIC 6770 today plus an S-1-family registration, no name evidence
- * - `low`    — blank-check name only in history, and the registration came after
- *              the rename (the Form 10 shell / reverse-merger pattern)
+ * - `high`   — an S-1-family registration plus either a blank-check name
+ *              (current or former) or EDGAR's 6770 coding, with nothing arguing
+ *              against it. 6770-plus-registration sits here on measurement (150
+ *              of 168 such 2019-2024 registrants appear in embarc's curated
+ *              list, 89%).
+ * - `medium` — one weakened or contradicted signal: a weak-class name with a
+ *              registration and nothing else, or a 6770 filer that registered
+ *              only AFTER shedding a blank-check name.
+ * - `low`    — a blank-check name only in history with the registration filed
+ *              after the rename (the Form 10 shell pattern), OR 6770 with no
+ *              registration on file at all.
  */
 export const SPAC_CANDIDATE_CONFIDENCES = ["high", "medium", "low"] as const;
 export type SpacCandidateConfidence = (typeof SPAC_CANDIDATE_CONFIDENCES)[number];

--- a/src/storage/spac/SpacCandidateSchema.ts
+++ b/src/storage/spac/SpacCandidateSchema.ts
@@ -47,7 +47,11 @@ export type SpacCandidateConfidence = (typeof SPAC_CANDIDATE_CONFIDENCES)[number
  */
 export const SpacCandidateSchema = Type.Object({
   cik: TypeSecCik(),
-  name: TypeNullable(Type.String({ maxLength: 200, description: "Entity name at scan time" })),
+  // 512, matching CompanyObservationSchema / CanonicalCompanySchema. `entities.name`
+  // is unbounded, so this column is the only place a conformed name is truncated —
+  // and on Postgres an over-long value does not truncate, it aborts the whole
+  // 1000-row putBulk the scan writes in.
+  name: TypeNullable(Type.String({ maxLength: 512, description: "Entity name at scan time" })),
   current_sic: TypeNullable(Type.Integer({ minimum: 0, description: "entities.sic at scan time" })),
 
   /** `entities.sic` reads 6770 (Blank Checks) right now. */
@@ -55,7 +59,7 @@ export const SpacCandidateSchema = Type.Object({
   /** The entity's *current* name looks like a blank check. */
   signal_name_match: Type.Boolean(),
   /** A *former* name looked like a blank check; carries that name. */
-  signal_renamed_from: TypeNullable(Type.String({ maxLength: 200 })),
+  signal_renamed_from: TypeNullable(Type.String({ maxLength: 512 })),
 
   /**
    * Earliest Securities Act registration and its form — `S-1` / `F-1` for a

--- a/src/task/spac/ListSpacCandidatesTask.ts
+++ b/src/task/spac/ListSpacCandidatesTask.ts
@@ -38,7 +38,11 @@ export class ListSpacCandidatesTask extends Task<
   public static inputSchema() {
     return Type.Object({
       confidence: Type.Optional(Type.Union(SPAC_CANDIDATE_CONFIDENCES.map((c) => Type.Literal(c)))),
-      limit: Type.Optional(Type.Integer({ minimum: 1 })),
+      // `minimum: 0`, matching the CLI's `parseIntOption`: `--limit 0` asks for
+      // the total with no rows, which `slice` already does. Rejecting it in the
+      // schema would surface as a validation failure from a value the option
+      // parser accepted.
+      limit: Type.Optional(Type.Integer({ minimum: 0 })),
       offset: Type.Optional(Type.Integer({ minimum: 0 })),
     });
   }

--- a/src/task/spac/classifySpacCandidate.test.ts
+++ b/src/task/spac/classifySpacCandidate.test.ts
@@ -293,4 +293,45 @@ describe("classifySpacCandidate", () => {
     );
     expect(row).toMatchObject({ confidence: "high", reg_while_spac_named: true });
   });
+
+  it("keeps a still-blank-check-named SPAC high when an EARLIER interval closed before the registration", () => {
+    // The company still calls itself "Ajax Acquisition Corp" today, so it never
+    // renamed away from the blank-check name — an earlier closed interval is a
+    // cosmetic variant or a pre-IPO sponsor rebrand, not a de-SPAC.
+    const row = classifySpacCandidate(
+      facts({
+        cik: 9001,
+        name: "Ajax Acquisition Corp",
+        current_sic: 7389,
+        first_reg_form: "S-1",
+        first_reg_date: "2021-06-01",
+        renamed_from: "Ajax Capital Acquisitions Corp",
+        spac_name_ended: "2021-01-15T00:00:00.000Z",
+      }),
+      AT
+    );
+    expect(row).toMatchObject({
+      confidence: "high",
+      signal_name_match: true,
+      reg_while_spac_named: true,
+    });
+  });
+
+  it("does not let the current-name check promote a weak-class name past medium", () => {
+    // Same shape, but both names only match the weak class. The current name
+    // must still count as "never renamed away", yet stay capped at medium.
+    const row = classifySpacCandidate(
+      facts({
+        cik: 9001,
+        name: "Ajax Capital Corp",
+        current_sic: 7389,
+        first_reg_form: "S-1",
+        first_reg_date: "2021-06-01",
+        renamed_from: "Ajax Capital Investment Corp",
+        spac_name_ended: "2021-01-15T00:00:00.000Z",
+      }),
+      AT
+    );
+    expect(row).toMatchObject({ confidence: "medium", reg_while_spac_named: true });
+  });
 });

--- a/src/task/spac/classifySpacCandidate.ts
+++ b/src/task/spac/classifySpacCandidate.ts
@@ -183,6 +183,10 @@ export interface SpacCandidateFacts {
    * interval's `valid_to`, not the first: EDGAR records cosmetic variants
    * ("Corp." → "Corp") as separate intervals, and the earliest one ends while
    * the company is still very much a SPAC.
+   *
+   * Consulted only when {@link name} no longer matches either naming class. A
+   * company still carrying the name has not renamed away from it, so a closed
+   * interval on it describes a variant it kept, not an era it left.
    */
   readonly spac_name_ended: string | null;
 }
@@ -247,12 +251,20 @@ export function classifySpacCandidate(
   // Whether the earliest registration predates the loss of the blank-check
   // name. Only answerable when the company renamed away from one; a company
   // that still carries the name has, trivially, not renamed away from it yet.
+  //
+  // The CURRENT name is consulted first, and that order is the whole point: a
+  // company still carrying a SPAC-shaped name today never renamed away from
+  // one, whatever `spac_name_ended` says. Any earlier closed interval is a
+  // cosmetic variant ("Corp." -> "Corp") or a pre-IPO sponsor rebrand, and
+  // dating the registration against it would wrongly read as "registered after
+  // shedding the name" — the Form 10 shell shape — and demote a live SPAC to
+  // `low`.
   let reg_while_spac_named: boolean | null = null;
-  if (hasRegistration && facts.spac_name_ended !== null) {
-    reg_while_spac_named = facts.first_reg_date! <= facts.spac_name_ended.slice(0, 10);
-  } else if (hasRegistration && (signal_name_match || looksLikeModernSpacName(facts.name))) {
+  if (hasRegistration && (signal_name_match || looksLikeModernSpacName(facts.name))) {
     // Still carrying the name today, so it has not renamed away from it.
     reg_while_spac_named = true;
+  } else if (hasRegistration && facts.spac_name_ended !== null) {
+    reg_while_spac_named = facts.first_reg_date! <= facts.spac_name_ended.slice(0, 10);
   }
 
   // `false` is the one value that argues against a SPAC: the company registered

--- a/src/task/spac/spacCandidateScan.sqlite.test.ts
+++ b/src/task/spac/spacCandidateScan.sqlite.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { globalServiceRegistry } from "workglow";
+import { withSqliteDb } from "../../config/testing/withSqliteDb";
+import type { Entity } from "../../storage/entity/EntitySchema";
+import { ENTITY_REPOSITORY_TOKEN } from "../../storage/entity/EntitySchema";
+import type { EntityHistory } from "../../storage/entity/EntityHistorySchema";
+import { ENTITY_HISTORY_REPOSITORY_TOKEN } from "../../storage/entity/EntityHistorySchema";
+import type { Filing } from "../../storage/filing/FilingSchema";
+import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
+import { PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedSubmissionsSchema";
+import { classifySpacCandidate, type SpacCandidateFacts } from "./classifySpacCandidate";
+import { scanRepository, scanSpacCandidates } from "./spacCandidateScan";
+
+const TEST_DB_NAME = "spac_candidate_scan_sqlite_test";
+const AT = "2026-08-02T12:00:00.000Z";
+
+const entity = (cik: number, name: string, sic: number | null): Entity => ({
+  cik,
+  name,
+  type: null,
+  sic,
+  ein: null,
+  description: null,
+  website: null,
+  investor_website: null,
+  category: null,
+  fiscal_year: null,
+  state_incorporation: null,
+  state_incorporation_desc: null,
+});
+
+const history = (
+  cik: number,
+  name: string,
+  valid_from: string,
+  valid_to: string | null
+): EntityHistory => ({
+  cik,
+  valid_from,
+  valid_to,
+  name,
+  type: null,
+  sic: null,
+  ein: null,
+  description: null,
+  website: null,
+  investor_website: null,
+  category: null,
+  fiscal_year: null,
+  state_incorporation: null,
+  state_incorporation_desc: null,
+  change_source: "SUBMISSION_UPDATE",
+  change_date: valid_from,
+});
+
+const filing = (cik: number, form: string, filing_date: string, seq: number): Filing => ({
+  cik,
+  accession_number: `0000000000-00-${String(seq).padStart(6, "0")}`,
+  filing_date,
+  report_date: null,
+  acceptance_date: `${filing_date}T00:00:00.000Z`,
+  form,
+  file_number: null,
+  film_number: null,
+  primary_doc: "doc.htm",
+  primary_doc_description: null,
+  size: null,
+  is_xbrl: null,
+  is_inline_xbrl: null,
+  items: null,
+  act: null,
+});
+
+function byCik(facts: SpacCandidateFacts[]): SpacCandidateFacts[] {
+  return [...facts].sort((a, b) => a.cik - b.cik);
+}
+
+/**
+ * Pins the hand-written `buildScanSql` against `scanRepository`, its JS twin.
+ * The two implementations must agree row for row on the same seeded data — the
+ * SQL is dual-dialect, deeply subqueried and binds its parameters positionally,
+ * so a drift between them (or a binding-order slip) is otherwise invisible until
+ * production.
+ *
+ * Each fixture pins a distinct fragment; see the comment on each seed. Not
+ * covered here: `toIsoOrNull`'s Postgres branch, which converts a `Date` from
+ * pg. On SQLite `valid_to` comes back as the stored TEXT, identical to what the
+ * repository twin reads, so both paths exercise the string branch only.
+ */
+describe("scanSpacCandidates (sqlite) vs the repository twin", () => {
+  withSqliteDb(TEST_DB_NAME, [
+    ENTITY_REPOSITORY_TOKEN,
+    ENTITY_HISTORY_REPOSITORY_TOKEN,
+    FILING_REPOSITORY_TOKEN,
+    PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN,
+  ]);
+
+  async function seed(): Promise<void> {
+    const entities = globalServiceRegistry.get(ENTITY_REPOSITORY_TOKEN);
+    const histories = globalServiceRegistry.get(ENTITY_HISTORY_REPOSITORY_TOKEN);
+    const filings = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
+    const processed = globalServiceRegistry.get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN);
+
+    // 1 — sicMatch + entityNameMatch, and both registration subqueries: the
+    // 10-K must be excluded from `first_reg_form`/`first_reg_date` even though
+    // it is this CIK's only other filing. `first_reg_form === "S-1"` is the
+    // direct catch for a parameter-binding-order slip between the two
+    // subqueries, which would otherwise silently swap form and date.
+    await entities.put(entity(1, "Alpha Acquisition Corp", 6770));
+    await filings.put(filing(1, "S-1", "2021-01-05", 1));
+    await filings.put(filing(1, "10-K", "2022-03-01", 2));
+
+    // 2 — historyNameMatch + renamedFrom + spacNameEnded: a de-SPAC whose
+    // current name and SIC carry no trace of the blank check.
+    await entities.put(entity(2, "Renovacor, Inc.", 2836));
+    await histories.put(
+      history(2, "Chardan Healthcare Acquisition 2 Corp", "2019-01-01", "2021-09-02")
+    );
+
+    // 3 — max(valid_to) must skip the OPEN current row: an earlier closed
+    // interval plus a still-open one. End-to-end regression for the classifier
+    // branch order (the registration postdates the closed interval, yet the
+    // current name still matches).
+    await entities.put(entity(3, "Ajax Acquisition Corp", 7389));
+    await histories.put(history(3, "Ajax Capital Acquisitions Corp", "2020-01-01", "2021-01-15"));
+    await histories.put(history(3, "Ajax Acquisition Corp", "2021-01-15", null));
+    await filings.put(filing(3, "S-1", "2021-06-01", 3));
+
+    // 4 — the NOT LIKE exclusions: an LLC holding vehicle that matches
+    // `%acquisition%` but must not appear at all.
+    await entities.put(entity(4, "Inergy Acquisition Company, LLC", null));
+    await filings.put(filing(4, "S-1", "2021-03-01", 4));
+
+    // 5 — negative control: matches nothing.
+    await entities.put(entity(5, "Apple Inc.", 3571));
+    await filings.put(filing(5, "S-1", "2021-04-01", 5));
+
+    // 6 — MODERN_SPAC_NAME_PATTERNS (weak class) with a DRS registration and no
+    // SIC at all.
+    await entities.put(entity(6, "Foo Capital Corp", null));
+    await filings.put(filing(6, "DRS", "2021-02-01", 6));
+
+    // 7 — the `--since` variant: excluded by an old `last_processed`.
+    await entities.put(entity(7, "Beta Acquisition Corp", 6770));
+    await filings.put(filing(7, "S-1", "2021-05-01", 7));
+    await processed.put({ cik: 7, last_processed: "2020-01-01", success: true });
+  }
+
+  it("agrees with the repository twin on a full scan", async () => {
+    await seed();
+
+    const sql = byCik(await scanSpacCandidates({}));
+    const twin = byCik(await scanRepository({}));
+
+    expect(sql).toEqual(twin);
+  });
+
+  it("agrees with the repository twin on an incremental --since scan", async () => {
+    await seed();
+
+    const sql = byCik(await scanSpacCandidates({ since: "2025-01-01" }));
+    const twin = byCik(await scanRepository({ since: "2025-01-01" }));
+
+    expect(sql).toEqual(twin);
+    // CIK 7 is the only seeded CIK with a `processed_submissions` row, and its
+    // watermark predates the cutoff, so `--since` must drop it while the full
+    // scan keeps it.
+    expect(sql.map((f) => f.cik)).not.toContain(7);
+    expect(byCik(await scanSpacCandidates({})).map((f) => f.cik)).toContain(7);
+  });
+
+  it("resolves each fragment correctly, independently of the twin", async () => {
+    // Spot assertions written against the fixtures rather than against the
+    // other implementation, so a bug SHARED by both still fails here.
+    await seed();
+    const facts = byCik(await scanSpacCandidates({}));
+    const at = (cik: number): SpacCandidateFacts => {
+      const found = facts.find((f) => f.cik === cik);
+      expect(found, `expected a candidate row for CIK ${cik}`).toBeDefined();
+      return found!;
+    };
+
+    expect(at(1)).toMatchObject({
+      name: "Alpha Acquisition Corp",
+      current_sic: 6770,
+      first_reg_form: "S-1",
+      first_reg_date: "2021-01-05",
+    });
+    expect(at(2)).toMatchObject({
+      renamed_from: "Chardan Healthcare Acquisition 2 Corp",
+      spac_name_ended: "2021-09-02",
+      first_reg_form: null,
+    });
+    // The open current row must not win max(valid_to) and blank the field.
+    expect(at(3).spac_name_ended).toBe("2021-01-15");
+    expect(at(6)).toMatchObject({ first_reg_form: "DRS", current_sic: null });
+
+    expect(facts.map((f) => f.cik)).not.toContain(4);
+    expect(facts.map((f) => f.cik)).not.toContain(5);
+  });
+
+  it("grades the scanned facts into the expected tiers", async () => {
+    await seed();
+    const graded = new Map(
+      byCik(await scanSpacCandidates({})).map((f) => [f.cik, classifySpacCandidate(f, AT)])
+    );
+
+    expect(graded.get(1)).toMatchObject({ confidence: "high" });
+    // Still blank-check-named today despite the earlier closed interval.
+    expect(graded.get(3)).toMatchObject({ confidence: "high", reg_while_spac_named: true });
+    // Weak-class name with a registration and nothing else.
+    expect(graded.get(6)).toMatchObject({ confidence: "medium" });
+  });
+});

--- a/src/task/spac/spacCandidateScan.test.ts
+++ b/src/task/spac/spacCandidateScan.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { globalServiceRegistry } from "workglow";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
+import { ENTITY_REPOSITORY_TOKEN } from "../../storage/entity/EntitySchema";
+import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
+import { scanSpacCandidates } from "./spacCandidateScan";
+
+describe("scanSpacCandidates backend dispatch", () => {
+  beforeEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  afterEach(() => {
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("uses the in-memory repositories even when SEC_DB_* names a SQLite database", async () => {
+    // `resetDependencyInjectionsForTesting` is what registers the in-memory
+    // repositories; the beforeEach already ran it.
+    await setupAllDatabases();
+
+    await globalServiceRegistry.get(ENTITY_REPOSITORY_TOKEN).put({
+      cik: 1,
+      name: "Alpha Acquisition Corp",
+      type: null,
+      sic: 6770,
+      ein: null,
+      description: null,
+      website: null,
+      investor_website: null,
+      category: null,
+      fiscal_year: null,
+      state_incorporation: null,
+      state_incorporation_desc: null,
+    });
+    await globalServiceRegistry.get(FILING_REPOSITORY_TOKEN).put({
+      cik: 1,
+      accession_number: "0000000000-21-000001",
+      filing_date: "2021-01-05",
+      report_date: null,
+      acceptance_date: "2021-01-05T00:00:00.000Z",
+      form: "S-1",
+      file_number: null,
+      film_number: null,
+      items: null,
+      size: null,
+      is_xbrl: null,
+      is_inline_xbrl: null,
+      primary_doc: "alpha-s1.htm",
+      primary_doc_description: null,
+      act: null,
+    });
+
+    // Only NOW bind the production SQLite config, pointing at a directory that
+    // does not exist. A backend probe that reads SEC_DB_* alone would select the
+    // SQLite fast path and either throw out of getDb() or scan an empty file;
+    // the in-memory repositories are what actually hold the seeded rows.
+    globalServiceRegistry.registerInstance(SEC_DB_TYPE, "sqlite");
+    globalServiceRegistry.registerInstance(SEC_DB_FOLDER, "/nonexistent/sec-scan-guard");
+    globalServiceRegistry.registerInstance(SEC_DB_NAME, "edgar");
+
+    const facts = await scanSpacCandidates();
+
+    expect(facts).toHaveLength(1);
+    expect(facts[0]).toMatchObject({
+      cik: 1,
+      name: "Alpha Acquisition Corp",
+      current_sic: 6770,
+      first_reg_form: "S-1",
+      first_reg_date: "2021-01-05",
+    });
+  });
+});

--- a/src/task/spac/spacCandidateScan.ts
+++ b/src/task/spac/spacCandidateScan.ts
@@ -5,13 +5,16 @@
  */
 
 import { globalServiceRegistry } from "workglow";
-import { SEC_DB_FOLDER, SEC_DB_NAME, SEC_DB_TYPE } from "../../config/tokens";
 import { ENTITY_HISTORY_REPOSITORY_TOKEN } from "../../storage/entity/EntityHistorySchema";
-import { ENTITY_REPOSITORY_TOKEN } from "../../storage/entity/EntitySchema";
+import {
+  ENTITY_REPOSITORY_TOKEN,
+  type EntityRepositoryStorage,
+} from "../../storage/entity/EntitySchema";
 import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
 import { PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedSubmissionsSchema";
 import { getDb } from "../../util/db";
 import { getPgPool } from "../../util/pg";
+import { resolveSqlBackend } from "../../util/sqlBackend";
 import {
   BLANK_CHECK_NAME_EXCLUSIONS,
   BLANK_CHECK_NAME_PATTERNS,
@@ -23,25 +26,17 @@ import {
 } from "./classifySpacCandidate";
 
 /**
- * Mirrors `feedFilings.activeBackend`: the SQLite fast path is only safe when
- * the full production config is present, since `getDb()` dereferences both
- * `SEC_DB_FOLDER` and `SEC_DB_NAME` and throws for any other `SEC_DB_TYPE`.
- * Tests that register in-memory repositories fall through to the repository
- * scan.
+ * The registered entity repo, when there is one. Handed to `resolveSqlBackend`
+ * so a non-durable (in-memory) binding forces the repository scan even under a
+ * `SEC_DB_TYPE` that would otherwise select a raw-SQL path — the fast path
+ * would read a real database the caller never populated and report no
+ * candidates. Also the destination of that scan, so it is resolved once per
+ * call.
  */
-function activeBackend(): "sqlite" | "postgres" | "repository" {
-  const dbType = globalServiceRegistry.has(SEC_DB_TYPE)
-    ? globalServiceRegistry.get(SEC_DB_TYPE)
-    : null;
-  if (
-    dbType === "sqlite" &&
-    globalServiceRegistry.has(SEC_DB_FOLDER) &&
-    globalServiceRegistry.has(SEC_DB_NAME)
-  ) {
-    return "sqlite";
-  }
-  if (dbType === "postgres") return "postgres";
-  return "repository";
+function entityRepoIfRegistered(): EntityRepositoryStorage | undefined {
+  return globalServiceRegistry.has(ENTITY_REPOSITORY_TOKEN)
+    ? globalServiceRegistry.get(ENTITY_REPOSITORY_TOKEN)
+    : undefined;
 }
 
 export interface ScanOptions {
@@ -172,7 +167,10 @@ function rowToFacts(row: Record<string, unknown>): SpacCandidateFacts {
  * `filings(form, cik)` index.
  */
 export async function scanSpacCandidates(options: ScanOptions = {}): Promise<SpacCandidateFacts[]> {
-  const backend = activeBackend();
+  const entityRepo = entityRepoIfRegistered();
+  // `access: "read"` — a scan commits nothing, so it keeps its fast path under
+  // `--dry-run` rather than streaming every entity through the repository.
+  const backend = resolveSqlBackend("read", entityRepo);
 
   if (backend === "postgres") {
     const { sql, params } = buildScanSql(
@@ -196,16 +194,23 @@ export async function scanSpacCandidates(options: ScanOptions = {}): Promise<Spa
     return rows.map(rowToFacts);
   }
 
-  return scanRepository(options);
+  return scanRepository(options, entityRepo);
 }
 
 /**
  * Repository fallback (tests / in-memory backend): stream entities and resolve
  * each candidate through the repositories. Only ever runs on small datasets —
  * the production paths above push the whole scan into SQL.
+ *
+ * Also the JS twin that `spacCandidateScan.sqlite.test.ts` compares
+ * {@link buildScanSql} against: the two must agree row for row on the same
+ * seeded data, which is what keeps the hand-written SQL honest.
  */
-async function scanRepository(options: ScanOptions): Promise<SpacCandidateFacts[]> {
-  const entityRepo = globalServiceRegistry.get(ENTITY_REPOSITORY_TOKEN);
+export async function scanRepository(
+  options: ScanOptions,
+  repo?: EntityRepositoryStorage
+): Promise<SpacCandidateFacts[]> {
+  const entityRepo = repo ?? globalServiceRegistry.get(ENTITY_REPOSITORY_TOKEN);
   const historyRepo = globalServiceRegistry.get(ENTITY_HISTORY_REPOSITORY_TOKEN);
   const filingRepo = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
   const processedRepo = globalServiceRegistry.get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN);

--- a/src/task/submissions/BackfillNameHistoryTask.ts
+++ b/src/task/submissions/BackfillNameHistoryTask.ts
@@ -14,16 +14,14 @@ import {
   ENTITY_HISTORY_REPOSITORY_TOKEN,
   type EntityHistory,
 } from "../../storage/entity/EntityHistorySchema";
-import { buildNameHistoryRows } from "./nameHistoryRows";
+import { buildNameHistoryRows, NAME_HISTORY_CHANGE_SOURCE } from "./nameHistoryRows";
 
 const CIK_FILE_PATTERN = /^CIK(\d+)\.json$/;
 
 /** Rows buffered before a bulk write. Bounds memory across ~1M source files. */
 const WRITE_BATCH = 5_000;
 
-export type BackfillNameHistoryTaskInput = {
-  readonly force?: boolean;
-};
+export type BackfillNameHistoryTaskInput = Record<string, never>;
 
 export type BackfillNameHistoryTaskOutput = {
   readonly success: boolean;
@@ -40,6 +38,17 @@ export type BackfillNameHistoryTaskOutput = {
  * rows, no network access required. Both paths share
  * {@link buildNameHistoryRows}, and the write is an upsert on
  * `(cik, valid_from)`, so re-running either is safe.
+ *
+ * Like the ingest writer, this reconciles: rows written under
+ * {@link NAME_HISTORY_CHANGE_SOURCE} that the current `formerNames` no longer
+ * produces are deleted, so a revised timeline cannot leave a second row with
+ * `valid_to: null`. That reconcile is what a `force` flag would have been for,
+ * so the task takes no options — every run rebuilds.
+ *
+ * The delete runs per renamed CIK inside the file loop while the writes stay
+ * batched. That is one extra point query per *renamed* CIK — a small minority
+ * of the ~1M files — against a loop that already pays a `readFile` plus a
+ * `JSON.parse` for every one of them, so it is not the pass's cost centre.
  */
 export class BackfillNameHistoryTask extends Task<
   BackfillNameHistoryTaskInput,
@@ -51,7 +60,7 @@ export class BackfillNameHistoryTask extends Task<
   static readonly cacheable = false;
 
   public static inputSchema() {
-    return Type.Object({ force: Type.Optional(Type.Boolean()) });
+    return Type.Object({});
   }
 
   public static outputSchema() {
@@ -109,8 +118,21 @@ export class BackfillNameHistoryTask extends Task<
         continue;
       }
 
-      const rows = buildNameHistoryRows(parseInt(match[1], 10), submission);
+      const cik = parseInt(match[1], 10);
+      const rows = buildNameHistoryRows(cik, submission);
       if (rows.length === 0) continue;
+
+      // Reconcile this CIK before buffering its rebuilt rows: drop any row a
+      // previous pass wrote that the current `formerNames` no longer produces.
+      // Scoped to this module's change source — `entities_history` is shared
+      // with `EntityTemporalRepo.saveEntityWithHistory`, whose rows must
+      // survive.
+      const keep = new Set(rows.map((r) => r.valid_from));
+      for (const existing of (await repo.query({ cik })) ?? []) {
+        if (existing.change_source !== NAME_HISTORY_CHANGE_SOURCE) continue;
+        if (keep.has(existing.valid_from)) continue;
+        await repo.delete({ cik, valid_from: existing.valid_from });
+      }
 
       ciksWithRenames++;
       pending.push(...rows);

--- a/src/task/submissions/StoreSubmissionNameHistoryTask.test.ts
+++ b/src/task/submissions/StoreSubmissionNameHistoryTask.test.ts
@@ -71,4 +71,86 @@ describe("StoreSubmissionNameHistoryTask", () => {
 
     expect((await history(1277021)) ?? []).toHaveLength(2);
   });
+
+  it("a later rename that does not chain does not leave a second current row", async () => {
+    // CIK 1820372's real two-ingest sequence: the second ingest adds a rename,
+    // which moves where the open interval starts. Without a reconcile the row
+    // written at 2020-08-10 by ingest A stays behind, still `valid_to: null`.
+    const task = new StoreSubmissionNameHistoryTask();
+    await task.execute(
+      {
+        submission: {
+          cik: 1820372,
+          name: "FAIRWOOD SUSTAINABILITY, INC.",
+          sic: "",
+          formerNames: [
+            {
+              name: "JW Sustainable Solutions, Inc.",
+              from: "2020-08-07T00:00:00.000Z",
+              to: "2020-08-10T00:00:00.000Z",
+            },
+          ],
+        },
+      } as never,
+      ctx
+    );
+    await task.execute(
+      {
+        submission: {
+          cik: 1820372,
+          name: "FAIRWOOD SUSTAINABILITY LLC",
+          sic: "",
+          formerNames: [
+            {
+              name: "JW Sustainable Solutions, Inc.",
+              from: "2020-08-07T00:00:00.000Z",
+              to: "2020-08-10T00:00:00.000Z",
+            },
+            {
+              name: "FAIRWOOD SUSTAINABILITY, INC.",
+              from: "2020-08-17T00:00:00.000Z",
+              to: "2020-08-20T00:00:00.000Z",
+            },
+          ],
+        },
+      } as never,
+      ctx
+    );
+
+    const rows = (await history(1820372)) ?? [];
+    expect(rows.filter((r) => r.valid_to === null)).toHaveLength(1);
+    expect(rows.map((r) => r.valid_from)).not.toContain("2020-08-10T00:00:00.000Z");
+  });
+
+  it("leaves rows written by another change source alone", async () => {
+    // `entities_history` is shared: EntityTemporalRepo.saveEntityWithHistory
+    // writes under its caller's own change_source. An unscoped reconcile would
+    // delete those rows because they are not in the rebuilt set.
+    const repo = globalServiceRegistry.get(ENTITY_HISTORY_REPOSITORY_TOKEN);
+    await repo.put({
+      cik: 1277021,
+      valid_from: "2019-01-01T00:00:00.000Z",
+      valid_to: null,
+      name: "SOMETHING ELSE",
+      type: null,
+      sic: null,
+      ein: null,
+      description: null,
+      website: null,
+      investor_website: null,
+      category: null,
+      fiscal_year: null,
+      state_incorporation: null,
+      state_incorporation_desc: null,
+      change_source: "ENTITY_UPDATE",
+      change_date: "2019-01-01T00:00:00.000Z",
+    });
+
+    await new StoreSubmissionNameHistoryTask().execute({ submission: renamed } as never, ctx);
+
+    const rows = (await history(1277021)) ?? [];
+    const survivor = rows.find((r) => r.change_source === "ENTITY_UPDATE");
+    expect(survivor).toBeDefined();
+    expect(survivor?.name).toBe("SOMETHING ELSE");
+  });
 });

--- a/src/task/submissions/StoreSubmissionNameHistoryTask.ts
+++ b/src/task/submissions/StoreSubmissionNameHistoryTask.ts
@@ -14,7 +14,7 @@ import {
 } from "workglow";
 import { ENTITY_HISTORY_REPOSITORY_TOKEN } from "../../storage/entity/EntityHistorySchema";
 import { FetchSubmissionsOutput, FetchSubmissionsTask } from "./FetchSubmissionsTask";
-import { buildNameHistoryRows } from "./nameHistoryRows";
+import { buildNameHistoryRows, writeNameHistoryRows } from "./nameHistoryRows";
 
 export type StoreSubmissionNameHistoryTaskInput = FetchSubmissionsOutput;
 
@@ -70,7 +70,7 @@ export class StoreSubmissionNameHistoryTask extends Task<
     if (rows.length === 0) return { success: true };
 
     const repo = globalServiceRegistry.get(ENTITY_HISTORY_REPOSITORY_TOKEN);
-    await repo.putBulk(rows);
+    await writeNameHistoryRows(repo, submission.cik, rows);
 
     return { success: true };
   }

--- a/src/task/submissions/nameHistoryRows.test.ts
+++ b/src/task/submissions/nameHistoryRows.test.ts
@@ -103,13 +103,75 @@ describe("buildNameHistoryRows", () => {
     expect(rows.map((r) => r.name)).toEqual(["Good", "Now Corp"]);
   });
 
-  it("keeps a still-open former name (blank `to`) rather than dropping it", () => {
+  it("promotes the current name over a trailing former name EDGAR left open-ended", () => {
+    // EDGAR sometimes leaves the last rename's `to` blank. `submission.name` is
+    // the authoritative current name, so it takes the open interval; the former
+    // name closes at the same instant it opened, which the duplicate-valid_from
+    // collapse then resolves to the single current row.
     const rows = buildNameHistoryRows(1, {
       name: "Now Corp",
       formerNames: [{ name: "Then Corp", from: "2020-01-01T00:00:00.000Z", to: "" }],
     });
     expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      name: "Now Corp",
+      valid_from: "2020-01-01T00:00:00.000Z",
+      valid_to: null,
+    });
+  });
+
+  it("leaves a trailing former name open when there is no current name to promote", () => {
+    const rows = buildNameHistoryRows(1, {
+      formerNames: [{ name: "Then Corp", from: "2020-01-01T00:00:00.000Z", to: "" }],
+    });
+    expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ name: "Then Corp", valid_to: null });
+  });
+
+  it("emits exactly one open interval", () => {
+    const real = buildNameHistoryRows(1820372, {
+      name: "FAIRWOOD SUSTAINABILITY LLC",
+      sic: "",
+      formerNames: [
+        {
+          name: "JW Sustainable Solutions, Inc.",
+          from: "2020-08-07T00:00:00.000Z",
+          to: "2020-08-10T00:00:00.000Z",
+        },
+        {
+          name: "FAIRWOOD SUSTAINABILITY, INC.",
+          from: "2020-08-17T00:00:00.000Z",
+          to: "2020-08-20T00:00:00.000Z",
+        },
+      ],
+    });
+    expect(real.filter((r) => r.valid_to === null)).toHaveLength(1);
+
+    // A closed interval followed by a blank-`to` one: the blank former row and
+    // the current-name row would both be open.
+    const mixed = buildNameHistoryRows(1, {
+      name: "Now Corp",
+      formerNames: [
+        { name: "First", from: "2020-01-01T00:00:00.000Z", to: "2020-06-01T00:00:00.000Z" },
+        { name: "Second", from: "2020-07-01T00:00:00.000Z", to: "" },
+      ],
+    });
+    expect(mixed.filter((r) => r.valid_to === null)).toHaveLength(1);
+  });
+
+  it("closes a blank-`to` former name at the next rename", () => {
+    const rows = buildNameHistoryRows(1, {
+      name: "Now Corp",
+      formerNames: [
+        { name: "First", from: "2020-01-01T00:00:00.000Z", to: "" },
+        { name: "Second", from: "2020-06-01T00:00:00.000Z", to: "2020-09-01T00:00:00.000Z" },
+      ],
+    });
+    const first = rows.find((r) => r.name === "First");
+    expect(first?.valid_to).toBe("2020-06-01T00:00:00.000Z");
+    const open = rows.filter((r) => r.valid_to === null);
+    expect(open).toHaveLength(1);
+    expect(open[0]).toMatchObject({ name: "Now Corp", valid_from: "2020-09-01T00:00:00.000Z" });
   });
 
   it("collapses duplicate valid_from values so a bulk write cannot violate the PK", () => {

--- a/src/task/submissions/nameHistoryRows.ts
+++ b/src/task/submissions/nameHistoryRows.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { EntityHistory } from "../../storage/entity/EntityHistorySchema";
+import type {
+  EntityHistory,
+  EntityHistoryRepositoryStorage,
+} from "../../storage/entity/EntityHistorySchema";
 
 /** Marks rows derived from the submissions feed's `formerNames` array. */
 export const NAME_HISTORY_CHANGE_SOURCE = "SUBMISSIONS_FORMER_NAMES";
@@ -70,33 +73,58 @@ export function buildNameHistoryRows(
     state_incorporation_desc: null,
   } as const;
 
-  const rows: EntityHistory[] = [];
-  let latestTo: string | undefined;
+  // Sorted, because the close-at-the-next-rename rule below reads its
+  // successor and EDGAR does not guarantee `formerNames` order.
+  const formers = formerNames
+    .map((former) => ({
+      validFrom: isoOrUndefined(former.from),
+      validTo: isoOrUndefined(former.to) ?? null,
+      name: former.name,
+    }))
+    .filter(
+      (f): f is { validFrom: string; validTo: string | null; name: string } =>
+        f.validFrom !== undefined && typeof f.name === "string"
+    )
+    .sort((a, b) => a.validFrom.localeCompare(b.validFrom));
 
-  for (const former of formerNames) {
-    const validFrom = isoOrUndefined(former.from);
-    if (validFrom === undefined || typeof former.name !== "string") continue;
-    const validTo = isoOrUndefined(former.to) ?? null;
+  if (formers.length === 0) return [];
+
+  const currentName = typeof submission.name === "string" ? submission.name : null;
+
+  const rows: EntityHistory[] = [];
+  let latestEnd: string | undefined;
+
+  for (const [index, former] of formers.entries()) {
+    // EDGAR sometimes leaves a rename's `to` blank. The interval still ends —
+    // at the next rename's `from`, which is the only date EDGAR actually gave
+    // us for it. A trailing blank `to` has no successor, so it stays open only
+    // when there is no current name to promote over it; otherwise
+    // `submission.name` is the authoritative name for the present and takes the
+    // open interval. Closing it at `change_date` instead would fabricate a date
+    // EDGAR never supplied, which this module never does.
+    const validTo = former.validTo ?? formers[index + 1]?.validFrom ?? null;
     rows.push({
       cik,
-      valid_from: validFrom,
-      valid_to: validTo,
+      valid_from: former.validFrom,
+      valid_to: currentName === null ? validTo : (validTo ?? former.validFrom),
       name: former.name,
       sic: null,
       ...unknownAtTime,
       change_source: NAME_HISTORY_CHANGE_SOURCE,
       change_date: changeDate,
     });
-    if (validTo !== null && (latestTo === undefined || validTo > latestTo)) latestTo = validTo;
+    // The open interval starts after every former interval — so `valid_to` when
+    // there is one, and the interval's own `valid_from` for a trailing blank
+    // `to`. Taking only `max(valid_to)` left the blank-`to` row open alongside
+    // the current-name row, i.e. two current names for one CIK.
+    const end = validTo ?? former.validFrom;
+    if (latestEnd === undefined || end > latestEnd) latestEnd = end;
   }
 
-  if (rows.length === 0) return [];
-
-  const currentName = typeof submission.name === "string" ? submission.name : null;
-  if (currentName !== null && latestTo !== undefined) {
+  if (currentName !== null && latestEnd !== undefined) {
     rows.push({
       cik,
-      valid_from: latestTo,
+      valid_from: latestEnd,
       valid_to: null,
       name: currentName,
       sic: sicOrNull(submission.sic),
@@ -111,4 +139,37 @@ export function buildNameHistoryRows(
   const byValidFrom = new Map<string, EntityHistory>();
   for (const row of rows) byValidFrom.set(row.valid_from, row);
   return [...byValidFrom.values()];
+}
+
+/**
+ * Writes one CIK's name-history rows, reconciling away rows this module wrote
+ * on a previous ingest that the current `formerNames` no longer produces.
+ *
+ * A plain `putBulk` upserts on `(cik, valid_from)` and so can only ever add. But
+ * EDGAR revises `formerNames` — a later rename shifts where the open interval
+ * starts, and the row that used to hold it stays behind still carrying
+ * `valid_to: null`, leaving a CIK with two "current" names. Deleting the rows
+ * that fell out of the rebuild is what keeps the timeline single-valued.
+ *
+ * Scoped to {@link NAME_HISTORY_CHANGE_SOURCE}: `entities_history` is shared
+ * with `EntityTemporalRepo.saveEntityWithHistory`, which writes under its
+ * caller's own `change_source`. An unscoped reconcile would silently delete
+ * those rows.
+ */
+export async function writeNameHistoryRows(
+  repo: EntityHistoryRepositoryStorage,
+  cik: number,
+  rows: readonly EntityHistory[]
+): Promise<void> {
+  if (rows.length === 0) return;
+
+  const keep = new Set(rows.map((r) => r.valid_from));
+  const existing = (await repo.query({ cik })) ?? [];
+  for (const row of existing) {
+    if (row.change_source !== NAME_HISTORY_CHANGE_SOURCE) continue;
+    if (keep.has(row.valid_from)) continue;
+    await repo.delete({ cik, valid_from: row.valid_from });
+  }
+
+  await repo.putBulk(rows as EntityHistory[]);
 }


### PR DESCRIPTION
## main was red — and is now green upstream, so this PR does not fix it

The originally-planned first commit here was the `resetAllDatabases` drift guard: `src/config/resetAllDatabases.test.ts` diffs the tokens registered in `DefaultDI` against those truncated in `resetAllDatabases.ts` and reported `missing: ["SPAC_CANDIDATE_REPOSITORY_TOKEN"]` (81 registered, 80 reset).

**That landed upstream while this branch was in flight**, as `b5cf927 fix(db): truncate the spac_candidate repo in the in-memory reset` (merged in #226). I verified both halves of the fix are present, not just the one that satisfies the regex-over-source guard:

- `src/config/resetAllDatabases.ts:108` — `import { SPAC_CANDIDATE_REPOSITORY_TOKEN } from "../storage/spac/SpacCandidateSchema";`
- `src/config/resetAllDatabases.ts:432` — `await globalServiceRegistry.get(SPAC_CANDIDATE_REPOSITORY_TOKEN).deleteAll();`

The `deleteAll()` call is the one that matters — without it, `db reset` on a non-SQL backend leaves `spac_candidate` populated, the next `update spacs` takes the incremental path against wiped tables, and `prune()` never removes the stale rows (`processed.get(cik)` is undefined, so they are not pruned). Both are there.

Before (on the pre-merge base) / after (this branch, rebased on `origin/main` `5374741`):

```
$ bunx vitest run src/config/resetAllDatabases.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

**So Step 1 is dropped from this PR.** Nothing here re-implements it.

---

## HIGH — the `addresses` rebuild could silently lose every row (`60c496d`)

This is the most serious thing in the PR. `AddressRegionNullableMigration.ts` merged into main with #226; a review of that PR found the defect but it was never fixed before merge, so it is now a main-branch bug.

The SQLite rebuild that relaxes `addresses.state_or_country` from NOT NULL was RENAME → `setupDatabase()` → `INSERT…SELECT` → DROP, with every `db.exec` autocommitted. **Three** silent-loss windows, not one:

1. **The copy fails** (disk full — the copy transiently doubles the table; SIGINT/SIGTERM; OOM; a unique-index violation). State left behind: an **empty** `addresses` at the new schema plus a stranded `addresses__legacy_region`. Re-running `sec db setup` sees `region.notnull === 0`, returns at the idempotency guard and **reports SUCCESS**. Every `address_hash_id` in `addresses_entity_junction`, `canonical_person_address` and `canonical_company_address` now dangles, and nothing reports it.
2. **A crash between the rename and `setupDatabase()`** is unrecoverable by a *different* early return: `addresses` does not exist at all, so `if (!tableExists) return` fires and the caller's own `setupDatabase()` creates an empty table over the top.
3. **`DROP TABLE IF EXISTS addresses__legacy_region`** ran before any backup existed on the current run, so it could destroy the only surviving copy.

### Fix

The whole rebuild now runs inside one transaction. SQLite DDL *is* transactional in this driver (`Sqlite.Database` → `bun:sqlite` on Bun, `better-sqlite3` on Node; both pass BEGIN/COMMIT straight through), so `CREATE TABLE`, `CREATE INDEX`, `ALTER TABLE … RENAME` and `DROP TABLE` all roll back.

- **`BEGIN IMMEDIATE`**, not plain `BEGIN` — a deferred transaction takes a read lock and fails the write upgrade with `SQLITE_BUSY` immediately, which `busy_timeout` does not cover.
- **Row-count verification inside the transaction**: `SELECT COUNT(*)` on both tables, throw if they differ, so a partial copy rolls back rather than commits.
- **Resume branch**: probe for `addresses__legacy_region` **first**. If it is present, go straight to the copy phase (creating `addresses` at the current schema if missing or still legacy-shaped) and log `resuming an interrupted addresses rebuild…`. The legacy table is **never** dropped outside the transaction, because on that path it is the only surviving copy.
- **`PRAGMA foreign_keys = OFF` and `PRAGMA legacy_alter_table = ON`** set outside the transaction (both are no-ops inside one) and restored in a `finally`. The second is not cosmetic: on SQLite ≥ 3.25 `ALTER TABLE … RENAME TO` rewrites references inside views, so an operator's (or a downstream superset's) view over `addresses` would be silently repointed at the legacy table and then broken when it is dropped.
- On error: `ROLLBACK` (swallowing its own failure so it cannot mask the cause) and rethrow wrapped with context naming the table and stating no rows were lost.

Calling `setupDatabase()` *inside* the transaction is safe **as currently wired**: `createStorage` passes no `tabularMigrations`, so it is only `CREATE TABLE IF NOT EXISTS` + `createIndexes()` — no BEGIN, no mutex. I verified this against the installed `@workglow/sqlite@0.3.37` source. A comment at both call sites notes that threading `tabularMigrations` through `createStorage` later would make the nested BEGIN throw.

### Tests

Three cases added to the existing `AddressRegionNullableMigration.test.ts` (keeping its three existing cases and its bespoke tmpdir harness — it must control table creation *before* `setupAllDatabases()`, so it cannot move to `withSqliteDb`). All three fail on the pre-fix implementation with total data loss:

```
 ❯ src/storage/address/AddressRegionNullableMigration.test.ts (6 tests | 3 failed)
     × an interrupted copy leaves every row recoverable
     × resumes a rebuild stranded by an older build
     × refuses to destroy a stranded legacy table when the live table is unusable
AssertionError: expected true to be false          // column already relaxed, table empty
AssertionError: expected [] to deeply equal [ 'hash-1', 'hash-2' ]
AssertionError: expected [] to deeply equal [ 'hash-1', 'hash-2' ]
```

and pass after:

```
$ bunx vitest run src/storage/address/AddressRegionNullableMigration.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

---

## Step 2 — classifier branch order (`f7f8dae`)

`reg_while_spac_named` dated the earliest registration against `spac_name_ended` whenever *any* blank-check-named interval had closed — even for a company still carrying the name today. An earlier cosmetic variant (`Corp.` → `Corp`) or a pre-IPO sponsor rebrand therefore read as "registered after shedding the blank-check name", the Form 10 shell shape, and demoted a live SPAC from `high` to `low`.

The two branches are swapped so the **current** name is consulted first. `SpacCandidateFacts.spac_name_ended`'s JSDoc now says it is consulted only when the current name no longer matches.

Fixed in the classifier, **not** the scan: that would need identical implementations in both `buildScanSql` and `scanRepository`, and `spac_name_ended` is never persisted, so the classifier fix is complete.

Pre-fix, the new tests fail exactly as predicted:

```
     × keeps a still-blank-check-named SPAC high when an EARLIER interval closed before the registration
AssertionError: expected { cik: 9001, …(10) } to match object { confidence: 'high', …(2) }
-   "confidence": "high",
+   "confidence": "low",
```

The companion case pins that the swap does not promote a weak-class name past `medium`. (Its `renamed_from` is `"Ajax Capital Investment Corp"` rather than `"Ajax Capital Acquisitions Corp"`: the latter matches `%acquisition%` and is strong name evidence on its own, which would have made `high` correct and the assertion meaningless.)

The four named existing cases still pass — Form 10 shell, `AMERICOM USA INC`, Renovacor, Melar:

```
$ bunx vitest run src/task/spac/
 Test Files  4 passed (4)
      Tests  31 passed (31)
```

## Step 3 — backend dispatch (`30a5a36`)

`spacCandidateScan.activeBackend()` decided the backend from the `SEC_DB_*` tokens alone. `EnvToDI` defaults `SEC_DB_TYPE` to `"sqlite"` and `.env.test` supplies `SEC_DB_FOLDER`/`SEC_DB_NAME`, so a caller holding in-memory repositories satisfied every check and took the raw-SQL path against a database it had never populated.

Replaced with `resolveSqlBackend("read", entityRepo)` — the repo-aware dispatch used elsewhere — plus an `entityRepoIfRegistered()` mirroring `feedFilings.filingRepoIfRegistered()`. The entity repo is resolved once and threaded into `scanRepository` rather than resolved twice. `access: "read"` is kept and commented: a scan commits nothing and must keep its fast path under `--dry-run`.

The new test reproduces the bug precisely:

```
 FAIL  src/task/spac/spacCandidateScan.test.ts > uses the in-memory repositories even when SEC_DB_* names a SQLite database
SqliteError: no such table: entities
 ❯ scanSpacCandidates src/task/spac/spacCandidateScan.ts:194:8
```

## Step 4 — SQLite parity test for `buildScanSql` (`23abf64`)

`scanRepository` is now exported (same name), with its JSDoc extended to say it is also the JS twin the parity test compares `buildScanSql` against.

New `spacCandidateScan.sqlite.test.ts` on a real SQLite database via `withSqliteDb`, seeded through repositories. Seven fixtures, each pinning a distinct SQL fragment: CIK 1 (sicMatch + entityNameMatch + both registration subqueries, with a 10-K that must be excluded — `first_reg_form === "S-1"` is the direct catch for the binding-order hazard), CIK 2 (historyNameMatch/renamedFrom/spacNameEnded), CIK 3 (`max(valid_to)` skipping an open row, and an end-to-end regression for step 2), CIK 4 (the five `NOT LIKE` exclusions), CIK 5 (negative control), CIK 6 (`MODERN_SPAC_NAME_PATTERNS`), CIK 7 (the `--since` variant).

Four assertions: full-scan parity with the twin, `--since` parity with CIK 7 absent from both, explicit spot-assertions written against the fixtures rather than the other implementation (so a bug **shared** by both still fails), and grading through `classifySpacCandidate`. A comment notes `toIsoOrNull`'s Postgres `Date` branch is not covered here — on SQLite `valid_to` is the stored TEXT, identical to the twin.

**No real SQL defect surfaced** — the two implementations already agreed on every fixture. To confirm the test is not vacuously passing through the repository fallback, I mutated `buildScanSql` (dropped the `valid_to IS NOT NULL` guard) and all four tests failed:

```
 ❯ src/task/spac/spacCandidateScan.sqlite.test.ts (4 tests | 4 failed)
     × agrees with the repository twin on a full scan
     × agrees with the repository twin on an incremental --since scan
     × resolves each fragment correctly, independently of the twin
     × grades the scanned facts into the expected tiers
```

## Step 5 — name history (`111211d`)

Two defects, one work item.

**5a.** `buildNameHistoryRows` opened the current-name interval at `max(valid_to)`, and a former name EDGAR left with a blank `to` was kept with `valid_to: null`. Both rows were then open — a CIK with two "current" names. Former rows are now sorted by `valid_from`, each blank `to` closes at the next rename's `from`, and the open interval starts at `max(valid_to ?? valid_from)` across all former rows; the existing `byValidFrom` collapse resolves the trailing-blank case. Guard: when `currentName === null`, the trailing former stays open.

> ### ⚠️ Semantic judgement call — the one in this PR
>
> For a **trailing** former name EDGAR left open-ended, this promotes `submission.name` (the authoritative current name) over it. The alternative was closing the former interval at `change_date`. The module's stated convention is **never to fabricate a date EDGAR did not give**, and `change_date` is our own processing timestamp, not a rename date — so promoting the name EDGAR does give us respects that convention while closing at `change_date` would not. The rationale is recorded in the JSDoc.
>
> The consequence is visible in the test rename: the existing case `"keeps a still-open former name (blank `to`) rather than dropping it"` **pinned the bug**, and is now `"promotes the current name over a trailing former name EDGAR left open-ended"`. A new companion case pins that the former name *does* stay open when there is no current name to promote.

**5b.** `putBulk` upserts on `(cik, valid_from)` and can only ever add. When a later ingest moved where the open interval starts, the row that used to hold it stayed behind, still `valid_to: null`. Both writers now go through a shared `writeNameHistoryRows(repo, cik, rows)`: query by cik, build `keep` from the rebuilt rows' `valid_from`, delete every existing row where `change_source === NAME_HISTORY_CHANGE_SOURCE && !keep.has(valid_from)`, then `putBulk`.

`ITabularStorage` exposes `deleteSearch`, but with no `NOT IN` operator it cannot express this predicate, so the per-row `delete()` loop stands — a handful of rows per CIK.

The reconcile is **scoped to `SUBMISSIONS_FORMER_NAMES`**, and there is a test for that: `EntityTemporalRepo.saveEntityWithHistory` writes to the same table under a caller-supplied `change_source`, so an unscoped reconcile would silently delete those rows. `"leaves rows written by another change source alone"` pre-seeds an `ENTITY_UPDATE` row with `valid_to: null` and asserts it survives an ingest.

`BackfillNameHistoryTask` keeps its 5,000-row `putBulk` batching; the query+delete runs per renamed CIK inside the file loop. The JSDoc notes this adds one point query per *renamed* CIK — a small minority of ~1M files — against a loop already paying a `readFile` + `JSON.parse` for every one of them.

Pre-fix, the 5b test shows exactly the reported symptom:

```
     × a later rename that does not chain does not leave a second current row
AssertionError: expected [ { cik: 1820372, …(15) }, …(1) ] to have a length of 1 but got 2
```

**5c. Public type change on an exported task:** `force` is removed from `BackfillNameHistoryTaskInput` and from `inputSchema()`. It was dead (never read), and the reconcile makes every run behave as `force` would. The only call site (`src/cli/groups/bootstrap.ts:162`) passes no options, so no CLI change was needed — but the input type is exported from the package barrel, so this is a breaking type change for any downstream consumer constructing it with `{ force: … }`.

## Step 6 — docs (`9da6912`)

`classifySpacCandidate`'s JSDoc is the accurate source; `CLAUDE.md` and `SpacCandidateSchema.ts` described an older, narrower rule (`high` written as name-only, omitting 6770-plus-registration; `low` omitting the 6770-with-no-registration case entirely). Both now carry the **same wording** so they cannot drift again, plus "The recall/precision tables below were measured on this rule." after the tables in CLAUDE.md.

Also reworded `PersonObservationTitleSchema`'s `PersonObservationTitleTable` JSDoc: the raw-SQL bulk reader it referenced was deleted in `0f2b5cd`. It now names the surviving consumers — the DI registration and `PersonObservationTitleRepo`'s integrity-check error message.

## Step 7 — CLI hardening + column widths (`42c4169`)

**7a.** `sec spac candidates` took `--limit`/`--offset` through a bare `Number()` (so `--limit abc` became NaN and rendered an empty table) and silently fell back to a table for any unrecognised `--format` (so `--format jsonl` looked like the flag being ignored). Both now use commander parsers: the existing `parseIntOption`, and a new `parseOutputFormat` in `src/cli/GlobalOptions.ts` that throws `InvalidArgumentError` for anything outside `table|csv|json`. `GlobalOptions.test.ts` gains accept/normalize/reject cases for it.

`ListSpacCandidatesTask.inputSchema()` declared `limit` with `minimum: 1` while `parseIntOption` accepts `0`. **Decision: relaxed the schema to `minimum: 0`** — `--limit 0` asks for the total with no rows, which `slice` already does, and rejecting a value the option parser just accepted would surface as a confusing validation failure. Noted in the code comment too.

Not unified with `validateFormat` in `src/cli/groups/query.ts` — 12 call sites, different error contracts, no gain here.

**7b.** `spac_candidate.name` and `signal_renamed_from` go `maxLength: 200` → `512`, matching `CompanyObservationSchema`/`CanonicalCompanySchema`. `entities.name` is unbounded, so on Postgres a long conformed name does not truncate — it aborts the whole 1000-row `putBulk` the scan writes in.

> **Postgres note — no manual intervention needed, contrary to the usual caveat.** I checked the setup path rather than assuming: `setupAllDatabases()` calls `alignPostgresColumnTypes()` (`src/config/setupAllDatabases.ts:235`) *after* the extension loop, and it emits an `ALTER … TYPE varchar(n)` for any column narrower than the declared schema (`kind: "widen"`). `spac_candidate` is registered through `createStorage` (`src/config/DefaultDI.ts:693`), so it is in the table registry and gets widened automatically on the next `sec db setup`. Widening a `varchar` is binary-coercible, so the heap is not rewritten. **No `DROP TABLE spac_candidate` is required** for a Postgres database already created from this branch's earlier shape. SQLite does not enforce `varchar` lengths at all, so that path is unaffected either way.

---

## Verification

Environment note: `bun run link-workglow` fails in this container (`@workglow/cli@link:@workglow/cli failed to resolve` — no local `libs` checkout to link against). It is not needed: `bun install` resolves the published `workglow@0.3.37` / `@workglow/cli@0.3.37` from npm, and the suite runs against those. Test runner is `bunx vitest run` (this repo has no `scripts/test.ts`).

```
$ bunx vitest run src/config/resetAllDatabases.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)

$ bunx vitest run src/task/spac/ src/util/sqlBackend.test.ts src/task/bootstrap/
 Test Files  7 passed | 1 skipped (8)
      Tests  55 passed | 18 skipped (73)

$ bunx vitest run src/task/submissions/ src/storage/entity/
 Test Files  4 passed (4)
      Tests  25 passed (25)

$ bunx vitest run src/cli/GlobalOptions.test.ts src/commands/
 Test Files  6 passed (6)
      Tests  50 passed (50)

$ bunx vitest run src/storage/address/
 Test Files  4 passed (4)
      Tests  72 passed (72)

$ bun run build-types
$ rm -f tsconfig.tsbuildinfo && tsc
(clean, exit 0)

$ bun run test
 Test Files  285 passed | 4 skipped (289)
      Tests  2125 passed | 32 skipped (2157)
   Duration  205.71s
```

## Not done

- **Step 1** — already fixed upstream in `b5cf927` (#226). Verified both the import and the `deleteAll()` call are present; nothing to add.

Everything else in the brief is implemented, one commit per step.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5jNNGBKsXNTBmsFwNoEkk

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5jNNGBKsXNTBmsFwNoEkk)_