### PR TITLE
fix(db): derive `db reset`'s rate-limiter table names from the limiter config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,7 +875,15 @@ sec exposes the general downstream seams embarc-data (and future features) build
   `db reset` drops only what sec owns: every table built through
   `createStorage` (recorded in `src/config/tableRegistry.ts`, supersets
   included), the `current_canonical_*` views, `_storage_migrations`, and the
-  Postgres rate-limiter tables. Every Postgres drop is schema-qualified to
+  Postgres rate-limiter tables. The rate-limiter names are **derived**, not
+  literals: `PostgresRateLimiterStorage` names its tables after its prefix
+  columns, so `setupSecFetchRateLimiter` and the reset both read one
+  configuration (`SecFetchRateLimiterOptions` /
+  `secFetchRateLimiterTableNames`, `src/task/fetch/secFetchRateLimiterConfig.ts`)
+  — sharding the fetch budget by a prefix column renames the tables on both
+  sides at once instead of silently orphaning them (the derivation is pinned
+  against the installed storage's own migration DDL by
+  `resetAllDatabases.test.ts`). Every Postgres drop is schema-qualified to
   `current_schema()` — an unqualified name resolves through the search_path and
   would reach a same-named table in the *next* schema on it. Tables it does not
   own are left in place and named in a warning. `--cascade` drops dependent

