### PR TITLE
fix(forms): restore the accession-doc cache hit for Forms 3/4/5

### DIFF
--- a/src/sec/forms/registration-statements/s1/resolvePrimaryDoc.ts
+++ b/src/sec/forms/registration-statements/s1/resolvePrimaryDoc.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { stripXslPrefix } from "../../../../util/accessionDocPath";
+
 export interface PrimaryDocLike {
   readonly primary_doc: string | null | undefined;
 }
@@ -17,5 +19,5 @@ export interface PrimaryDocLike {
 export function resolveS1PrimaryDoc(filing: PrimaryDocLike): string | null {
   const raw = (filing.primary_doc ?? "").trim();
   if (raw === "") return null;
-  return raw.replace(/^xsl[^/]+\//, "");
+  return stripXslPrefix(raw);
 }

--- a/src/task/bootstrap/BootstrapAccessionDocsTask.ts
+++ b/src/task/bootstrap/BootstrapAccessionDocsTask.ts
@@ -11,7 +11,7 @@ import { globalServiceRegistry, IExecuteContext, Task } from "workglow";
 import { isDryRun } from "../../cli/isDryRun";
 import { SecUserAgent } from "../../config/Constants";
 import { SEC_RAW_DATA_FOLDER } from "../../config/tokens";
-import { assertInsideDir, sanitizePrimaryDoc } from "../../util/accessionDocPath";
+import { assertInsideDir, sanitizePrimaryDoc, stripXslPrefix } from "../../util/accessionDocPath";
 import { parseDate } from "../../util/parseDate";
 import { REGISTRATION_PROSPECTUS_FORMS } from "../forms/ProcessAccessionDocFormTask";
 import { extractPrimaryDocFromSubmission, streamFeedTarball } from "./feedTarball";
@@ -45,12 +45,6 @@ type FeedStream =
 interface DayResult {
   readonly filingsMatched: number;
   readonly docsWritten: number;
-}
-
-/** Strips the EDGAR inline-XBRL viewer prefix so the fetch resolves the raw
- * primary document — mirrors ComputeFormsWorklistTask's `fileName` mapping. */
-function stripXslPrefix(fileName: string): string {
-  return fileName.replaceAll(/^(xsl[^/]+\/)/g, "");
 }
 
 /**

--- a/src/task/forms/ComputeFormsWorklistTask.ts
+++ b/src/task/forms/ComputeFormsWorklistTask.ts
@@ -21,6 +21,7 @@ import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/Extract
 import { getActiveSlot } from "../../storage/versioning/getActiveSlot";
 import { VersionRegistry } from "../../storage/versioning/VersionRegistry";
 import { SecFetchMaxPerSec } from "../../config/Constants";
+import { stripXslPrefix } from "../../util/accessionDocPath";
 
 export type ComputeFormsWorklistTaskInput = {
   /** Omit (or pass empty) to process every form with a registered extractor. */
@@ -329,9 +330,7 @@ export class ComputeFormsWorklistTask extends Task<
         accessionNumber.push(f.accession_number);
         cik.push(f.cik);
         formOut.push(f.form!);
-        // Strip the EDGAR inline-XBRL viewer prefix ("xslF345X02/…") so the
-        // fetch resolves the raw primary document.
-        fileName.push(f.primary_doc.replaceAll(/^(xsl[^/]+\/)/g, ""));
+        fileName.push(stripXslPrefix(f.primary_doc));
       }
 
       if (lastExamined !== undefined) {

--- a/src/task/forms/FetchAndStoreFormsTask.ts
+++ b/src/task/forms/FetchAndStoreFormsTask.ts
@@ -8,6 +8,7 @@ import { Static, Type } from "typebox";
 import { globalServiceRegistry, IExecuteContext, Task, TaskError, Workflow } from "workglow";
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { type Filing, FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
+import { stripXslPrefix } from "../../util/accessionDocPath";
 import { ProcessAccessionDocFormTask } from "./ProcessAccessionDocFormTask";
 
 const FetchAndStoreFormsTaskInputSchema = () =>
@@ -91,7 +92,7 @@ export class FetchAndStoreFormsTask extends Task<
         cik: filings.map(() => cik),
         form: filings.map(() => form),
         accessionNumber: filings.map((f) => f.accession_number),
-        fileName: filings.map((f) => f.primary_doc.replaceAll(/^(xsl[^\/]+\/)/g, "")),
+        fileName: filings.map((f) => stripXslPrefix(f.primary_doc)),
       });
     }
     return { success: true };

