### PR TITLE
fix(html): drop repeated heading blocks as page furniture

### DIFF
--- a/src/sec/html/DePaginator.test.ts
+++ b/src/sec/html/DePaginator.test.ts
@@ -5,10 +5,19 @@
  */
 import { describe, expect, it } from "vitest";
 import { depaginate } from "./DePaginator";
-import type { EdgarBlock } from "./types";
+import type { EdgarBlock, ResolvedStyle } from "./types";
 import { NodeKind, uuid4 } from "workglow";
 import type { ParagraphNode, TableCell, TableNode } from "workglow";
 
+const style: ResolvedStyle = {
+  fontSizePt: 14,
+  bold: true,
+  italic: false,
+  underline: false,
+  centered: true,
+  upperRatio: 1,
+};
+const heading = (text: string): EdgarBlock => ({ type: "heading", text, style, level: 2 });
 const para = (text: string): EdgarBlock => ({
   type: "paragraph",
   node: {
@@ -51,6 +60,43 @@ describe("depaginate", () => {
       false
     );
     expect(out.filter((b) => b.type === "paragraph").length).toBe(6);
+  });
+
+  it("drops a running header repeated >= 5 times when it is styled as a heading", () => {
+    const blocks: EdgarBlock[] = [];
+    for (let i = 0; i < 6; i++) {
+      blocks.push(heading("Table of Contents"), para(`Real content ${i}`));
+    }
+    const out = depaginate(blocks);
+    expect(out.some((b) => b.type === "heading")).toBe(false);
+    expect(out.filter((b) => b.type === "paragraph").length).toBe(6);
+  });
+
+  it("keeps a heading that repeats only a few times (table of contents + body)", () => {
+    const blocks: EdgarBlock[] = [heading("MANAGEMENT"), para("body"), heading("MANAGEMENT")];
+    const out = depaginate(blocks);
+    expect(out.filter((b) => b.type === "heading")).toHaveLength(2);
+  });
+
+  it("keeps a heading whose words are also repeated as running prose", () => {
+    const blocks: EdgarBlock[] = [heading("PROSPECTUS SUMMARY")];
+    for (let i = 0; i < 6; i++) blocks.push(para("Prospectus Summary"), para(`page ${i} body`));
+    const out = depaginate(blocks);
+    expect(out.filter((b) => b.type === "heading")).toHaveLength(1);
+    expect(out.some((b) => b.type === "paragraph" && b.node.text === "Prospectus Summary")).toBe(
+      false
+    );
+  });
+
+  it("keeps a heading that starts a page, unlike an adjacent short paragraph", () => {
+    const blocks: EdgarBlock[] = [
+      para("tail of the previous page"),
+      { type: "page-break" },
+      heading("THE OFFERING"),
+      para("The offering body runs on from here."),
+    ];
+    const out = depaginate(blocks);
+    expect(out.some((b) => b.type === "heading" && b.text === "THE OFFERING")).toBe(true);
   });
 
   it("stitches a table split across a page break with a repeated header", () => {

--- a/src/sec/html/DePaginator.ts
+++ b/src/sec/html/DePaginator.ts
@@ -20,15 +20,25 @@ function isPageNumber(text: string): boolean {
   return /^\W*page\s+\d+\W*$/i.test(t) || /^[-\s]*\d{1,4}[-\s]*$/.test(t);
 }
 
+/**
+ * Key a block votes under in the repetition tally, or undefined when it is not
+ * eligible (not short text). Headings and paragraphs are tallied separately: a
+ * phrase repeated as body text must not vote away the single heading that spells
+ * the same words, since dropping a heading also unparents that section's body.
+ */
+function furnitureKey(b: EdgarBlock): string | undefined {
+  const text = b.type === "paragraph" ? b.node.text : b.type === "heading" ? b.text : undefined;
+  if (text === undefined || text.length > SHORT_LEN) return undefined;
+  return `${b.type}:${normalize(text)}`;
+}
+
 /** Mark furniture (running headers/footers, page numbers) and drop it; then stitch. */
 export function depaginate(blocks: EdgarBlock[]): EdgarBlock[] {
-  // --- Pass 1: frequency table of short prose ---
+  // --- Pass 1: frequency table of short prose and short heading text ---
   const freq = new Map<string, number>();
   for (const b of blocks) {
-    if (b.type === "paragraph") {
-      const t = b.node.text;
-      if (t.length <= SHORT_LEN) freq.set(normalize(t), (freq.get(normalize(t)) ?? 0) + 1);
-    }
+    const key = furnitureKey(b);
+    if (key !== undefined) freq.set(key, (freq.get(key) ?? 0) + 1);
   }
 
   const isAdjacentToBreak = (i: number): boolean =>
@@ -37,14 +47,15 @@ export function depaginate(blocks: EdgarBlock[]): EdgarBlock[] {
   // --- Pass 2: classify + drop furniture (keep page-break markers for stitching) ---
   const kept: EdgarBlock[] = [];
   blocks.forEach((b, i) => {
+    const key = furnitureKey(b);
+    if (key !== undefined && (freq.get(key) ?? 0) >= FREQ_THRESHOLD) return;
     if (b.type === "paragraph") {
       const t = b.node.text;
       if (isPageNumber(t)) return;
-      if (t.length <= SHORT_LEN) {
-        const f = freq.get(normalize(t)) ?? 0;
-        if (f >= FREQ_THRESHOLD) return;
-        if (isAdjacentToBreak(i)) return;
-      }
+      // Page-break adjacency stays a paragraph-only signal. A genuine section
+      // heading normally starts a fresh page, so extending it to headings would
+      // strip the very titles the tree is built from.
+      if (t.length <= SHORT_LEN && isAdjacentToBreak(i)) return;
     }
     kept.push(b);
   });

--- a/src/sec/html/parseEdgarHtml.golden.test.ts
+++ b/src/sec/html/parseEdgarHtml.golden.test.ts
@@ -6,7 +6,7 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import type { TableNode } from "workglow";
+import type { SectionNode, TableNode } from "workglow";
 import { NodeKind, traverseDepthFirst } from "workglow";
 import type { S1SectionName } from "../forms/registration-statements/s1/DocumentSegmenter";
 import { S1_SECTIONS } from "../forms/registration-statements/s1/DocumentSegmenter";
@@ -110,6 +110,91 @@ const SPAC_FIXTURES = [
   "s1_2114227_000121390026039320.htm",
 ];
 
+/**
+ * Minimum body size, in characters, of each resolved section. Section
+ * *presence* alone is not enough: a section whose body is cut short at the
+ * first page break still resolves, so a presence-only corpus stayed green while
+ * every section of a 12 MB prospectus had been truncated to a few thousand
+ * characters.
+ *
+ * Each floor is roughly half the size the section actually resolves to, so a
+ * routine parser adjustment has room to move a section a little without
+ * failing, while any halving of a section's body — the signature of silent
+ * truncation — is caught. Re-derive the same way (observed / 2, rounded down)
+ * when a deliberate change moves these.
+ *
+ * A section with no entry here is not size-checked, so adding a section to
+ * {@link EXPECTED} does not require adding a floor.
+ */
+const MIN_SECTION_CHARS: Readonly<Record<string, Partial<Record<S1SectionName, number>>>> = {
+  "s1_1848507_000119312521066104.htm": {
+    [PROSPECTUS_SUMMARY]: 60_000,
+    [MANAGEMENT]: 25_000,
+    [BENEFICIAL_OWNERSHIP]: 6_000,
+    [RELATED_PARTY]: 4_000,
+    [THE_OFFERING]: 35_000,
+    [UNDERWRITING]: 14_000,
+    [USE_OF_PROCEEDS]: 7_000,
+  },
+  "s1_1849470_000110465921035696.htm": {
+    [PROSPECTUS_SUMMARY]: 55_000,
+    [MANAGEMENT]: 21_000,
+    [BENEFICIAL_OWNERSHIP]: 5_000,
+    [RELATED_PARTY]: 6_000,
+    [THE_OFFERING]: 32_000,
+    [UNDERWRITING]: 18_000,
+    [USE_OF_PROCEEDS]: 8_000,
+  },
+  "s1_1822912_000121390021001475.htm": {
+    [PROSPECTUS_SUMMARY]: 59_000,
+    [MANAGEMENT]: 16_000,
+    [BENEFICIAL_OWNERSHIP]: 4_000,
+    [RELATED_PARTY]: 5_000,
+    [THE_OFFERING]: 30_000,
+    [UNDERWRITING]: 16_000,
+    [USE_OF_PROCEEDS]: 9_000,
+  },
+  "s1_2114227_000121390026039320.htm": {
+    [PROSPECTUS_SUMMARY]: 92_000,
+    [MANAGEMENT]: 28_000,
+    [BENEFICIAL_OWNERSHIP]: 6_000,
+    [RELATED_PARTY]: 7_000,
+    [THE_OFFERING]: 45_000,
+    [UNDERWRITING]: 14_000,
+    [USE_OF_PROCEEDS]: 9_000,
+  },
+  "s1_2030954_000149315226027129.htm": {
+    [PROSPECTUS_SUMMARY]: 3_000,
+    [BENEFICIAL_OWNERSHIP]: 2_000,
+    [THE_OFFERING]: 1_500,
+    [UNDERWRITING]: 12_000,
+    [USE_OF_PROCEEDS]: 1_000,
+  },
+  "s1_2087989_000143774926019444.htm": {
+    [PROSPECTUS_SUMMARY]: 9_000,
+    [THE_OFFERING]: 4_000,
+    [THE_SPONSOR]: 4_000,
+    [UNDERWRITING]: 2_000,
+    [USE_OF_PROCEEDS]: 200,
+  },
+  "s1_1817004_000149315226027137.htm": {
+    [PROSPECTUS_SUMMARY]: 7_000,
+    [THE_OFFERING]: 400,
+    [UNDERWRITING]: 2_000,
+    [USE_OF_PROCEEDS]: 100,
+  },
+};
+
+/**
+ * Page furniture (a per-page "Table of Contents" back-link, a running issuer
+ * header) recurs far more often than any real heading — three occurrences is
+ * the most any genuine heading reaches across this corpus. Furniture that
+ * survives into the tree becomes a section, and every such section closes the
+ * one it interrupts, so this bound guards the truncation mechanism directly and
+ * independently of the per-section sizes above.
+ */
+const MAX_REPEATED_SECTION_TITLE = 5;
+
 const fixtures = readdirSync(dir).filter((f) => f.endsWith(".htm"));
 
 describe("parseEdgarHtml golden fixtures (real EDGAR S-1 filings)", () => {
@@ -137,6 +222,31 @@ describe("parseEdgarHtml golden fixtures (real EDGAR S-1 filings)", () => {
       const doc = parseEdgarHtml(html, file);
       const resolved = new DocumentTreeSegmenter().segment(doc).map((s) => s.name);
       expect(new Set(resolved)).toEqual(new Set(expected));
+    });
+
+    it(`${file}: every resolved section carries a full body, not a truncated one`, () => {
+      const floors = MIN_SECTION_CHARS[file];
+      expect(floors, `add a MIN_SECTION_CHARS entry for ${file}`).toBeDefined();
+      const doc = parseEdgarHtml(html, file);
+      const sizes = new Map(
+        new DocumentTreeSegmenter().segment(doc).map((s) => [s.name, s.text.length])
+      );
+      for (const [name, min] of Object.entries(floors) as [S1SectionName, number][]) {
+        expect(sizes.get(name) ?? 0, `${file} ${name} body`).toBeGreaterThanOrEqual(min);
+      }
+    });
+
+    it(`${file}: no page furniture survives as a repeated section`, () => {
+      const doc = parseEdgarHtml(html, file);
+      const counts = new Map<string, number>();
+      for (const node of traverseDepthFirst(doc)) {
+        if (node.kind !== NodeKind.SECTION) continue;
+        const title = (node as SectionNode).title.replace(/\s+/g, " ").trim().toLowerCase();
+        counts.set(title, (counts.get(title) ?? 0) + 1);
+      }
+      for (const [title, n] of counts) {
+        expect(n, `${file} repeats section "${title}"`).toBeLessThan(MAX_REPEATED_SECTION_TITLE);
+      }
     });
 
     it(`${file}: no stitched table leaves a duplicated header row in its body`, () => {


### PR DESCRIPTION
Found while triaging #144 and #147 — independently, by two separate investigations. Not tracked by an existing issue.

## Summary

`depaginate()`'s repeated-furniture pass only inspected **paragraph** blocks, so page furniture that the style cascade promotes to a **heading** was never dropped. Since `buildDocumentTree` opens a section per heading and closes the one it interrupts, a filing whose per-page furniture is heading-styled had *every* section truncated to its first page.

On the committed fixture `s1_1848507_000119312521066104.htm`, the per-page `Table of Contents` back-link is 14pt bold, which `StyleResolver` promotes to a level-2 heading — **214 occurrences**, plus a running issuer header and an F-page header for **244** furniture headings in total. Section nodes: 388 → 144.

## Measured impact

`s1_1848507_000119312521066104.htm`:

| Section | before | after |
| --- | ---: | ---: |
| Prospectus Summary | 4,807 | 127,011 |
| The Offering | 2,909 | 75,571 |
| Management | 3,778 | 50,051 |
| Underwriting | 3,800 | 28,572 |
| Principal and Selling Stockholders | 5,124 | 13,309 |
| Certain Relationships / Related Tx | 4,892 | 8,439 |
| Use of Proceeds | 3,987 | 15,142 |

Peer SPAC fixtures carry The Offering at 61,088 / 65,513 / 90,650 characters, so 2,909 was plainly wrong.

**Blast radius across all 7 fixtures.** All 7 target-section sizes are byte-identical on the other six. Two of them do change structurally, in the financial-statement pages only:

| Fixture | section nodes | markdown chars | target sections |
| --- | --- | --- | --- |
| `s1_1822912` | 73 → 60 | 730,229 → 729,526 | unchanged |
| `s1_2114227` | 65 → 48 | 1,048,975 → 1,047,991 | unchanged |
| `s1_1849470`, `s1_2087989`, `s1_2030954`, `s1_1817004` | — | — | identical |

Those 13 and 17 dropped blocks are `<Issuer>Notes to Financial Statements` (×8, ×10) and underscore page rules (×5, ×7) — page furniture. Dropping them stops the notes to financial statements being chopped into spurious sections. This is a fix, not a regression.

**Bonus fix.** Table nodes on `s1_1848507` go 517 → 492: the `Table of Contents` heading was sitting between the page break and a table continuation, blocking the stitcher. Verified as pure gain — `totalRows` 905 → 905, `totalCells` 3,412 → 3,412, `stitchedFromSum` 517 → 517, `stitchedTables` 0 → **22**. No table data lost; 25 page-split continuations now reunify.

## The change

Extends the existing repetition rule to heading text — no second mechanism, no special-casing of the string "Table of Contents". `FREQ_THRESHOLD` stays 5.

Two safety decisions, both measured rather than assumed:

1. **Headings and paragraphs tally under separate keys.** A shared table would let a phrase repeated as body text vote away the one heading spelling the same words, deleting that section. (A shared table drops nothing extra on this corpus, so separating costs nothing and removes the hazard.)
2. **Page-break adjacency stays paragraph-only.** Extending that second existing rule to headings would strip 233/388, 39/73 and 20/77 headings on three fixtures — including `PROSPECTUS SUMMARY`, `THE OFFERING`, `RISK FACTORS` and `USE OF PROCEEDS`. A real section heading normally *starts* a page. Frequency generalizes to other filer agents' furniture; adjacency does not.

**Is threshold 5 safe for headings?** The full repetition distribution over all 7 fixtures says yes. Everything recurring ≥5 times is furniture; the most any legitimate heading reaches is **3**. A heading appearing twice (table-of-contents stub + body) is untouched, and `DocumentTreeSegmenter` already keeps the occurrence with the most body text.

## Closing the test gap

`parseEdgarHtml.golden.test.ts` asserted section **presence**, never section **size**, which is why the truncation stayed green. Two additive assertions:

- **`MIN_SECTION_CHARS`** — per-fixture, per-section floors at roughly half each section's resolved size. Catches a halving (the truncation signature) without pinning exact counts that break on unrelated parser tweaks. Deliberately a `Partial<Record<…>>`: a section with no entry is not size-checked, so adding a section to `EXPECTED` needs no edit here.
- **`MAX_REPEATED_SECTION_TITLE`** — no section title may repeat ≥5 times. Zero-maintenance and fixture-agnostic; guards the truncation mechanism directly rather than its symptom.

Confirmed they catch the bug — reverting only `DePaginator.ts`:

```
 × drops a running header repeated >= 5 times when it is styled as a heading
 × s1_1822912…: no page furniture survives as a repeated section
 × s1_1848507…: every resolved section carries a full body, not a truncated one
 × s1_1848507…: no page furniture survives as a repeated section
 × s1_2114227…: no page furniture survives as a repeated section
AssertionError: s1_1848507… Prospectus Summary body: expected 4807 to be greater than or equal to 60000
AssertionError: s1_1848507… repeats section "table of contents": expected 214 to be less than 5
 Test Files  2 failed (2) | Tests  5 failed | 39 passed (44)
```

Four unit tests were also added to `DePaginator.test.ts`: furniture headings are dropped; a heading repeating twice survives; a heading survives when its words also recur as prose; a heading that starts a page survives.

## Verification

```
$ bunx vitest run --maxWorkers=2 src/sec/html src/sec/forms/registration-statements src/eval
 Test Files  49 passed (49)
      Tests  398 passed (398)
   Duration  72.07s

$ bun run build-types
$ rm -f tsconfig.tsbuildinfo && tsc
exit=0

$ bunx prettier --check src/sec/html/DePaginator.ts src/sec/html/DePaginator.test.ts src/sec/html/parseEdgarHtml.golden.test.ts
All matched files use Prettier code style!
```

## Files changed

- `src/sec/html/DePaginator.ts` — the fix
- `src/sec/html/DePaginator.test.ts` — 4 new unit tests, existing tests untouched
- `src/sec/html/parseEdgarHtml.golden.test.ts` — additive only: one import symbol, two new top-level consts, two new `it(...)` blocks. `EXPECTED`, `SPAC_FIXTURES` and all existing tests are unmodified.

## Downstream

The other open triage branches are rebased onto this one, so every branch is tested against the fixed parser. #239 (risk-factor extraction) is the one whose *results* change materially: its recall on `s1_1848507` was bounded by the 3,023-character truncated section, and it notes that limitation explicitly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV)_