--- a/src/config/resetAllDatabases.test.ts
+++ b/src/config/resetAllDatabases.test.ts
@@ -6,6 +6,15 @@
 
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import type { Pool, RateLimiterStorageOptions } from "workglow";
+import { PostgresRateLimiterStorage } from "workglow";
+import { createSecFetchRateLimiterStorage } from "../task/fetch/SecJobQueue";
+import {
+  rateLimiterStorageTableNames,
+  SecFetchRateLimiterOptions,
+  secFetchRateLimiterTableNames,
+} from "../task/fetch/secFetchRateLimiterConfig";
+import { ownedTableNames } from "./resetAllDatabases";
 
 /**
  * Drift guard for `sec db reset --confirm`. The SQL backends drop the schema
@@ -30,5 +39,66 @@ describe("resetAllDatabases token coverage", () => {
 
     const missing = [...registered].filter((token) => !reset.has(token)).sort();
     expect(missing).toEqual([]);
+  });
+});
+
+/**
+ * Runs a rate-limiter storage's own migrations against a pool that records SQL
+ * instead of executing it, and returns the tables the DDL actually creates.
+ * That is the authority on what a reset has to drop — not a name written down
+ * on this side of the boundary.
+ */
+async function tablesCreatedBy(storage: PostgresRateLimiterStorage): Promise<string[]> {
+  const statements: string[] = [];
+  const recordingPool = {
+    query: async (sql: string) => {
+      statements.push(sql);
+      return { rows: [] };
+    },
+  } as unknown as Pool;
+  for (const migration of storage.getMigrations()) {
+    await migration.up(recordingPool);
+  }
+  return statements
+    .flatMap((sql) => [...sql.matchAll(/CREATE TABLE IF NOT EXISTS\s+([A-Za-z0-9_]+)/g)])
+    .map((match) => match[1]!)
+    .sort();
+}
+
+describe("rate-limiter table ownership", () => {
+  it("drops exactly the tables the configured rate-limiter storage creates", async () => {
+    const created = await tablesCreatedBy(createSecFetchRateLimiterStorage({} as Pool));
+
+    expect(created).toEqual([...secFetchRateLimiterTableNames()].sort());
+    expect(ownedTableNames()).toEqual(expect.arrayContaining(created));
+  });
+
+  it("tracks the table names when the fetch budget is sharded by prefix columns", async () => {
+    // The installed storage derives its table names from its prefix columns,
+    // so a sharded budget renames them. Both sides read one configuration, so
+    // this hypothetical config is what the reset would target as well.
+    const sharded: RateLimiterStorageOptions = {
+      prefixes: [
+        { name: "host", type: "uuid" },
+        { name: "queue", type: "number" },
+      ],
+      prefixValues: { host: "edgar", queue: 1 },
+    };
+    const created = await tablesCreatedBy(new PostgresRateLimiterStorage({} as Pool, sharded));
+
+    expect(created).toEqual([
+      "rate_limit_executions_host_queue",
+      "rate_limit_next_available_host_queue",
+    ]);
+    expect([...rateLimiterStorageTableNames(sharded)].sort()).toEqual(created);
+  });
+
+  it("derives the reset's rate-limiter names instead of hardcoding them", () => {
+    const source = readFileSync(new URL("./resetAllDatabases.ts", import.meta.url), "utf8");
+
+    expect(source).not.toMatch(/"rate_limit_/);
+    expect(rateLimiterStorageTableNames(SecFetchRateLimiterOptions)).toEqual(
+      secFetchRateLimiterTableNames()
+    );
   });
 });

--- a/src/config/resetAllDatabases.ts
+++ b/src/config/resetAllDatabases.ts
@@ -6,6 +6,7 @@
 
 import { globalServiceRegistry } from "workglow";
 import { isDryRun } from "../cli/isDryRun";
+import { secFetchRateLimiterTableNames } from "../task/fetch/secFetchRateLimiterConfig";
 import { getDb } from "../util/db";
 import { getPgPool } from "../util/pg";
 import { listDatabaseExtensionTokens, runDatabaseSetupHooks } from "./databaseExtensions";
@@ -127,15 +128,9 @@ export interface ResetAllDatabasesOptions {
  * so they are not in the table registry but are still ours to drop.
  *
  * `_storage_migrations` is workglow's tabular-migration ledger; leaving it
- * behind would make a recreated table look already-migrated. The two
- * `rate_limit_*` tables are created by `setupSecFetchRateLimiter()` on the
- * Postgres path.
+ * behind would make a recreated table look already-migrated.
  */
-const NON_REGISTRY_OWNED_TABLES: ReadonlyArray<string> = [
-  "_storage_migrations",
-  "rate_limit_executions",
-  "rate_limit_next_available",
-];
+const NON_REGISTRY_OWNED_TABLES: ReadonlyArray<string> = ["_storage_migrations"];
 
 /**
  * Drops the tables sec owns so `setupAllDatabases()` can recreate them at the
@@ -199,9 +194,22 @@ export async function resetAllDatabases(options: ResetAllDatabasesOptions = {}):
   await truncateAllRepositories();
 }
 
-/** Every table name this reset owns: the registry plus the few created outside it. */
-function ownedTableNames(): ReadonlyArray<string> {
-  return [...listRegisteredTables().map((t) => t.table), ...NON_REGISTRY_OWNED_TABLES];
+/**
+ * Every table name this reset owns: the registry plus the few created outside it.
+ *
+ * The rate-limiter tables are derived from the configuration
+ * `setupSecFetchRateLimiter()` builds its storage with, not named literally:
+ * `PostgresRateLimiterStorage` renames them when it is given prefix columns,
+ * and a reset that kept dropping the unprefixed names would silently leave the
+ * real ones — and their execution rows — behind, so a recreated database would
+ * inherit a rate-limit budget from before the reset.
+ */
+export function ownedTableNames(): ReadonlyArray<string> {
+  return [
+    ...listRegisteredTables().map((t) => t.table),
+    ...NON_REGISTRY_OWNED_TABLES,
+    ...secFetchRateLimiterTableNames(),
+  ];
 }
 
 /** The schema sec's tables live in, i.e. the one `CREATE TABLE` writes to. */

--- a/src/task/fetch/SecJobQueue.ts
+++ b/src/task/fetch/SecJobQueue.ts
@@ -15,6 +15,7 @@ import {
   type IRateLimiterStorage,
   JobQueueClient,
   JobQueueServer,
+  type Pool,
   PostgresRateLimiterStorage,
   RateLimiter,
   wrapQueueStorage,
@@ -24,6 +25,7 @@ import { SecFetchMaxPerSec, SecJobQueueName } from "../../config/Constants";
 import { SEC_DB_TYPE } from "../../config/tokens";
 import { getPgPool } from "../../util/pg";
 import { SecFetchJob } from "./SecFetchJob";
+import { SecFetchRateLimiterOptions } from "./secFetchRateLimiterConfig";
 import { setSecFetchLimiter } from "./secFetchThrottle";
 
 export interface SecJobQueueHandles {
@@ -40,13 +42,23 @@ function isPostgres(): boolean {
 }
 
 /**
+ * Builds the Postgres rate-limiter storage from {@link SecFetchRateLimiterOptions}.
+ *
+ * Every construction goes through here so the tables the limiter creates and
+ * the tables `db reset` drops are derived from the same configuration.
+ */
+export function createSecFetchRateLimiterStorage(pool: Pool): PostgresRateLimiterStorage {
+  return new PostgresRateLimiterStorage(pool, SecFetchRateLimiterOptions);
+}
+
+/**
  * Creates the shared rate-limiter's Postgres tables. Called once from
  * {@link setupAllDatabases} (i.e. `db setup`) — NOT per process — so a
  * multi-shard launch never races on the DDL. No-op on non-Postgres backends.
  */
 export async function setupSecFetchRateLimiter(): Promise<void> {
   if (!isPostgres()) return;
-  await new PostgresRateLimiterStorage(getPgPool()).migrate();
+  await createSecFetchRateLimiterStorage(getPgPool()).migrate();
 }
 
 let handles: SecJobQueueHandles | undefined;
@@ -82,7 +94,7 @@ export async function getSecJobQueue(): Promise<SecJobQueueHandles> {
   if (handles) return handles;
 
   const rateLimiterStorage: IRateLimiterStorage = isPostgres()
-    ? new PostgresRateLimiterStorage(getPgPool())
+    ? createSecFetchRateLimiterStorage(getPgPool())
     : new InMemoryRateLimiterStorage();
 
   const limiter = new RateLimiter(rateLimiterStorage, SecJobQueueName, {

--- a/src/task/fetch/secFetchRateLimiterConfig.ts
+++ b/src/task/fetch/secFetchRateLimiterConfig.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { RateLimiterStorageOptions } from "workglow";
+
+/**
+ * The single configuration sec builds its Postgres rate-limiter storage from.
+ *
+ * No prefix columns: every process shares ONE EDGAR fetch budget, so there is
+ * nothing to shard the reservation window by. Sharding it later (a column per
+ * host, per queue, …) is a matter of adding prefixes here — which also renames
+ * the storage's tables, which is why `db setup` and `db reset` both go through
+ * {@link secFetchRateLimiterTableNames} rather than naming them literally.
+ */
+export const SecFetchRateLimiterOptions: RateLimiterStorageOptions = {
+  prefixes: [],
+  prefixValues: {},
+};
+
+/**
+ * The tables `PostgresRateLimiterStorage` creates for a given configuration.
+ *
+ * That class derives its table names from its prefix columns and exposes
+ * neither the names nor the derivation, so a caller cannot ask what it built.
+ * This mirrors the derivation of the installed version; `resetAllDatabases`
+ * has to know the names to drop them, and a copy that silently disagreed would
+ * leave stale execution rows behind — so the copy is pinned by a test that
+ * runs the storage's own migrations and compares the emitted DDL.
+ */
+export function rateLimiterStorageTableNames(
+  options: RateLimiterStorageOptions
+): ReadonlyArray<string> {
+  const prefixes = options.prefixes ?? [];
+  const suffix = prefixes.length > 0 ? `_${prefixes.map((p) => p.name).join("_")}` : "";
+  return [`rate_limit_executions${suffix}`, `rate_limit_next_available${suffix}`];
+}
+
+/** The rate-limiter tables sec's own configuration creates, i.e. what a reset owns. */
+export function secFetchRateLimiterTableNames(): ReadonlyArray<string> {
+  return rateLimiterStorageTableNames(SecFetchRateLimiterOptions);
+}


### PR DESCRIPTION
Closes #229.

## Problem

`resetAllDatabases` named the Postgres rate-limiter tables literally:

```ts
const NON_REGISTRY_OWNED_TABLES = ["rate_limit_executions", "rate_limit_next_available", ...];
```

But `PostgresRateLimiterStorage` **derives** them from its prefix columns. Verified against the installed `@workglow/postgres@0.3.37` (`dist/job-queue/node.js:895-908`):

```js
const prefixNames = this.prefixes.map((p) => p.name).join("_");
this.executionTableName = `rate_limit_executions_${prefixNames}`;
this.nextAvailableTableName = `rate_limit_next_available_${prefixNames}`;
```

They matched only because `setupSecFetchRateLimiter()` passed no prefix columns, and nothing enforced that. The day the fetch budget is sharded — a prefix column per host, per queue, whatever — the storage starts creating `rate_limit_executions_host` and `sec db reset --confirm` silently stops dropping the rate-limiter tables. Stale execution rows survive, so the recreated database inherits a rate-limit budget from before the reset, and the only signal is those names appearing in the "tables sec does not own" warning — a line an operator running a destructive command is unlikely to read closely.

Upstream exposes neither the names (`protected readonly`, no accessor) nor the derivation, so this is the in-repo interim the issue describes: one place in sec owns the configuration, and both sides read from it.

## Change

- **`src/task/fetch/secFetchRateLimiterConfig.ts`** (new) — `SecFetchRateLimiterOptions` (the single storage configuration; no prefixes, because every process shares one EDGAR budget) plus `rateLimiterStorageTableNames(options)` / `secFetchRateLimiterTableNames()`.
- **`src/task/fetch/SecJobQueue.ts`** — `createSecFetchRateLimiterStorage(pool)` is now the only place the storage is constructed; `setupSecFetchRateLimiter()` and `getSecJobQueue()` both go through it. Passing `{prefixes: [], prefixValues: {}}` is behaviorally identical to the previous `undefined` (`options?.prefixes ?? []`), so there is no runtime change today.
- **`src/config/resetAllDatabases.ts`** — the two literals are gone; `ownedTableNames()` appends the derived names.
- **`CLAUDE.md`** — the `db reset` paragraph now says the rate-limiter names are derived, and from where.

Adding prefix columns now renames the tables on both sides at once.

## Why the copied derivation is safe

The issue's core complaint was that "no test ties the two together". The new tests run the **real installed storage's own migrations** against a pool that records SQL instead of executing it, and compare the `CREATE TABLE IF NOT EXISTS` names it emits:

1. the storage that `db setup` builds creates exactly the tables `ownedTableNames()` drops;
2. a hypothetical prefix-sharded configuration produces `rate_limit_executions_host_queue` / `rate_limit_next_available_host_queue` from the upstream DDL **and** from sec's derivation — the exact scenario that breaks today;
3. `resetAllDatabases.ts` contains no `"rate_limit_` literal.

Deliberately mutating the derivation to `rate_limit_nextavailable${suffix}` fails tests 1 and 2, so the guard has teeth:

```
 FAIL  src/config/resetAllDatabases.test.ts > drops exactly the tables the configured rate-limiter storage creates
 FAIL  src/config/resetAllDatabases.test.ts > tracks the table names when the fetch budget is sharded by prefix columns
-   "rate_limit_next_available_host_queue",
+   "rate_limit_nextavailable_host_queue",
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

No database is required to run them.

## Alternative considered

Reading the name off the instance via `(storage as {executionTableName})` would avoid duplicating the derivation, but it reaches into a `protected` member of a published package and silently yields `undefined` if upstream renames the field. The copy plus a DDL-comparison test fails loudly instead.

## Not touched

`_storage_migrations` stays in `NON_REGISTRY_OWNED_TABLES` — that is #228, handled separately. Scoped-reset behavior, the schema-qualified drops, the single transaction, and the "tables sec does not own" warning are unchanged.

## Verification

```
$ bunx vitest run src/config src/task/fetch
 Test Files  12 passed | 1 skipped (13)
      Tests  63 passed | 9 skipped (72)

$ bun run build-types
(clean)
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV)_