--- a/src/task/forms/ProcessAccessionDocFormTask.cache.test.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.cache.test.ts
@@ -11,7 +11,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { globalServiceRegistry, type IExecuteContext } from "workglow";
 import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
 import { SEC_RAW_DATA_FOLDER } from "../../config/tokens";
+import { stripXslPrefix } from "../../util/accessionDocPath";
 import { ProcessAccessionDocFormTask } from "./ProcessAccessionDocFormTask";
+import { SecFetchAccessionDocTask } from "./SecFetchAccessionDocTask";
 
 // Exposes the protected runFetch so we can prove the cache fast-path is taken.
 class ExposedTask extends ProcessAccessionDocFormTask {
@@ -74,5 +76,59 @@ describe("runFetch on-disk cache fast-path", () => {
     await expect(
       new ExposedTask().runFetchPublic(5678, "0001999999-25-000002", "x.htm", {} as IExecuteContext)
     ).rejects.toBeDefined();
+  });
+
+  it("hits the cache for an xsl-prefixed primary_doc (ownership forms 3/4/5)", async () => {
+    // Forms 3/4/5 carry the EDGAR inline-XBRL viewer prefix in `primary_doc`
+    // ("xslF345X03/wf-form4.xml"). Every path that composes a cache location
+    // strips it first, so the cached document lives under the bare filename —
+    // the read must strip too or these filings never hit cache and re-fetch
+    // through the rate-limited queue on every run.
+    const cik = 1234;
+    const accession = "0001999999-25-000003";
+    const rawPrimaryDoc = "xslF345X03/wf-form4.xml";
+
+    // Prime the cache at exactly the location the write path composes, using
+    // the write path's own filename mapper rather than a hand-built string.
+    const relative = new SecFetchAccessionDocTask({
+      cik,
+      accessionNumber: accession,
+      fileName: stripXslPrefix(rawPrimaryDoc),
+    }).inputToFileName({
+      cik,
+      accessionNumber: accession,
+      fileName: stripXslPrefix(rawPrimaryDoc),
+    });
+    const fullPath = path.join(root!, relative);
+    mkdirSync(path.dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, "FORM 4 XML BODY");
+
+    const text = await new ExposedTask().runFetchPublic(
+      cik,
+      accession,
+      rawPrimaryDoc,
+      {} as IExecuteContext
+    );
+    expect(text).toBe("FORM 4 XML BODY");
+  });
+
+  it("still treats a traversal-shaped primary_doc as a silent cache miss", async () => {
+    // Stripping a known-safe prefix must not open a hole: whatever survives the
+    // strip still goes through the traversal guard, and a rejection stays a
+    // silent miss (fall through to the network) rather than reading outside the
+    // accession-doc directory.
+    writeFileSync(path.join(root!, "outside-secret.txt"), "SECRET");
+    const dir = path.join(root!, "accessiondocs", "0000009999");
+    mkdirSync(dir, { recursive: true });
+
+    for (const evil of [
+      "../../outside-secret.txt",
+      "xslF345X03/../../outside-secret.txt",
+      "/etc/passwd",
+    ]) {
+      await expect(
+        new ExposedTask().runFetchPublic(9999, "0001999999-25-000004", evil, {} as IExecuteContext)
+      ).rejects.toBeDefined();
+    }
   });
 });

