### PR TITLE
fix(db): report n/a for a missing table instead of failing `db stats`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.0.22
+
+### Bug Fixes
+
+#### db
+
+- report `n/a` for a table the database has not created instead of failing the whole `db stats` report; `TableStat.rows` widens to `number | null`
+
 ## 0.0.21
 
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1082,6 +1082,12 @@ sec exposes the general downstream seams embarc-data (and future features) build
   also calls `registerSecResolvers()` so resolver component-version rows seed even
   on the `init` path that skips the CLI preAction hook.
 
+  `registerDbStatsTables` (`src/cli/queries/DbStatus.ts`) is the reporting half
+  of that seam — a superset's tables are counted by `db stats` alongside sec's
+  own — and a registered table the database has not created reports `n/a`
+  (`rows: null`, with a "run `db setup`?" hint) rather than failing the whole
+  report; only a missing relation degrades, every other error still throws.
+
   `db setup` finishes with a **column-alignment pass**
   (`alignPostgresColumnTypes`, run after the extension loop so a superset's
   tables are registered first). `CREATE TABLE IF NOT EXISTS` never alters an

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workglow/sec",
   "type": "module",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "repository": {
     "type": "git",
     "url": "https://github.com/workglow-dev/sec.git"

--- a/src/cli/groups/db.ts
+++ b/src/cli/groups/db.ts
@@ -60,11 +60,21 @@ export function addDbCommands(program: Command): void {
           { key: "rows", header: "Rows", width: 12 },
         ];
 
-        console.log(
-          renderTable(tables as unknown as Record<string, unknown>[], columns, {
-            format: (options.format as "table" | "json") ?? "table",
-          })
-        );
+        const format = (options.format as "table" | "json") ?? "table";
+        // A null count means the relation does not exist yet. JSON keeps the
+        // null (a consumer must be able to tell "not counted" from zero); the
+        // text table would render it as an empty cell, so label it.
+        const rendered =
+          format === "json"
+            ? (tables as unknown as Record<string, unknown>[])
+            : tables.map((stat) => ({ table: stat.table, rows: stat.rows ?? "n/a" }));
+
+        console.log(renderTable(rendered, columns, { format }));
+
+        const missing = tables.filter((stat) => stat.rows === null).length;
+        if (missing > 0 && format !== "json") {
+          console.log(`\n${missing} table(s) not counted (n/a) — run \`db setup\`?`);
+        }
       });
     });
 

--- a/src/cli/queries/DbStatus.test.ts
+++ b/src/cli/queries/DbStatus.test.ts
@@ -1,9 +1,15 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { globalServiceRegistry } from "workglow";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServiceToken, globalServiceRegistry } from "workglow";
 import { SEC_STORAGE_REGISTRY } from "../../config/storageRegistry";
 import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
 import { ENTITY_REPOSITORY_TOKEN } from "../../storage/entity/EntitySchema";
