### PR TITLE
fix(db): count estimates against the real table names

### DIFF
--- a/src/cli/queries/DbStatus.test.ts
+++ b/src/cli/queries/DbStatus.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { globalServiceRegistry } from "workglow";
+import { SEC_STORAGE_REGISTRY } from "../../config/storageRegistry";
 import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
 import { ENTITY_REPOSITORY_TOKEN } from "../../storage/entity/EntitySchema";
 import { getDbStats, getDbStatus } from "./DbStatus";
@@ -58,6 +59,18 @@ describe("getDbStats", () => {
       expect(typeof stat.table).toBe("string");
       expect(typeof stat.rows).toBe("number");
     }
+  });
+
+  it("names the physical relation for every built-in table", async () => {
+    // The Postgres estimate path filters on `relid = to_regclass($1)`, which
+    // matches nothing when the name is a display label rather than the real
+    // relation (`entity` for `entities`, `filing` for `filings`) — the count
+    // then silently degrades to the exact scan the estimate exists to avoid.
+    const registered = new Set(SEC_STORAGE_REGISTRY.map((storage) => storage.table));
+    const reported = (await getDbStats()).map((stat) => stat.table);
+
+    expect(reported.length).toBeGreaterThan(0);
+    expect(reported.filter((table) => !registered.has(table))).toEqual([]);
   });
 
   it("reports progress through every counted table", async () => {

--- a/src/cli/queries/DbStatus.ts
+++ b/src/cli/queries/DbStatus.ts
@@ -1,5 +1,6 @@
 import type { ServiceToken } from "workglow";
 import { globalServiceRegistry } from "workglow";
+import { SEC_STORAGE_REGISTRY } from "../../config/storageRegistry";
 import { getPgPool } from "../../util/pg";
 import { resolveSqlBackend } from "../../util/sqlBackend";
 import { ADDRESS_REPOSITORY_TOKEN } from "../../storage/address/AddressSchema";
@@ -70,12 +71,36 @@ interface CountableRepository {
 }
 
 /**
+ * Physical table name per repository token, read from the same registry
+ * `createStorage` builds the tables from. The estimate query needs the real
+ * relation name — `to_regclass` returns NULL for a name no relation has, the
+ * row filter then matches nothing, and the count silently falls back to the
+ * exact scan the estimate exists to avoid. Deriving the name instead of
+ * repeating it here is what stops a hand-written label (`entity` for
+ * `entities`, `filing` for `filings`) from reintroducing that.
+ */
+const TABLE_NAME_BY_TOKEN_ID: ReadonlyMap<string, string> = new Map(
+  SEC_STORAGE_REGISTRY.map((storage) => [storage.token.id, storage.table])
+);
+
+/**
+ * Physical table name for a repository sec owns. Throws rather than guessing:
+ * a token missing from the registry is a wiring mistake, and falling back to
+ * the token id would silently reinstate the exact-count path.
+ */
+function secTableName(token: ServiceToken<CountableRepository>): string {
+  const table = TABLE_NAME_BY_TOKEN_ID.get(token.id);
+  if (table === undefined) {
+    throw new Error(`db stats token is not in the storage registry: ${token.id}`);
+  }
+  return table;
+}
+
+/**
  * Counts rows through the storage interface. This exact path is used for
  * status metrics and every non-Postgres backend.
  */
-async function countRows(
-  token: ServiceToken<CountableRepository>
-): Promise<number> {
+async function countRows(token: ServiceToken<CountableRepository>): Promise<number> {
   const repo = globalServiceRegistry.get(token);
   return await repo.size();
 }
@@ -107,55 +132,60 @@ async function countTableRows(
 
 const STATUS_TABLES: readonly {
   readonly key: keyof DbStatusResult;
-  readonly table: string;
   readonly token: ServiceToken<CountableRepository>;
 }[] = [
-  { key: "entityCount", table: "entity", token: ENTITY_REPOSITORY_TOKEN as any },
-  { key: "filingCount", table: "filing", token: FILING_REPOSITORY_TOKEN as any },
-  { key: "factsCount", table: "company_facts", token: COMPANY_FACTS_REPOSITORY_TOKEN as any },
-  {
-    key: "processedSubmissions",
-    table: "processed_submissions",
-    token: PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN as any,
-  },
-  { key: "processedFacts", table: "processed_facts", token: PROCESSED_FACTS_REPOSITORY_TOKEN as any },
-  { key: "extractorRuns", table: "extractor_runs", token: EXTRACTOR_RUN_REPOSITORY_TOKEN as any },
+  { key: "entityCount", token: ENTITY_REPOSITORY_TOKEN as any },
+  { key: "filingCount", token: FILING_REPOSITORY_TOKEN as any },
+  { key: "factsCount", token: COMPANY_FACTS_REPOSITORY_TOKEN as any },
+  { key: "processedSubmissions", token: PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN as any },
+  { key: "processedFacts", token: PROCESSED_FACTS_REPOSITORY_TOKEN as any },
+  { key: "extractorRuns", token: EXTRACTOR_RUN_REPOSITORY_TOKEN as any },
 ];
 
 export async function getDbStatus(options: DbCountOptions = {}): Promise<DbStatusResult> {
   const result = {} as Record<keyof DbStatusResult, number>;
-  for (const { key, table, token } of STATUS_TABLES) {
-    result[key] = await countTableRows(table, token, options.exact === true);
+  for (const { key, token } of STATUS_TABLES) {
+    result[key] = await countTableRows(secTableName(token), token, options.exact === true);
   }
   return result;
 }
 
-const TABLE_TOKENS: readonly DbStatsTable[] = [
-  { table: "cik_names", token: CIK_NAME_REPOSITORY_TOKEN as any },
-  { table: "entity", token: ENTITY_REPOSITORY_TOKEN as any },
-  { table: "filing", token: FILING_REPOSITORY_TOKEN as any },
-  { table: "company_facts", token: COMPANY_FACTS_REPOSITORY_TOKEN as any },
-  { table: "investment_offering", token: INVESTMENT_OFFERING_REPOSITORY_TOKEN as any },
-  { table: "crowdfunding", token: CROWDFUNDING_REPOSITORY_TOKEN as any },
-  { table: "address", token: ADDRESS_REPOSITORY_TOKEN as any },
-  { table: "phone", token: PHONE_REPOSITORY_TOKEN as any },
-  { table: "portal", token: PORTAL_REPOSITORY_TOKEN as any },
-  { table: "extractor_runs", token: EXTRACTOR_RUN_REPOSITORY_TOKEN as any },
-  { table: "person_observation", token: PERSON_OBSERVATION_REPOSITORY_TOKEN as any },
-  { table: "person_observation_titles", token: PERSON_OBSERVATION_TITLE_REPOSITORY_TOKEN as any },
-  { table: "person_role", token: PERSON_ROLE_REPOSITORY_TOKEN as any },
-  { table: "company_observation", token: COMPANY_OBSERVATION_REPOSITORY_TOKEN as any },
-  { table: "canonical_person", token: CANONICAL_PERSON_REPOSITORY_TOKEN as any },
-  { table: "canonical_company", token: CANONICAL_COMPANY_REPOSITORY_TOKEN as any },
-  { table: "person_identity_link", token: PERSON_IDENTITY_LINK_REPOSITORY_TOKEN as any },
-  { table: "company_identity_link", token: COMPANY_IDENTITY_LINK_REPOSITORY_TOKEN as any },
-  { table: "section16_filings", token: SECTION16_FILING_REPOSITORY_TOKEN as any },
-  { table: "section16_transactions", token: SECTION16_TRANSACTION_REPOSITORY_TOKEN as any },
-  { table: "section16_holdings", token: SECTION16_HOLDING_REPOSITORY_TOKEN as any },
-  { table: "form144_filings", token: FORM144_FILING_REPOSITORY_TOKEN as any },
-  { table: "form144_acquisitions", token: FORM144_ACQUISITION_REPOSITORY_TOKEN as any },
-  { table: "form144_recent_sales", token: FORM144_RECENT_SALE_REPOSITORY_TOKEN as any },
+/**
+ * Repositories counted by `db stats`, in report order. Each table name is
+ * derived from the storage registry via {@link secTableName}, so the report
+ * names the relation a `psql \dt` would show and the estimate query can find it.
+ */
+const BUILT_IN_TABLE_TOKENS: readonly ServiceToken<CountableRepository>[] = [
+  CIK_NAME_REPOSITORY_TOKEN as any,
+  ENTITY_REPOSITORY_TOKEN as any,
+  FILING_REPOSITORY_TOKEN as any,
+  COMPANY_FACTS_REPOSITORY_TOKEN as any,
+  INVESTMENT_OFFERING_REPOSITORY_TOKEN as any,
+  CROWDFUNDING_REPOSITORY_TOKEN as any,
+  ADDRESS_REPOSITORY_TOKEN as any,
+  PHONE_REPOSITORY_TOKEN as any,
+  PORTAL_REPOSITORY_TOKEN as any,
+  EXTRACTOR_RUN_REPOSITORY_TOKEN as any,
+  PERSON_OBSERVATION_REPOSITORY_TOKEN as any,
+  PERSON_OBSERVATION_TITLE_REPOSITORY_TOKEN as any,
+  PERSON_ROLE_REPOSITORY_TOKEN as any,
+  COMPANY_OBSERVATION_REPOSITORY_TOKEN as any,
+  CANONICAL_PERSON_REPOSITORY_TOKEN as any,
+  CANONICAL_COMPANY_REPOSITORY_TOKEN as any,
+  PERSON_IDENTITY_LINK_REPOSITORY_TOKEN as any,
+  COMPANY_IDENTITY_LINK_REPOSITORY_TOKEN as any,
+  SECTION16_FILING_REPOSITORY_TOKEN as any,
+  SECTION16_TRANSACTION_REPOSITORY_TOKEN as any,
+  SECTION16_HOLDING_REPOSITORY_TOKEN as any,
+  FORM144_FILING_REPOSITORY_TOKEN as any,
+  FORM144_ACQUISITION_REPOSITORY_TOKEN as any,
+  FORM144_RECENT_SALE_REPOSITORY_TOKEN as any,
 ];
+
+const TABLE_TOKENS: readonly DbStatsTable[] = BUILT_IN_TABLE_TOKENS.map((token) => ({
+  table: secTableName(token),
+  token: token as DbStatsTable["token"],
+}));
 
 const extensionTableTokens = new Map<string, DbStatsTable>();
 

--- a/src/cli/queries/DbStatus.ts
+++ b/src/cli/queries/DbStatus.ts
@@ -48,26 +48,31 @@ export interface TableStat {
   readonly rows: number;
 }
 
+/**
+ * Counts rows in a repository via the storage `size()` method rather than
+ * loading every entity with `getAll()`. `cik_names` in particular has ~1M rows,
+ * so `getAll()` would be both slow and memory-hungry.
+ *
+ * Every `*_REPOSITORY_TOKEN` satisfies this structurally — `ITabularStorage`
+ * declares both members — and `ServiceToken` holds its service type in a
+ * readonly position, so a concrete repository token is assignable here with no
+ * cast.
+ */
+export interface CountableRepository {
+  size(): Promise<number>;
+  isDurable?(): boolean;
+}
+
 /** A repository whose row count is included in the `db stats` command. */
 export interface DbStatsTable {
   readonly table: string;
-  readonly token: ServiceToken<{ size(): Promise<number> }>;
+  readonly token: ServiceToken<CountableRepository>;
 }
 
 /** Controls whether database counts may use Postgres catalog estimates. */
 export interface DbCountOptions {
   /** Force exact storage-level counts, including on Postgres. */
   readonly exact?: boolean;
-}
-
-/**
- * Counts rows in a repository via the storage `size()` method rather than
- * loading every entity with `getAll()`. `cik_names` in particular has ~1M rows,
- * so `getAll()` would be both slow and memory-hungry.
- */
-interface CountableRepository {
-  size(): Promise<number>;
-  isDurable?(): boolean;
 }
 
 /**
@@ -134,12 +139,12 @@ const STATUS_TABLES: readonly {
   readonly key: keyof DbStatusResult;
   readonly token: ServiceToken<CountableRepository>;
 }[] = [
-  { key: "entityCount", token: ENTITY_REPOSITORY_TOKEN as any },
-  { key: "filingCount", token: FILING_REPOSITORY_TOKEN as any },
-  { key: "factsCount", token: COMPANY_FACTS_REPOSITORY_TOKEN as any },
-  { key: "processedSubmissions", token: PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN as any },
-  { key: "processedFacts", token: PROCESSED_FACTS_REPOSITORY_TOKEN as any },
-  { key: "extractorRuns", token: EXTRACTOR_RUN_REPOSITORY_TOKEN as any },
+  { key: "entityCount", token: ENTITY_REPOSITORY_TOKEN },
+  { key: "filingCount", token: FILING_REPOSITORY_TOKEN },
+  { key: "factsCount", token: COMPANY_FACTS_REPOSITORY_TOKEN },
+  { key: "processedSubmissions", token: PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN },
+  { key: "processedFacts", token: PROCESSED_FACTS_REPOSITORY_TOKEN },
+  { key: "extractorRuns", token: EXTRACTOR_RUN_REPOSITORY_TOKEN },
 ];
 
 export async function getDbStatus(options: DbCountOptions = {}): Promise<DbStatusResult> {
@@ -156,35 +161,35 @@ export async function getDbStatus(options: DbCountOptions = {}): Promise<DbStatu
  * names the relation a `psql \dt` would show and the estimate query can find it.
  */
 const BUILT_IN_TABLE_TOKENS: readonly ServiceToken<CountableRepository>[] = [
-  CIK_NAME_REPOSITORY_TOKEN as any,
-  ENTITY_REPOSITORY_TOKEN as any,
-  FILING_REPOSITORY_TOKEN as any,
-  COMPANY_FACTS_REPOSITORY_TOKEN as any,
-  INVESTMENT_OFFERING_REPOSITORY_TOKEN as any,
-  CROWDFUNDING_REPOSITORY_TOKEN as any,
-  ADDRESS_REPOSITORY_TOKEN as any,
-  PHONE_REPOSITORY_TOKEN as any,
-  PORTAL_REPOSITORY_TOKEN as any,
-  EXTRACTOR_RUN_REPOSITORY_TOKEN as any,
-  PERSON_OBSERVATION_REPOSITORY_TOKEN as any,
-  PERSON_OBSERVATION_TITLE_REPOSITORY_TOKEN as any,
-  PERSON_ROLE_REPOSITORY_TOKEN as any,
-  COMPANY_OBSERVATION_REPOSITORY_TOKEN as any,
-  CANONICAL_PERSON_REPOSITORY_TOKEN as any,
-  CANONICAL_COMPANY_REPOSITORY_TOKEN as any,
-  PERSON_IDENTITY_LINK_REPOSITORY_TOKEN as any,
-  COMPANY_IDENTITY_LINK_REPOSITORY_TOKEN as any,
-  SECTION16_FILING_REPOSITORY_TOKEN as any,
-  SECTION16_TRANSACTION_REPOSITORY_TOKEN as any,
-  SECTION16_HOLDING_REPOSITORY_TOKEN as any,
-  FORM144_FILING_REPOSITORY_TOKEN as any,
-  FORM144_ACQUISITION_REPOSITORY_TOKEN as any,
-  FORM144_RECENT_SALE_REPOSITORY_TOKEN as any,
+  CIK_NAME_REPOSITORY_TOKEN,
+  ENTITY_REPOSITORY_TOKEN,
+  FILING_REPOSITORY_TOKEN,
+  COMPANY_FACTS_REPOSITORY_TOKEN,
+  INVESTMENT_OFFERING_REPOSITORY_TOKEN,
+  CROWDFUNDING_REPOSITORY_TOKEN,
+  ADDRESS_REPOSITORY_TOKEN,
+  PHONE_REPOSITORY_TOKEN,
+  PORTAL_REPOSITORY_TOKEN,
+  EXTRACTOR_RUN_REPOSITORY_TOKEN,
+  PERSON_OBSERVATION_REPOSITORY_TOKEN,
+  PERSON_OBSERVATION_TITLE_REPOSITORY_TOKEN,
+  PERSON_ROLE_REPOSITORY_TOKEN,
+  COMPANY_OBSERVATION_REPOSITORY_TOKEN,
+  CANONICAL_PERSON_REPOSITORY_TOKEN,
+  CANONICAL_COMPANY_REPOSITORY_TOKEN,
+  PERSON_IDENTITY_LINK_REPOSITORY_TOKEN,
+  COMPANY_IDENTITY_LINK_REPOSITORY_TOKEN,
+  SECTION16_FILING_REPOSITORY_TOKEN,
+  SECTION16_TRANSACTION_REPOSITORY_TOKEN,
+  SECTION16_HOLDING_REPOSITORY_TOKEN,
+  FORM144_FILING_REPOSITORY_TOKEN,
+  FORM144_ACQUISITION_REPOSITORY_TOKEN,
+  FORM144_RECENT_SALE_REPOSITORY_TOKEN,
 ];
 
 const TABLE_TOKENS: readonly DbStatsTable[] = BUILT_IN_TABLE_TOKENS.map((token) => ({
   table: secTableName(token),
-  token: token as DbStatsTable["token"],
+  token,
 }));
 
 const extensionTableTokens = new Map<string, DbStatsTable>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,12 @@ export { isJsonOutput } from "./cli/isJsonOutput";
 export * from "./cli/output";
 export { runCommand } from "./cli/runCommand";
 export { runWorkflowCli } from "./cli/runWorkflow";
-export { getDbStats, registerDbStatsTables, type DbStatsTable } from "./cli/queries/DbStatus";
+export {
+  getDbStats,
+  registerDbStatsTables,
+  type CountableRepository,
+  type DbStatsTable,
+} from "./cli/queries/DbStatus";
 export { AddCommands } from "./commands";
 
 // ── Config / dependency injection ───────────────────────────────────────────


### PR DESCRIPTION
Two fixes to the fast-count work already on `main` (`87f3151`).

## The estimate never applied to the big tables

The table strings passed to `to_regclass($1)` were display labels, not relation names — `entity` for `entities`, `filing` for `filings`, plus `addresses`, `phones`, `portals`, `investment_offerings`, `person_observations`, `company_observations`. 8 of 24, and the largest ones in the database.

`to_regclass` returns NULL for a name no relation has, so `WHERE relid = to_regclass($1)` matched nothing, `result.rows[0]` was undefined, and the count silently fell back to the exact `SELECT count(*)` the estimate exists to avoid. `db stats` was strictly slower than before the feature landed on precisely the tables it was built for.

Each built-in name is now derived from `SEC_STORAGE_REGISTRY` — the same list `createStorage` builds the tables from — keyed by `token.id`. That removes the hand-written strings rather than correcting them, so a label cannot drift back in, and a token missing from the registry throws instead of degrading quietly. Extension tables registered through `registerDbStatsTables` keep supplying their own name (embarc-data passes the same descriptors `db setup` registers, so those were already correct).

Reported names are now the relations `psql \dt` shows, which is also more useful output than the labels were.

## The token casts were never needed

Every repository token in the two count lists was written `as any` — 30 of them. `ITabularStorage` already declares both `size(): Promise<number>` and `isDurable(): boolean`, and `ServiceToken<T>` holds `T` in a readonly position, so a concrete `ServiceToken<EntityRepositoryStorage>` is assignable to `ServiceToken<CountableRepository>` by structural covariance. The casts were suppressing a check that passes on its own — and would have hidden a genuinely mistyped token, which is the same class of mistake that produced the bug above.

All removed. `DbStatsTable.token` now names `CountableRepository` instead of re-declaring `{ size(): Promise<number> }` inline, so the module has one vocabulary type for "a repository we can count"; it is exported from the barrel so downstream registrants can name it.

## Verification

- New regression test asserts every `db stats` table name exists in the storage registry. It fails on the pre-fix code with `expected [ 'entity', 'filing', …(6) ] to deeply equal []` and passes here.
- `src/cli` + `src/config` + `src/task/db` — 351 passed, 5 skipped, 41 files.
- `tsc --noEmit` clean, declaration emit clean, Prettier clean.
- The Postgres estimate path itself is **not** covered — no Postgres in the dev container — so only the name alignment that gates it is verified automatically. Worth an eyeball on a real deployment to confirm `db stats` drops from full scans to catalog lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sCJvLZjRzfQ8c2epuEmm5