### PR TITLE
fix(html): keep a section heading, and the first instance of furniture

### DIFF
--- a/src/sec/html/DePaginator.test.ts
+++ b/src/sec/html/DePaginator.test.ts
@@ -50,26 +50,54 @@ const table = (headerRows: TableCell[][], rows: TableCell[][]): EdgarBlock => ({
 });
 
 describe("depaginate", () => {
-  it("drops a running header repeated >= 5 times", () => {
+  it("drops the repeats of a running header, keeping its first occurrence", () => {
     const blocks: EdgarBlock[] = [];
     for (let i = 0; i < 6; i++) {
       blocks.push(para("ACME CORPORATION"), para(`Real content ${i}`));
     }
     const out = depaginate(blocks);
-    expect(out.some((b) => b.type === "paragraph" && b.node.text === "ACME CORPORATION")).toBe(
-      false
-    );
-    expect(out.filter((b) => b.type === "paragraph").length).toBe(6);
+    const acme = out.filter((b) => b.type === "paragraph" && b.node.text === "ACME CORPORATION");
+    expect(acme).toHaveLength(1);
+    expect(out[0]).toBe(acme[0]);
+    expect(out.filter((b) => b.type === "paragraph").length).toBe(7);
   });
 
-  it("drops a running header repeated >= 5 times when it is styled as a heading", () => {
+  it("drops the repeats of a running header styled as a heading, keeping the first", () => {
     const blocks: EdgarBlock[] = [];
     for (let i = 0; i < 6; i++) {
       blocks.push(heading("Table of Contents"), para(`Real content ${i}`));
     }
     const out = depaginate(blocks);
-    expect(out.some((b) => b.type === "heading")).toBe(false);
+    expect(out.filter((b) => b.type === "heading")).toHaveLength(1);
+    expect(out[0]).toEqual(expect.objectContaining({ type: "heading", text: "Table of Contents" }));
     expect(out.filter((b) => b.type === "paragraph").length).toBe(6);
+  });
+
+  it("keeps every occurrence of a target section heading, however often it repeats", () => {
+    const blocks: EdgarBlock[] = [];
+    for (let i = 0; i < 6; i++) {
+      blocks.push(heading("MANAGEMENT"), para(`Management page ${i}`));
+    }
+    const out = depaginate(blocks);
+    // The segmenter picks the occurrence with the most body, so the de-paginator
+    // must not decide for it by thinning them down to the first.
+    expect(out.filter((b) => b.type === "heading")).toHaveLength(6);
+  });
+
+  it("keeps a repeated section heading whose page furniture is dropped around it", () => {
+    const blocks: EdgarBlock[] = [];
+    for (let i = 0; i < 6; i++) {
+      blocks.push(
+        heading("THE OFFERING"),
+        para("ACME CORPORATION"),
+        para(`Offering page ${i} body text`)
+      );
+    }
+    const out = depaginate(blocks);
+    expect(out.filter((b) => b.type === "heading")).toHaveLength(6);
+    expect(
+      out.filter((b) => b.type === "paragraph" && b.node.text === "ACME CORPORATION")
+    ).toHaveLength(1);
   });
 
   it("keeps a heading that repeats only a few times (table of contents + body)", () => {
@@ -83,9 +111,11 @@ describe("depaginate", () => {
     for (let i = 0; i < 6; i++) blocks.push(para("Prospectus Summary"), para(`page ${i} body`));
     const out = depaginate(blocks);
     expect(out.filter((b) => b.type === "heading")).toHaveLength(1);
-    expect(out.some((b) => b.type === "paragraph" && b.node.text === "Prospectus Summary")).toBe(
-      false
-    );
+    // The prose repeats are furniture and thin down to one; the heading is
+    // tallied separately, so they never vote it away.
+    expect(
+      out.filter((b) => b.type === "paragraph" && b.node.text === "Prospectus Summary")
+    ).toHaveLength(1);
   });
 
   it("keeps a heading that starts a page, unlike an adjacent short paragraph", () => {

--- a/src/sec/html/DePaginator.ts
+++ b/src/sec/html/DePaginator.ts
@@ -5,6 +5,7 @@
  */
 import { renderMarkdown } from "workglow";
 import type { TableCell, TableNode } from "workglow";
+import { SECTION_HEADING_PATTERNS } from "../forms/registration-statements/s1/DocumentSegmenter";
 import type { EdgarBlock } from "./types";
 
 const FREQ_THRESHOLD = 5;
@@ -32,6 +33,25 @@ function furnitureKey(b: EdgarBlock): string | undefined {
   return `${b.type}:${normalize(text)}`;
 }
 
+/**
+ * Whether a heading names a section the segmenter builds sections from. Such a
+ * heading is exempt from the repetition rule entirely: a prospectus that prints
+ * its section title as the running header of every page inside that section
+ * would otherwise vote the real heading away, and losing it unparents the whole
+ * section into its predecessor. Which occurrence is the real one is left to the
+ * segmenter, which already keeps the occurrence with the most body text.
+ *
+ * The exemption reads the segmenter's own pattern table, so a section added
+ * there is protected here without a second list to keep in sync.
+ */
+function isTargetSectionHeading(b: EdgarBlock): boolean {
+  if (b.type !== "heading") return false;
+  const line = b.text.replace(/\s+/g, " ").trim();
+  return Object.values(SECTION_HEADING_PATTERNS).some((patterns) =>
+    patterns.some((re) => re.test(line))
+  );
+}
+
 /** Mark furniture (running headers/footers, page numbers) and drop it; then stitch. */
 export function depaginate(blocks: EdgarBlock[]): EdgarBlock[] {
   // --- Pass 1: frequency table of short prose and short heading text ---
@@ -45,10 +65,18 @@ export function depaginate(blocks: EdgarBlock[]): EdgarBlock[] {
     blocks[i - 1]?.type === "page-break" || blocks[i + 1]?.type === "page-break";
 
   // --- Pass 2: classify + drop furniture (keep page-break markers for stitching) ---
+  // Repetition identifies furniture, but the text itself is still content that
+  // appeared in the filing: only the repeats are page furniture, so the first
+  // surviving occurrence is kept and every later one dropped.
   const kept: EdgarBlock[] = [];
+  const keptOnce = new Set<string>();
   blocks.forEach((b, i) => {
     const key = furnitureKey(b);
-    if (key !== undefined && (freq.get(key) ?? 0) >= FREQ_THRESHOLD) return;
+    const repeatKey =
+      key !== undefined && (freq.get(key) ?? 0) >= FREQ_THRESHOLD && !isTargetSectionHeading(b)
+        ? key
+        : undefined;
+    if (repeatKey !== undefined && keptOnce.has(repeatKey)) return;
     if (b.type === "paragraph") {
       const t = b.node.text;
       if (isPageNumber(t)) return;
@@ -57,6 +85,10 @@ export function depaginate(blocks: EdgarBlock[]): EdgarBlock[] {
       // strip the very titles the tree is built from.
       if (t.length <= SHORT_LEN && isAdjacentToBreak(i)) return;
     }
+    // Recorded only once the block survives the remaining rules, so a first
+    // occurrence dropped as a page number or page-break neighbour does not
+    // spend the one slot its later occurrences would otherwise have filled.
+    if (repeatKey !== undefined) keptOnce.add(repeatKey);
     kept.push(b);
   });
 


### PR DESCRIPTION
Follow-up to #242, which taught the de-paginator to treat a repeated **heading** as page furniture. That closed a real truncation bug, but it drops every occurrence of the repeated text — including the first, and including a heading the segmenter needs.

## Two problems with drop-all

**A repeated heading is not necessarily furniture.** `FREQ_THRESHOLD = 5` counts occurrences without asking what the text is. A prospectus that prints its section title as the running header of every page inside that section crosses the threshold *on the strength of the real heading*. Dropping it unparents the section into its predecessor, so the segmenter reports the section missing and the caller dead-letters `SECTION_NOT_FOUND` for a section that is plainly present in the filing.

**Repetition does not make the text itself furniture — only the repeats are.** `Table of Contents` recurs 214 times on the `s1_1848507` fixture and all 214 blocks were deleted, so a phrase the filing really does contain vanished from the document entirely.

## The fix

- A heading matching the segmenter's own `SECTION_HEADING_PATTERNS` is **exempt** from the frequency drop. Which occurrence is the real one stays the segmenter's call — `DocumentTreeSegmenter` already keeps the occurrence with the most body text, so a TOC stub loses to the real section. Reading that table rather than restating it means a section added there is protected here with no second list to keep in sync.
- Everything else that trips the threshold keeps its **first surviving occurrence** and drops the rest.

The word *surviving* is load-bearing: the first occurrence is recorded only once it clears the page-number and page-break-adjacency rules. Otherwise a first instance dropped as a page number would spend the one slot, and every later occurrence would be dropped as a repeat — leaving nothing, which is the bug this is meant to prevent.

## Measured on the golden corpus

Every section is **byte-identical in size** across all seven fixtures, in both directions — so keeping all occurrences of an exempt heading causes no fragmentation, and keep-first causes no bleed. The only delta is the restored first instances: 1–3 blocks per filing.

## Two things a reviewer should weigh

**The exemption is currently inert.** No target heading repeats ≥5 times anywhere in the committed corpus — every ≥5 repeat there is genuine furniture (`table of contents` 214x, `1.12 acquisition corp` 19x, notes-to-financial-statements running headers). It is protection against a shape the committed sample does not contain. The keep-first half is what changes behavior on real filings today.

**Three pinned expectations were rewritten**, from erase-entirely to keep-one: the `Table of Contents` heading test, the `ACME CORPORATION` paragraph test, and the `Prospectus Summary` prose test. That is the intended semantic change, not a test working around the code.

## Interaction with #239

#239 adds `RISK_FACTORS` directly into `SECTION_HEADING_PATTERNS`, so its headings inherit the exemption the moment it merges — no follow-up wiring, and no `SECTION_NOT_FOUND` from a running-header collision. No file overlap with any other open PR.

## Verification

- `tsc --noEmit` clean
- `src/sec/html/` — 83 tests across 8 files pass
- S-1 forms + eval — 317 tests across 41 files pass
- Golden corpus section sizes diffed before/after: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV


---
_Generated by [Claude Code](https://claude.ai/code/session_01KB8s4qR5goCoxjE94YDFUV)_