### PR TITLE
feat: export the canonical person identity tier from the barrel

### DIFF
--- a/src/index.barrel.test.ts
+++ b/src/index.barrel.test.ts
@@ -40,3 +40,17 @@ test("exports family-tier primitives for a downstream family resolver", () => {
   expect(typeof b.normalizeFamilyName).toBe("function");
   expect(typeof b.CanonicalFamilyAliasRepo).toBe("function");
 });
+
+test("exports the person identity tier a downstream role query joins through", () => {
+  const b = sec as Record<string, unknown>;
+  expect(typeof b.PersonIdentityLinkRepo).toBe("function");
+  expect(typeof b.CanonicalPersonAliasRepo).toBe("function");
+  expect(typeof b.PersonRoleRepo).toBe("function");
+  for (const name of [
+    "PERSON_IDENTITY_LINK_REPOSITORY_TOKEN",
+    "CANONICAL_PERSON_ALIAS_REPOSITORY_TOKEN",
+    "PERSON_ROLE_REPOSITORY_TOKEN",
+  ]) {
+    expect(sec[name as keyof typeof sec], `missing barrel export: ${name}`).toBeDefined();
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,22 @@ export {
 } from "./storage/observation/PersonObservationTitleSchema";
 export { FILING_REPOSITORY_TOKEN } from "./storage/filing/FilingSchema";
 
+// ── Canonical person identity tier (observation → canonical id, merge aliases)
+// The join a downstream superset needs to get from a person observation to the
+// canonical id `person_role` and the junction tables are keyed by: the identity
+// link resolves it at a given `resolver_version`, and the alias table redirects
+// an id that a later merge retired.
+export { PersonIdentityLinkRepo } from "./storage/canonical/PersonIdentityLinkRepo";
+export {
+  PERSON_IDENTITY_LINK_REPOSITORY_TOKEN,
+  type PersonIdentityLink,
+} from "./storage/canonical/PersonIdentityLinkSchema";
+export { CanonicalPersonAliasRepo } from "./storage/canonical/CanonicalPersonAliasRepo";
+export {
+  CANONICAL_PERSON_ALIAS_REPOSITORY_TOKEN,
+  type CanonicalPersonAlias,
+} from "./storage/canonical/CanonicalAliasSchemas";
+
 // ── Dated person roles (person↔company title tenures) ───────────────────────
 export { PersonRoleRepo } from "./storage/canonical/PersonRoleRepo";
 export {


### PR DESCRIPTION
## What changed

Four new barrel exports in `src/index.ts`, in a new section placed just above the existing dated-person-roles block:

```ts
export { PersonIdentityLinkRepo } from "./storage/canonical/PersonIdentityLinkRepo";
export {
  PERSON_IDENTITY_LINK_REPOSITORY_TOKEN,
  type PersonIdentityLink,
} from "./storage/canonical/PersonIdentityLinkSchema";
export { CanonicalPersonAliasRepo } from "./storage/canonical/CanonicalPersonAliasRepo";
export {
  CANONICAL_PERSON_ALIAS_REPOSITORY_TOKEN,
  type CanonicalPersonAlias,
} from "./storage/canonical/CanonicalAliasSchemas";
```

Each repo ships with its DI token and row type, matching how `PersonRoleRepo` / `PERSON_ROLE_REPOSITORY_TOKEN` / `PersonRole` and `CanonicalCompanyRepo` / `CANONICAL_COMPANY_REPOSITORY_TOKEN` / `CanonicalCompany` are already exported — a consumer needs the token to resolve the storage out of `globalServiceRegistry` and the type to hold a row, so exporting the class alone would not be usable.

## Why

`0.0.20` exports `PersonRoleRepo`, but not the tier that gets you to a canonical person id to query it with. A downstream superset holding a person observation needs:

1. `PersonIdentityLinkRepo` — `(observation_id, resolver_version) → canonical_person_id`
2. `CanonicalPersonAliasRepo` — redirect an id a later merge retired

Neither is reachable: both are absent from the barrel, and `package.json` exposes only the `.` export path, so there is no deep-import fallback.

The practical effect showed up in embarc-data, joining dated tenures into its startup people view (sroussey/embarc-data#32). With no import route, it bound both storages by reconstructing sec's token id strings by hand:

```ts
createServiceToken<...>("sec.storage.personIdentityLinkRepository")
createServiceToken<...>("sec.storage.canonicalPersonAliasRepository")
```

That works — the ids match — but it is a contract nothing in this package pins. A rename here would not break that consumer's build; it would resolve an unregistered token and degrade to "this person has no tenures", which reads as a data gap rather than a wiring break. Exporting the tier removes the need for the workaround, and the barrel test makes the contract explicit for any consumer still on it.

## Test

Added a fourth case to `src/index.barrel.test.ts`, in the file's existing idiom, covering both new repos and all three tokens of the identity→role join path (identity link, alias, role) together — the point being that the join is only usable if the whole path is exported, so the test should fail if any one of them regresses.

Verified the test is meaningful rather than tautological — with `src/index.ts` stashed and only the test applied:

```
error: expect(received).toBe(expected)
(fail) exports the person identity tier a downstream role query joins through [3.91ms]
 3 pass / 1 fail
```

## Verification

```
$ bun test src/index.barrel.test.ts
 4 pass / 0 fail — 48 expect() calls [1241.00ms]

$ bun run build-types
$ rm -f tsconfig.tsbuildinfo && tsc
TSC_EXIT=0

$ bun test
 2123 pass / 7 skip / 9 fail — 29367 expect() calls, 287 files [208.92s]
```

**The 9 failures are pre-existing and environmental, not from this change.** They are the live-network EDGAR fetch tests (`FetchQuarterlyIndexTask`, `FetchDailyIndexTask`, …), each timing out at exactly 5000ms because this sandbox cannot reach sec.gov. Confirmed by stashing the change and re-running the same files on a clean tree — the identical set fails:

```
$ git stash && bun test src/task/index/
(fail) FetchQuarterlyIndexTask > should get the quarterly index for 2025-QTR1 [5000.44ms]
(fail) FetchDailyIndexTask > should get the daily index for 2024-01-02 [5000.14ms]
 … 4 pass / 7 fail
```

An additive re-export cannot affect an HTTP fetch task either way; the clean-tree run is there so that is checked rather than asserted.

## Scope

Deliberately just these two. `CanonicalPersonRepo` is not exported here — the identity link plus the alias table is the whole join `person_role` needs, and adding more of the canonical tier to the public surface is a separate call to make on its own merits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBpD6WKV3t3KJPMncFAb5u)_