--- a/src/task/forms/ProcessAccessionDocFormTask.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.ts
@@ -46,7 +46,7 @@ import {
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { SEC_RAW_DATA_FOLDER } from "../../config/tokens";
-import { assertInsideDir, sanitizePrimaryDoc } from "../../util/accessionDocPath";
+import { assertInsideDir, sanitizePrimaryDoc, stripXslPrefix } from "../../util/accessionDocPath";
 import { SecFetchAccessionDocTask } from "./SecFetchAccessionDocTask";
 
 /**
@@ -135,9 +135,19 @@ export class ProcessAccessionDocFormTask extends Task<
   protected async runFetch(
     cik: number,
     accessionNumber: string,
-    fileName: string,
+    rawFileName: string,
     context: IExecuteContext
   ): Promise<string> {
+    // Normalize ONCE, here, so the cache read below and the network fetch that
+    // populates it compose the same path. Ownership forms 3/4/5 arrive as
+    // `xslF345X03/wf-form4.xml` on the accession-only path (the caller supplied
+    // no filename, so this is the verbatim submissions-API `primary_doc`);
+    // callers that do supply a filename already hand over the bare name, so
+    // this is a no-op for them. Stripping only one half of the round trip means
+    // the write lands where the read never looks — a permanent cache miss —
+    // and the viewer URL serves rendered HTML where the parser wants raw XML.
+    const fileName = stripXslPrefix(rawFileName);
+
     // Fast path: serve an already-cached primary document straight from disk,
     // bypassing the rate-limited SEC fetch queue. A cache hit touches no
     // network, so throttling it against EDGAR's 10 req/sec budget is pure

--- a/src/util/accessionDocPath.test.ts
+++ b/src/util/accessionDocPath.test.ts
@@ -6,7 +6,56 @@
 
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { assertInsideDir, sanitizePrimaryDoc } from "./accessionDocPath";
+import { assertInsideDir, sanitizePrimaryDoc, stripXslPrefix } from "./accessionDocPath";
+
+describe("stripXslPrefix", () => {
+  it("strips the EDGAR inline-XBRL viewer prefix", () => {
+    expect(stripXslPrefix("xslF345X03/wf-form4.xml")).toBe("wf-form4.xml");
+    expect(stripXslPrefix("xslF345X02/b.xml")).toBe("b.xml");
+  });
+
+  it("leaves a bare filename untouched", () => {
+    expect(stripXslPrefix("wf-form4.xml")).toBe("wf-form4.xml");
+    expect(stripXslPrefix("")).toBe("");
+  });
+
+  it("strips at most one prefix, and only when anchored at the start", () => {
+    // The pattern is anchored, so a second segment is left alone and an
+    // interior occurrence is never touched.
+    expect(stripXslPrefix("xslA/xslB/foo.xml")).toBe("xslB/foo.xml");
+    expect(stripXslPrefix("a/xslF345X03/b.xml")).toBe("a/xslF345X03/b.xml");
+    expect(stripXslPrefix("primary_docxsl/x.htm")).toBe("primary_docxsl/x.htm");
+  });
+
+  it("requires a non-empty segment after 'xsl' and is case-sensitive", () => {
+    expect(stripXslPrefix("xsl/foo.xml")).toBe("xsl/foo.xml");
+    expect(stripXslPrefix("XSLF345X03/wf-form4.xml")).toBe("XSLF345X03/wf-form4.xml");
+  });
+
+  it("does not trim, so callers control the order", () => {
+    expect(stripXslPrefix("  xslFoo/bar.htm  ")).toBe("  xslFoo/bar.htm  ");
+  });
+});
+
+describe("stripXslPrefix composed with sanitizePrimaryDoc", () => {
+  it("accepts a viewer-prefixed ownership document", () => {
+    expect(sanitizePrimaryDoc(stripXslPrefix("xslF345X03/wf-form4.xml"))).toBe("wf-form4.xml");
+  });
+
+  it("still rejects traversal that a stripped prefix would otherwise hide", () => {
+    // Stripping a known-safe prefix must not open a hole: whatever survives
+    // the strip still faces the traversal guard.
+    for (const evil of [
+      "../../etc/passwd",
+      "xslFoo/../../etc/passwd",
+      "/etc/passwd",
+      "xslFoo//etc/passwd",
+      "xslFoo/sub/dir/x.htm",
+    ]) {
+      expect(() => sanitizePrimaryDoc(stripXslPrefix(evil))).toThrow(/Refusing unsafe primary_doc/);
+    }
+  });
+});
 
 describe("sanitizePrimaryDoc", () => {
   it("rejects a parent-directory traversal", () => {
@@ -49,8 +98,6 @@ describe("assertInsideDir", () => {
   it("rejects a composed path that escapes via `..`", () => {
     const base = path.resolve("/tmp/accessiondocs/0001193125");
     const escaping = path.join(base, "..", "..", "..", "etc", "edgar-attacker");
-    expect(() => assertInsideDir(escaping, base)).toThrow(
-      /Path escapes accession-doc directory/
-    );
+    expect(() => assertInsideDir(escaping, base)).toThrow(/Path escapes accession-doc directory/);
   });
 });

--- a/src/util/accessionDocPath.ts
+++ b/src/util/accessionDocPath.ts
@@ -7,6 +7,25 @@
 import path from "node:path";
 
 /**
+ * Strips the EDGAR inline-XBRL viewer prefix from a primary-document filename,
+ * so the raw document is what gets fetched and cached. Ownership forms 3/4/5
+ * carry it (`xslF345X03/wf-form4.xml` renders `wf-form4.xml` through the
+ * viewer), and every path that composes a fetch URL or a cache location must
+ * agree on the bare name or the two halves of the round trip disagree.
+ *
+ * Deliberately separate from {@link sanitizePrimaryDoc}: a sanitizer that
+ * silently rewrites its input is harder to reason about than one that only
+ * accepts or rejects. Compose them — strip, then sanitize — so whatever
+ * survives the strip still faces the traversal guard.
+ *
+ * Does not trim: the prefix is anchored at the start, so a caller that trims
+ * has to decide for itself whether that happens before or after.
+ */
+export function stripXslPrefix(fileName: string): string {
+  return fileName.replace(/^xsl[^/]+\//, "");
+}
+
+/**
  * Validates a filer-authored primary-document filename before it is used to
  * compose an on-disk cache path. Rejects anything that could escape the
  * accession-doc directory (path separators, parent-directory refs, absolute
@@ -38,10 +57,7 @@ export function sanitizePrimaryDoc(name: string): string {
 export function assertInsideDir(fullPath: string, dir: string): void {
   const resolvedDir = path.resolve(dir);
   const resolvedPath = path.resolve(fullPath);
-  if (
-    resolvedPath !== resolvedDir &&
-    !resolvedPath.startsWith(resolvedDir + path.sep)
-  ) {
+  if (resolvedPath !== resolvedDir && !resolvedPath.startsWith(resolvedDir + path.sep)) {
     throw new Error(
       `Path escapes accession-doc directory: ${JSON.stringify(fullPath)} resolved to ${JSON.stringify(resolvedPath)} (base ${JSON.stringify(resolvedDir)})`
     );


### PR DESCRIPTION
Closes #227.

## Summary

Forms 3/4/5 never hit the accession-document cache. Every `sec extractor backfill`, `sec extractor retry-dead-letters`, and `sec spac backfill-*` run re-fetched their primary document through the 10 req/s EDGAR budget, forever. Nothing errored — it simply never hit cache. At Form 4 volume that is millions of avoidable throttled requests.

## Mechanism

Ownership forms carry the EDGAR inline-XBRL viewer prefix in `primary_doc` (`xslF345X03/wf-form4.xml`). `readCachedDoc` sanitized that **raw** value; `sanitizePrimaryDoc` rejects any `/` as a traversal guard, and the surrounding `catch` turns the throw into a silent cache miss that falls through to the network.

The round trip used to be self-consistent — `readCachedDoc` and `SecFetchAccessionDocTask` receive the same `fileName`, and neither stripped, so both composed the same nested path and the second run hit cache. The traversal fix (#214) changed only the **read** side, so the write still lands at a path the read can no longer produce.

Three of the four consumers already stripped the prefix, each with its own copy of the regex. `ProcessAccessionDocFormTask` is the outlier: it reaches the raw value on the accession-only path, where the caller supplies no filename.

## Fix

- `stripXslPrefix` moves into `src/util/accessionDocPath.ts` beside the traversal guard and is exported; all four call sites now share it. It stays **composed** with `sanitizePrimaryDoc` rather than folded into it — a sanitizer that silently rewrites its input is harder to reason about than one that only accepts or rejects. The guard is not relaxed.
- `runFetch` normalizes the filename **once**, so the cache read and the network fetch that populates it compose the same path.

### Deviation from the issue's suggested step 3

The issue says "in `readCachedDoc`, strip, then sanitize". That alone is an **incomplete** fix. `SecFetchAccessionDocTask.inputToFileName` does not strip and `SecFetchFileOutputCache.saveOutput` does `mkdir -p` on the dirname, so the network path genuinely writes to the nested `…-xslF345X03/wf-form4.xml`. Stripping only the read half means the write still lands where the read no longer looks — the next run misses again, which is the defect itself.

Normalizing in `runFetch` instead restores the round-trip consistency the issue identifies as what broke, and keeps a single strip (`readCachedDoc` is private with one caller, so a second strip there would be dead code re-introducing the duplication this change removes).

Two consequences worth flagging: this path now also hits the **Feed-tarball bulk cache**, which writes under the stripped name — so it was missing that too, even before #214 — and it fetches the raw XML rather than the viewer's rendered HTML, which on this path was very likely producing `PARSE_ERROR` dead-letters.

### The four regex variants were identical

Verified empirically across 15 inputs before unifying, since the variance was real (`[^/]` vs `[^\/]`, `.replace` vs `.replaceAll`+`g`):

```
SAME  "xslF345X03/wf-form4.xml" -> "wf-form4.xml"
SAME  "xslA/xslB/foo.xml" -> "xslB/foo.xml"
SAME  "xslFoo/../../etc/passwd" -> "../../etc/passwd"
SAME  "  xslFoo/bar.htm  " -> "  xslFoo/bar.htm  "
SAME  "XSLF345X03/wf-form4.xml" -> "XSLF345X03/wf-form4.xml"
SAME  "a/xslF345X03/b.xml" -> "a/xslF345X03/b.xml"
... (15 cases)
ALL VARIANTS EQUIVALENT
```

The `.replace`/`.replaceAll` difference is not observable: `^` without the `m` flag matches only at index 0, so the `g` flag was inert — at most one replacement either way.

The shared helper deliberately does **not** trim: `BootstrapAccessionDocsTask` strips then trims while `resolveS1PrimaryDoc` trims then strips, and those differ on a leading-whitespace input (the fourth row above). Each call site keeps its own trim placement.

## Verification

New case in `ProcessAccessionDocFormTask.cache.test.ts` primes the cache at the location composed by the write path's own `inputToFileName`, then asserts the read hits. It fails before the fix:

```
 FAIL  src/task/forms/ProcessAccessionDocFormTask.cache.test.ts >
       hits the cache for an xsl-prefixed primary_doc (ownership forms 3/4/5)
TypeError: context.own is not a function
 ❯ ExposedTask.runFetch src/task/forms/ProcessAccessionDocFormTask.ts:153:24

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
```

(the cache missed and fell through to the network path — the fall-through idiom this test file already relies on).

Traversal coverage added at both levels: `stripXslPrefix` composed with `sanitizePrimaryDoc` still rejects `../../etc/passwd`, `xslFoo/../../etc/passwd`, an absolute path, `xslFoo//etc/passwd`, and `xslFoo/sub/dir/x.htm`; and `runFetch` treats each as a silent miss rather than reading outside the accession-doc directory.

```
$ bunx vitest run src/task/forms src/util src/task/bootstrap src/sec/forms
 Test Files  91 passed | 1 skipped (92)
      Tests  761 passed | 18 skipped (779)
   Duration  103.53s

$ bun run build-types
$ rm -f tsconfig.tsbuildinfo && tsc
(exit 0)
```

## Not included

`storageArgs.primary_doc` still records the raw prefixed name on the accession-only path while the `FetchAndStoreFormsTask` path records the stripped one for the same filing. That inconsistency pre-dates this issue and changing it would alter stored rows, so it is left alone.

`prettier --write` also reflowed two pre-existing lines in `accessionDocPath.ts` / `.test.ts` that already failed `--check` on `main`; both files now pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV)_