-import { getDbStats, getDbStatus } from "./DbStatus";
+import {
+  getDbStats,
+  getDbStatus,
+  registerDbStatsTables,
+  resetDbStatsTablesForTesting,
+  type CountableRepository,
+} from "./DbStatus";
 
 describe("getDbStatus", () => {
   beforeEach(() => {
@@ -42,9 +48,29 @@ describe("getDbStatus", () => {
   });
 });
 
+/**
+ * Registers a `db stats` extension table whose `size()` always rejects with
+ * `error`, the way a storage does when its relation was never created.
+ */
+function registerFailingExtensionTable(table: string, error: unknown): void {
+  const token = createServiceToken<CountableRepository>(`test.dbstats.${table}`);
+  globalServiceRegistry.registerInstance(token, {
+    size: async (): Promise<number> => {
+      throw error;
+    },
+  });
+  registerDbStatsTables([{ table, token }]);
+}
+
 describe("getDbStats", () => {
   beforeEach(() => {
     resetDependencyInjectionsForTesting();
+  });
+
+  // Registration is process-global: an extension table left registered would
+  // change the report every later assertion in this file reads.
+  afterEach(() => {
+    resetDbStatsTablesForTesting();
   });
 
   it("returns array of table stats", async () => {
@@ -71,6 +97,45 @@ describe("getDbStats", () => {
 
     expect(reported.length).toBeGreaterThan(0);
     expect(reported.filter((table) => !registered.has(table))).toEqual([]);
+  });
+
+  it("reports n/a instead of throwing when a registered extension table is missing", async () => {
+    // A downstream package registers a table, then the report runs against a
+    // database that was set up before that table existed. Losing every other
+    // row count — sec's own included — to one uncreated relation is the bug.
+    registerFailingExtensionTable(
+      "ext_missing",
+      new Error("SQLITE_ERROR: no such table: ext_missing")
+    );
+
+    const stats = await getDbStats();
+    const missing = stats.find((stat) => stat.table === "ext_missing");
+
+    expect(missing).toEqual({ table: "ext_missing", rows: null });
+    const builtIns = stats.filter((stat) => stat.table !== "ext_missing");
+    expect(builtIns.length).toBeGreaterThan(0);
+    expect(builtIns.every((stat) => typeof stat.rows === "number")).toBe(true);
+  });
+
+  it("reports n/a for the Postgres form of a missing relation", async () => {
+    const error = Object.assign(new Error(`relation "ext_missing_pg" does not exist`), {
+      code: "42P01",
+    });
+    registerFailingExtensionTable("ext_missing_pg", error);
+
+    const stats = await getDbStats();
+    expect(stats.find((stat) => stat.table === "ext_missing_pg")?.rows).toBeNull();
+  });
+
+  it("rethrows a failure that is not a missing relation", async () => {
+    // The guard must stay narrow: a database that is down is not a table that
+    // has not been created, and reporting it as `n/a` would hide an outage.
+    registerFailingExtensionTable(
+      "ext_unreachable",
+      new Error("connect ECONNREFUSED 127.0.0.1:5432")
+    );
+
+    await expect(getDbStats()).rejects.toThrow(/ECONNREFUSED/);
   });
 
   it("reports progress through every counted table", async () => {

--- a/src/cli/queries/DbStatus.ts
+++ b/src/cli/queries/DbStatus.ts
@@ -45,7 +45,12 @@ export interface DbStatusResult {
 
 export interface TableStat {
   readonly table: string;
-  readonly rows: number;
+  /**
+   * Row count, or `null` when the relation does not exist yet — a registered
+   * table the database has not been `db setup` for. Every other failure still
+   * throws.
+   */
+  readonly rows: number | null;
 }
 
 /**
@@ -101,6 +106,28 @@ function secTableName(token: ServiceToken<CountableRepository>): string {
   return table;
 }
 
+/** Postgres SQLSTATE for `undefined_table`. */
+const POSTGRES_UNDEFINED_TABLE = "42P01";
+/** `SQLITE_ERROR: no such table: adv_landing_replacement` */
+const SQLITE_MISSING_TABLE = /no such table:/i;
+/** `error: relation "adv_landing_replacement" does not exist` */
+const POSTGRES_MISSING_RELATION = /relation\s+"[^"]*"\s+does not exist/i;
+
+/**
+ * True only for "this relation has not been created", the one failure `db
+ * stats` degrades on — a table registered through {@link registerDbStatsTables}
+ * (or a sec built-in) in a database that has not been `db setup` since it was
+ * added. Deliberately narrow: a connection failure, a permissions error or a
+ * corrupt file must still surface loudly rather than be reported as `n/a`.
+ */
+export function isMissingRelationError(err: unknown): boolean {
+  if (err === null || typeof err !== "object") return false;
+  if ((err as { code?: unknown }).code === POSTGRES_UNDEFINED_TABLE) return true;
+  const message = (err as { message?: unknown }).message;
+  if (typeof message !== "string") return false;
+  return SQLITE_MISSING_TABLE.test(message) || POSTGRES_MISSING_RELATION.test(message);
+}
+
 /**
  * Counts rows through the storage interface. This exact path is used for
  * status metrics and every non-Postgres backend.
@@ -133,6 +160,30 @@ async function countTableRows(
     if (estimated !== undefined) return Number(estimated);
   }
   return await countRows(token);
+}
+
+/**
+ * {@link countTableRows}, degrading to `null` when the relation does not exist.
+ * `db stats` counts tables a downstream package registered as well as sec's
+ * own, and a database set up before one of them was added has no such
+ * relation — counting it must not cost the operator every other row count in
+ * the report. Only a missing relation degrades; every other error rethrows.
+ *
+ * Both backends funnel through here: on Postgres a name no relation has makes
+ * `to_regclass` NULL, the estimate matches no row, and the exact
+ * {@link countRows} call below it raises `42P01`.
+ */
+async function countTableRowsOrNull(
+  table: string,
+  token: ServiceToken<CountableRepository>,
+  exact: boolean
+): Promise<number | null> {
+  try {
+    return await countTableRows(table, token, exact);
+  } catch (err) {
+    if (isMissingRelationError(err)) return null;
+    throw err;
+  }
 }
 
 const STATUS_TABLES: readonly {
@@ -208,8 +259,20 @@ export function registerDbStatsTables(tables: readonly DbStatsTable[]): void {
 }
 
 /**
+ * Clears the extension tables {@link registerDbStatsTables} collected.
+ * Registration is process-global, so a test that registers a table would
+ * otherwise change what every later `db stats` assertion in the same process
+ * sees (the report order, its length, and which table is counted last).
+ */
+export function resetDbStatsTablesForTesting(): void {
+  extensionTableTokens.clear();
+}
+
+/**
  * Counts each table in order so the task runner can render useful progress
- * while a database with many extension tables is being inspected.
+ * while a database with many extension tables is being inspected. A table the
+ * database has not created reports `rows: null` (rendered `n/a`) instead of
+ * failing the whole report — see {@link countTableRowsOrNull}.
  */
 export async function getDbStats(
   onProgress?: (progress: number, message: string) => void | Promise<void>,
@@ -223,7 +286,7 @@ export async function getDbStats(
       Math.round((index / tables.length) * 100),
       `counting ${table} (${current}/${tables.length})`
     );
-    results.push({ table, rows: await countTableRows(table, token, options.exact === true) });
+    results.push({ table, rows: await countTableRowsOrNull(table, token, options.exact === true) });
     await onProgress?.(
       Math.round((current / tables.length) * 100),
       `counted ${table} (${current}/${tables.length})`

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,12 @@ export { runCommand } from "./cli/runCommand";
 export { runWorkflowCli } from "./cli/runWorkflow";
 export {
   getDbStats,
+  isMissingRelationError,
   registerDbStatsTables,
+  resetDbStatsTablesForTesting,
   type CountableRepository,
   type DbStatsTable,
+  type TableStat,
 } from "./cli/queries/DbStatus";
 export { AddCommands } from "./commands";
 

--- a/src/task/db/DbStatsTask.test.ts
+++ b/src/task/db/DbStatsTask.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Value } from "typebox/value";
+import { createServiceToken, globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import {
+  registerDbStatsTables,
+  resetDbStatsTablesForTesting,
+  type CountableRepository,
+} from "../../cli/queries/DbStatus";
+import { DbStatsTask } from "./DbStatsTask";
+
+describe("DbStatsTask", () => {
+  beforeEach(() => resetDependencyInjectionsForTesting());
+  afterEach(() => resetDbStatsTablesForTesting());
+
+  // The declared port schema is what downstream graph wiring reads, so the
+  // degraded (`rows: null`) count has to be part of the contract, not just a
+  // value the execute() happens to return.
+  it("declares the null row count in its output schema", () => {
+    const degraded = { tables: [{ table: "ext_missing", rows: null }] };
+    expect(Value.Check(DbStatsTask.outputSchema(), degraded)).toBe(true);
+    expect(Value.Check(DbStatsTask.outputSchema(), { tables: [{ table: "t", rows: 3 }] })).toBe(
+      true
+    );
+  });
+
+  it("reports a null row count for a table the database has not created", async () => {
+    const token = createServiceToken<CountableRepository>("test.dbstatstask.missing");
+    globalServiceRegistry.registerInstance(token, {
+      size: async (): Promise<number> => {
+        throw new Error("SQLITE_ERROR: no such table: ext_missing");
+      },
+    });
+    registerDbStatsTables([{ table: "ext_missing", token }]);
+
+    const output = await new DbStatsTask().run();
+
+    expect(output.tables.find((stat) => stat.table === "ext_missing")?.rows).toBeNull();
+    expect(Value.Check(DbStatsTask.outputSchema(), output)).toBe(true);
+  });
+});

--- a/src/task/db/DbStatsTask.ts
+++ b/src/task/db/DbStatsTask.ts
@@ -28,7 +28,12 @@ export class DbStatsTask extends Task<DbStatsTaskInput, DbStatsTaskOutput> {
 
   public static outputSchema() {
     return Type.Object({
-      tables: Type.Array(Type.Object({ table: Type.String(), rows: Type.Number() })),
+      // `rows` is null for a registered table the database has not created.
+      // The port schema is the declared contract downstream wiring reads, so
+      // the union belongs here rather than only in `TableStat`.
+      tables: Type.Array(
+        Type.Object({ table: Type.String(), rows: Type.Union([Type.Number(), Type.Null()]) })
+      ),
     });
   }
 


### PR DESCRIPTION
## The failure

`db stats` counts every table a downstream package registered through `registerDbStatsTables` alongside sec's own built-ins, and each count went straight to `globalServiceRegistry.get(token).size()` with no guard (`src/cli/queries/DbStatus.ts`).

Concretely: embarc-data recently added `adv_landing_replacement` to its registered descriptors. Deploy that against a database set up **before** that table existed and run `db stats` before `db setup` — SQLite raises `no such table: adv_landing_replacement`, `DbStatsTask` fails, and the operator loses **every** row count, sec's own included. Postgres behaves identically: `to_regclass` NULLs, the `n_live_tup` estimate matches no row, the code falls through to the same exact count, and Postgres raises `42P01 relation "…" does not exist`.

Note that embarc-data's own sibling command `db stats-ext` already degrades to `n/a` with a "run `db setup`?" hint. The inherited `db stats` did not.

## Why the fix belongs in sec, not embarc-data

sec invites downstream tables in via `registerDbStatsTables` but gave no contract for a table the database has not created yet — and `TableStat.rows` was typed `number`, so a superset literally could not report `n/a` through that seam. Any embarc-side workaround would have to pre-check table existence, which races `db setup`, and it would still leave sec's own tables unguarded for the next superset that registers one. The seam owner has to define the degradation.

## What changed

- **`isMissingRelationError(err)`** (`src/cli/queries/DbStatus.ts`) — recognises exactly two forms: SQLite's `no such table:` and Postgres's `42P01` / `relation "…" does not exist`. Deliberately narrow, so a connection failure, a permissions error, or real corruption still surfaces loudly instead of being laundered into `n/a`.
- **`countTableRowsOrNull`** wraps the existing `countTableRows`, returning `null` on a missing relation and rethrowing everything else. Both backends funnel through it — the Postgres estimate path already NULLs through `to_regclass` and lands on the same exact count — so one guard covers both.
- **`TableStat.rows` widens to `number | null`**, and `DbStatsTask`'s output port schema becomes `Type.Union([Type.Number(), Type.Null()])`.
- **CLI rendering** (`src/cli/groups/db.ts`): the text table renders `n/a` (a null would otherwise be a blank cell, indistinguishable from an empty string) and appends the `stats-ext`-style hint ``N table(s) not counted (n/a) — run `db setup`?``. `--format json` keeps the literal `null`, because a consumer must be able to tell "not counted" from a real zero.
- **`resetDbStatsTablesForTesting()`** is exported: registration is process-global, and a test-registered extension table would otherwise change the report every later assertion in the same process reads (the existing "reports progress through every counted table" test asserts the last counted table is `form144_recent_sales`).
- Version → `0.0.22`, CHANGELOG entry, and one paragraph in the `registerDatabaseExtension` seam section of `CLAUDE.md`.

`db status` is deliberately **unchanged**: it counts only sec's own six built-ins, where a missing table is a broken install rather than a not-yet-created extension table, and its `DbStatusResult` fields stay `number`.

## Shape change for supersets

`TableStat.rows: number | null` and the `DbStatsTask` output port are a public-ish shape change — anything consuming `getDbStats()` or the task output must handle the null (sum with `?? 0`, render `n/a`, etc.). `TableStat`, `isMissingRelationError`, and `resetDbStatsTablesForTesting` are now exported from the barrel so a superset can do that without re-deriving it. **embarc-data should bump its `@workglow/sec` floor to `^0.0.22` once this is released.**

## Tests

`src/cli/queries/DbStatus.test.ts`:
- *reports n/a instead of throwing when a registered extension table is missing* — registers an extension table whose `size()` rejects with the SQLite form; asserts `getDbStats()` **resolves**, the entry is `rows: null`, and sec's built-ins still carry numbers.
- *reports n/a for the Postgres form of a missing relation* — `42P01` / `relation "…" does not exist`.
- *rethrows a failure that is not a missing relation* — `ECONNREFUSED` rejects. This pins the narrowness of the guard.

`src/task/db/DbStatsTask.test.ts` (new) pins the output-port union: a `rows: null` output must satisfy `DbStatsTask.outputSchema()`, checked both directly and on a real degraded run.

## Verified vs not

Run in the worktree after `bun install`:

- `bunx vitest run src/cli/queries/DbStatus.test.ts` — **9 passed**. The two missing-relation tests were confirmed to **fail** with the guard removed. (The `ECONNREFUSED` test also passes pre-fix — nothing was being caught before — it exists to keep the guard narrow, not to reproduce the bug.)
- `bunx vitest run src/task/db/DbStatsTask.test.ts` — **2 passed**; both confirmed to **fail** with the schema reverted to `Type.Number()`.
- `bunx vitest run src/cli/queries src/task/db src/cli/groups` — **151 passed / 23 files** (final green run used `--testTimeout=120000`; an earlier run of the same set had `src/cli/groups/version.test.ts` time out at the default 15s under parallel load — that file passes on its own in ~68s and is untouched by this change).
- `npx tsc --noEmit` — clean.
- `bunx prettier --check` on every file I touched — clean. (`src/task/db/DbStatsTask.ts` and `CLAUDE.md` already fail `prettier --check` on `main`, in regions this PR does not touch; left alone to keep the diff reviewable.)

**Not verified:** no Postgres or SQLite database was available in this environment, so the Postgres `42P01` path and the SQLite `no such table:` path are exercised through injected errors of exactly those shapes, not against a live backend. The rendered CLI output (`n/a` cells and the hint line) was not executed end-to-end — only the data it renders from is tested. There is no repo `lint` script, so no ESLint run.

## Scope

Guard and its plumbing only. The Postgres `n_live_tup` estimate default, `search_path` qualification, `IdentifySpacsTask`, the S-1 extractors, and `ExtractionDeadLetterSchema` are untouched — separate findings with their own plan.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhfGNbddCCJR71UvDw2c7f)_