### PR TITLE
refactor(forms): type the parsed form document at the dispatch boundary

### DIFF
--- a/src/sec/forms/Form.ts
+++ b/src/sec/forms/Form.ts
@@ -86,14 +86,14 @@ export function decodePredefinedEntities<T>(value: T): T {
  * entities. Returned by {@link Form.getParser}.
  */
 export interface FormXmlParser {
-  parse(xml: string): any;
+  parse(xml: string): unknown;
 }
 
 export abstract class Form {
   static readonly name: string;
   static readonly description: string;
   static readonly forms: readonly string[];
-  static async parse(form: string, xml: string): Promise<any> {
+  static async parse(form: string, xml: string): Promise<unknown> {
     throw new Error(`Parsing not implemented for ${form}`);
   }
 
@@ -134,13 +134,24 @@ export abstract class Form {
     };
     const parser = new XMLParser(options);
     return {
-      parse(xml: string): any {
+      parse(xml: string): unknown {
         return decodePredefinedEntities(parser.parse(stripDoctype(xml)));
       },
     };
   }
 }
 
-export type FormConstructor = typeof Form & {
-  parse(form: string, xml: string): Promise<any>;
+/**
+ * The static side of a {@link Form} subclass, optionally carrying the type its
+ * {@link Form.parse} produces.
+ *
+ * The parsed type is a parameter of this alias rather than of `Form` itself
+ * because `parse` is `static`: TypeScript forbids a static member from
+ * referencing a class type parameter, so `abstract class Form<TParsed>` cannot
+ * type its own `parse`. Registries that hold mixed form classes keep the
+ * default `unknown`; `ParsedFormDocument` (`./parsedFormDocument`) is what
+ * recovers the concrete type per form name.
+ */
+export type FormConstructor<TParsed = unknown> = typeof Form & {
+  parse(form: string, xml: string): Promise<TParsed>;
 };

--- a/src/sec/forms/parsedFormDocument.ts
+++ b/src/sec/forms/parsedFormDocument.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { FormConstructor } from "./Form";
+import { Form_1_A } from "./exempt-offerings/Form_1_A";
+import { Form_1_K } from "./exempt-offerings/Form_1_K";
+import { Form_1_Z } from "./exempt-offerings/Form_1_Z";
+import { Form_C } from "./exempt-offerings/Form_C";
+import { Form_D } from "./exempt-offerings/Form_D";
+import { Form_F_1 } from "./foreign-registration-statements/Form_F_1";
+import { Form_F_1MEF } from "./foreign-registration-statements/Form_F_1MEF";
+import { Form_144 } from "./insider-trading/Form_144";
+import { Form_3 } from "./insider-trading/Form_3";
+import { Form_4 } from "./insider-trading/Form_4";
+import { Form_5 } from "./insider-trading/Form_5";
+import { Form_8_K } from "./miscellaneous-filings/Form_8_K";
+import { Form_CFPORTAL } from "./portal/Form_CFPORTAL";
+import { Form_DEFM14A } from "./proxies-information-statements/Form_DEFM14A";
+import { Form_DEFM14C } from "./proxies-information-statements/Form_DEFM14C";
+import { Form_DEFR14A } from "./proxies-information-statements/Form_DEFR14A";
+import { Form_PREM14A } from "./proxies-information-statements/Form_PREM14A";
+import { Form_PREM14C } from "./proxies-information-statements/Form_PREM14C";
+import { Form_PRER14A } from "./proxies-information-statements/Form_PRER14A";
+import { Form_424 } from "./registration-statements/Form_424";
+import { Form_DRS } from "./registration-statements/Form_DRS";
+import { Form_S_1 } from "./registration-statements/Form_S_1";
+
+/**
+ * One arm of {@link ParsedFormDocument}: a form class's declared form names
+ * paired with what its `parse` resolves to. Both halves are read off the class,
+ * so a new form name or a changed parse result flows through without editing
+ * this file.
+ */
+interface ParsedDocumentOf<C extends FormConstructor> {
+  readonly form: C["forms"][number];
+  readonly parsed: Awaited<ReturnType<C["parse"]>>;
+}
+
+/**
+ * Discriminated union of every form the storage dispatch handles, keyed on the
+ * form name.
+ *
+ * `Form.parse` is `static` and so cannot be typed by a class type parameter
+ * (TypeScript rejects `abstract class Form<TParsed>` referencing `TParsed` from
+ * a static member), which leaves the registry's parse result as `unknown`.
+ * Narrowing this union on `form` recovers the concrete parsed type for each
+ * storage handler, so a `switch` over form names type-checks its handler
+ * arguments instead of passing `any` through.
+ *
+ * Only forms with a storage handler appear here; the rest never reach the
+ * dispatch.
+ */
+export type ParsedFormDocument =
+  | ParsedDocumentOf<typeof Form_D>
+  | ParsedDocumentOf<typeof Form_C>
+  | ParsedDocumentOf<typeof Form_CFPORTAL>
+  | ParsedDocumentOf<typeof Form_1_A>
+  | ParsedDocumentOf<typeof Form_1_K>
+  | ParsedDocumentOf<typeof Form_1_Z>
+  | ParsedDocumentOf<typeof Form_3>
+  | ParsedDocumentOf<typeof Form_4>
+  | ParsedDocumentOf<typeof Form_5>
+  | ParsedDocumentOf<typeof Form_144>
+  | ParsedDocumentOf<typeof Form_S_1>
+  | ParsedDocumentOf<typeof Form_DRS>
+  | ParsedDocumentOf<typeof Form_F_1>
+  | ParsedDocumentOf<typeof Form_F_1MEF>
+  | ParsedDocumentOf<typeof Form_424>
+  | ParsedDocumentOf<typeof Form_8_K>
+  | ParsedDocumentOf<typeof Form_DEFM14A>
+  | ParsedDocumentOf<typeof Form_PREM14A>
+  | ParsedDocumentOf<typeof Form_DEFM14C>
+  | ParsedDocumentOf<typeof Form_PREM14C>
+  | ParsedDocumentOf<typeof Form_DEFR14A>
+  | ParsedDocumentOf<typeof Form_PRER14A>;

--- a/src/task/forms/ProcessAccessionDocFormTask.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.ts
@@ -14,6 +14,7 @@ import {
   Workflow,
 } from "workglow";
 import { ALL_FORMS_MAP } from "../../sec/forms/all-forms";
+import type { ParsedFormDocument } from "../../sec/forms/parsedFormDocument";
 import { processForm1A } from "../../sec/forms/exempt-offerings/Form_1_A.storage";
 import { processForm1K } from "../../sec/forms/exempt-offerings/Form_1_K.storage";
 import { processForm1Z } from "../../sec/forms/exempt-offerings/Form_1_Z.storage";
@@ -437,8 +438,7 @@ export class ProcessAccessionDocFormTask extends Task<
     // throws below remain hard errors: they run on parsed data, so a throw
     // there is a code bug that should surface loudly.
     await context.updateProgress(60, `${label} · parsing`);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Form.parse returns any; each switch arm narrows it
-    let parsed: any;
+    let parsed: unknown;
     try {
       parsed = await formCls.parse(form!, text);
     } catch (err) {
@@ -455,6 +455,12 @@ export class ProcessAccessionDocFormTask extends Task<
       return { success: false };
     }
 
+    // The registry is keyed by form name and holds every form class, so the
+    // parse result it hands back is `unknown`. Re-pairing the name with the
+    // value recovers the discriminated union each arm below narrows, which is
+    // what type-checks the handler arguments.
+    const parsedDocument = { form: form!, parsed } as ParsedFormDocument;
+
     await context.updateProgress(80, `${label} · storing`);
     let parseError: unknown = undefined;
     try {
@@ -470,10 +476,10 @@ export class ProcessAccessionDocFormTask extends Task<
         context,
       };
 
-      switch (form) {
+      switch (parsedDocument.form) {
         case "D":
         case "D/A":
-          await processFormD({ ...storageArgs, formD: parsed });
+          await processFormD({ ...storageArgs, formD: parsedDocument.parsed });
           break;
         case "C":
         case "C/A":
@@ -487,25 +493,25 @@ export class ProcessAccessionDocFormTask extends Task<
         case "C-AR/A-W":
         case "C-TR":
         case "C-TR-W":
-          await processFormC({ ...storageArgs, formC: parsed });
+          await processFormC({ ...storageArgs, formC: parsedDocument.parsed });
           break;
         case "CFPORTAL":
         case "CFPORTAL/A":
         case "CFPORTAL-W":
-          await processFormCFPORTAL({ ...storageArgs, formCfportal: parsed });
+          await processFormCFPORTAL({ ...storageArgs, formCfportal: parsedDocument.parsed });
           break;
         case "1-A":
         case "1-A/A":
         case "1-A POS":
-          await processForm1A({ ...storageArgs, form1A: parsed });
+          await processForm1A({ ...storageArgs, form1A: parsedDocument.parsed });
           break;
         case "1-K":
         case "1-K/A":
-          await processForm1K({ ...storageArgs, form1K: parsed });
+          await processForm1K({ ...storageArgs, form1K: parsedDocument.parsed });
           break;
         case "1-Z":
         case "1-Z/A":
-          await processForm1Z({ ...storageArgs, form1Z: parsed });
+          await processForm1Z({ ...storageArgs, form1Z: parsedDocument.parsed });
           break;
         case "3":
         case "3/A":
@@ -513,11 +519,11 @@ export class ProcessAccessionDocFormTask extends Task<
         case "4/A":
         case "5":
         case "5/A":
-          await processOwnershipForm({ ...storageArgs, form: form!, doc: parsed });
+          await processOwnershipForm({ ...storageArgs, form: form!, doc: parsedDocument.parsed });
           break;
         case "144":
         case "144/A":
-          await processForm144({ ...storageArgs, form: form!, doc: parsed });
+          await processForm144({ ...storageArgs, form: form!, doc: parsedDocument.parsed });
           break;
         case "S-1":
         case "S-1/A":
@@ -527,7 +533,7 @@ export class ProcessAccessionDocFormTask extends Task<
         case "F-1":
         case "F-1/A":
         case "F-1MEF":
-          await processFormS1({ ...storageArgs, form: form!, formS1: parsed });
+          await processFormS1({ ...storageArgs, form: form!, formS1: parsedDocument.parsed });
           break;
         case "424A":
         case "424B1":
@@ -536,7 +542,7 @@ export class ProcessAccessionDocFormTask extends Task<
         case "424B4":
         case "424B5":
         case "424B7":
-          await processForm424({ ...storageArgs, form: form!, form424: parsed });
+          await processForm424({ ...storageArgs, form: form!, form424: parsedDocument.parsed });
           break;
         case "8-K":
         case "8-K/A":
@@ -545,7 +551,7 @@ export class ProcessAccessionDocFormTask extends Task<
             form: form!,
             items,
             report_date,
-            form8K: parsed,
+            form8K: parsedDocument.parsed,
             extractor_id: extractorId,
             extractor_version: extractorVersion,
             fullSubmissionText: spacNarrativeFullSubmission ? text : undefined,
@@ -557,7 +563,11 @@ export class ProcessAccessionDocFormTask extends Task<
         case "PREM14C":
         case "DEFR14A":
         case "PRER14A":
-          await processMergerProxy({ ...storageArgs, form: form!, formMergerProxy: parsed });
+          await processMergerProxy({
+            ...storageArgs,
+            form: form!,
+            formMergerProxy: parsedDocument.parsed,
+          });
           break;
         default:
           throw new TaskError(`Form '${form}' has no storage handler`);


### PR DESCRIPTION
Closes #141.

`Form.parse` returned `Promise<any>`, so the parse result flowed untyped into all fifteen storage handlers at the form dispatch. There were no casts to delete — the `any` is what made them unnecessary, and with them went all checking: `processFormD({ formD: parsed })` would have accepted a `Form8K` without complaint.

## Why not `abstract class Form<TParsed>`

The issue asks for the parsed type as a class parameter. That does not compile — `parse` is `static`, and TypeScript forbids a static member from referencing a class type parameter:

```
error TS2302: Static members cannot reference class type parameters.
```

Nor can the type survive the dispatch on its own. `ALL_FORMS_MAP` is `Map<string, FormConstructor>` (`src/sec/forms/all-forms.ts:142`) — a heterogeneous registry keyed by form-name string — so `formCls.parse(form, text)` necessarily erases to the map's value type. Parameterizing the constructor alias alone would turn `any` into `unknown` and force fifteen fresh casts in the switch arms: a net loss.

## What this does instead

Recover the type *after* erasure, using the discriminant the dispatch already switches on:

- `Form.parse`, `FormXmlParser.parse` and the parser wrapper return `unknown`. All eleven subclass parsers already assert their parsed shape and keep their concrete return types, so nothing downstream needed touching.
- `FormConstructor<TParsed = unknown>` carries the parse result, and documents in-file why the parameter lives on the alias rather than the class.
- New `src/sec/forms/parsedFormDocument.ts` — `ParsedFormDocument`, a discriminated union pairing each form name with what its class parses to. Both halves are *derived* off the class (`C["forms"][number]`, `Awaited<ReturnType<C["parse"]>>`), so a new form name or a changed parser result flows through without editing it. 22 arms covering every class the dispatch handles.

The dispatch narrows that union on the form name. One assertion at the boundary buys back full checking in all fifteen arms.

## Payoff

| | before | after |
|---|---|---|
| `any` in the parse pipeline (`Form.ts` + task) | 5 | 0 |
| Explicit casts at the 15 handler sites | 0 | 0 |
| Assertions at the dispatch boundary | 0 | 1 |

Plus a guardrail that did not exist: `switch (form)` on a `string` accepted any case label, so a typo'd form name compiled into a silently-unreachable arm. `switch (parsedDocument.form)` rejects it (`TS2678`).

Type-only. Same `formCls.parse` call, same switch on the same string value, same parse/store containment domains, same `default:` throw. No parsing behavior changes.

## Verification

Rather than trusting a clean build, the narrowing was confirmed to actually bite by temporarily annotating three arms with a deliberately wrong type:

```
ProcessAccessionDocFormTask.ts(482,17): error TS2322: Type '{ schemaVersion?: string | undefined; ... offeringData: {...}; }' is not assignable to type 'number'.
ProcessAccessionDocFormTask.ts(537,17): error TS2322: Type 'FormS1Parsed' is not assignable to type 'number'.
ProcessAccessionDocFormTask.ts(556,44): error TS1360: Type '{ submissionType?: "8-K" | "8-K/A" | undefined; ... }' does not satisfy the expected type 'number'.
```

The Form D arm sees Form D, the S-1 arm sees `FormS1Parsed`, the 8-K arm sees `Form8K`. Probes reverted.

```
$ bun run build-types
$ rm -f tsconfig.tsbuildinfo && tsc
(clean, no output)

$ bunx vitest run src/sec/forms
 Test Files  70 passed (70)
      Tests  621 passed (621)
   Duration  63.49s

$ bunx vitest run src/task/forms
 Test Files  11 passed (11)
      Tests  49 passed (49)
   Duration  34.39s

$ npx prettier --check src/sec/forms/Form.ts src/sec/forms/parsedFormDocument.ts src/task/forms/ProcessAccessionDocFormTask.ts
All matched files use Prettier code style!
```

## Not in scope

Replacing the per-form `switch` with a handler dispatch table registered alongside `ALL_FORMS_MAP` is a runtime restructure that would merge the parse and store containment domains — deliberately distinct today (parse throw → `PARSE_ERROR` dead-letter, store throw → hard error). It is not needed to get the types and remains open as its own change.

ESLint could not be run in this environment (`@typescript-eslint/eslint-plugin` is absent from the installed dependency set); the one rule at issue, `no-explicit-any`, no longer needs its disable comment.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV)_