### PR TITLE
fix(sec): correct estimate reporting, unbounded prune, and silent partial extractions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ The CLI entrypoint is `src/sec.ts` and uses Commander for subcommands (e.g., `./
 
 Source is not shipped in the tarball. `use-source` is a workspace-local `bun link` flow that reads directly from the linked working copy on disk, so consumers using `bun link @workglow/sec` see live source without needing `src` inside `node_modules/@workglow/sec/`. Do not add `src` back to `files` in `package.json` — the `prepack-check` script guards this and CI will fail.
 
-`use-source` does not edit `package.json`. `exports` keeps pointing at `./dist/*`, and the script writes re-export stubs into the gitignored `dist` folder (`dist/index.js` → `src/index.ts`, plus a `dist/sec.js` bin stub so the linked CLI runs live source), so switching modes leaves `git status` clean. `bun run use-dist` removes the stubs — identified by a `@workglow-source-stub` sentinel, so real build output is never deleted — and rebuilds; `--no-build` skips the rebuild. `prepack-check` fails if any stub is still present.
+`use-source` does not edit `package.json`. `exports` keeps pointing at `./dist/*`, and the script writes re-export stubs into the gitignored `dist` folder (`dist/index.js` → `src/index.ts`, plus a `dist/sec.js` bin stub so the linked CLI runs live source), so switching modes leaves `git status` clean. `bun run use-dist` removes the stubs — identified by a `@workglow-source-stub` sentinel, so real build output is never deleted — and rebuilds; `--no-build` skips the rebuild. Finding no stubs is reported but does **not** skip the rebuild: `dist/` is gitignored, so "no stubs" most often means it was deleted, and returning early left the developer with "already in dist mode", no dist at all, and nothing saying why the build never ran. `prepack-check` fails if any stub is still present.
 
 Local Workglow deps: from a libs checkout run `bun run link-all` (and usually `bun run use-source`), then in sec run `bun run link-workglow`. Register this package for consumers with `bun run link`. For the full libs → sec → embarc-data chain, run `bun ./dev-link.ts` from the parent `workglow/` folder (or `bun run dev-link` in libs). Re-run `link-workglow` after any `bun install`.
 
@@ -121,7 +121,10 @@ eligible. Configure the model via `SEC_S1_MODEL` (default `claude-sonnet-5`)
 and an optional confidence floor via `SEC_S1_CONFIDENCE_FLOOR`.
 
 Extraction samples greedily: every call sends `temperature: 0`
-(`SEC_EXTRACTION_TEMPERATURE`, empty value to send no temperature at all).
+(`SEC_EXTRACTION_TEMPERATURE`, empty value to send no temperature at all; a
+malformed or out-of-`[0, 2]` value throws naming the variable rather than
+coercing to `0`, which would read back as "greedy sampling is on" — the opposite
+of what a typo like `0,5` was asking for).
 Extraction is transcription — the answer is already in the filing — and unpinned
 sampling made re-processing ONE filing yield 138/138/109 risk factors whose
 contents differed in all three cases; the two 138-row runs disagreed on *which*
@@ -166,6 +169,17 @@ retryable under the **same** extractor version — `retry-dead-letters` recovers
 once the model/provider is registered, no version bump required
 (`MODEL_ERROR_REASON_CODES` in `ExtractionDeadLetterSchema.ts`). Every other reason
 code stays version-gated (fix the extractor, bump the version, then retry).
+
+The vocabulary is `DEAD_LETTER_REASON_CODES` in
+`ExtractionDeadLetterSchema.ts`: `SECTION_NOT_FOUND`, `MODEL_INVALID_OUTPUT`,
+`MODEL_EMPTY`, `MODEL_RESOLUTION_ERROR`, `LOW_CONFIDENCE_ALL`,
+`PRIMARY_DOC_UNRESOLVED`, `FETCH_ERROR`, `PARSE_ERROR`, `STORE_ERROR`,
+`OVERSIZED_INPUT`, `UNVERIFIED_SOURCE_SPAN`, `SOURCE_SPAN_TOO_LONG`,
+`MIXED_CAPTION_SHAPE`, `NONCE_MISMATCH`. The stored column is a plain string, so
+`DeadLetterInput.reason_code` is typed to that union — a code written but never
+declared used to persist silently (which is how `UNVERIFIED_SOURCE_SPAN` and
+`SOURCE_SPAN_TOO_LONG` were both written for some time without appearing in the
+list an operator reads); adding one is now a compile error until it is declared.
 
 #### Filing-level dead-letters (every form, not just the AI ones)
 
@@ -264,8 +278,17 @@ reporting a vacuous pass), and its help lists only the scorable ones.
 `related-party` and `offering-terms` still have no fixture — `offering-terms` is
 covered instead by `sec eval unit-terms` against the embarc truth set.
 
+The documented default set is cross-provider — `claude-haiku-4-5`,
+`claude-sonnet-5`, `deepseek-v4-flash`, `gemini-3.6-flash` — so a full bare run
+wants **three** keys: `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY` and
+`GEMINI_API_KEY`. A default whose key is absent is **skipped with a warning**
+naming the ids and the missing variables, rather than sweeping into a table half
+full of failed runs presented as if the models had been ranked and lost. An
+explicit `--models` is never filtered: naming an id is a request to run it, and
+a failed run is the honest answer.
+
 ```bash
-sec eval extract                              # default: haiku vs sonnet
+sec eval extract                              # default: haiku, sonnet, deepseek-flash, gemini-flash
 sec eval extract --models "claude-haiku-4-5,onnx-community/Qwen3-4B-Instruct-2507-ONNX"
 sec eval extract --extractor management --format json
 
@@ -613,11 +636,25 @@ is the caption vocabulary, not the grid — which is exactly what the
 That gate runs first and is what keeps the section cheap: a blank-check
 company's compensation section is one sentence stating that no officer has been
 paid, and most registration statements have no compensation section at all.
-Neither is a failure, so neither costs an AI call — and the skip path resolves
-any dead letter a previous version left, so a correctly-behaving filing never
-lingers on the retry worklist. Dead letters are recorded under the `S-1`
-extractor id with section name `Executive Compensation`
+**Neither is a failure**, so neither costs an AI call and **both resolve rather
+than dead-letter** — explicitly: "no section matched" (nothing in `byName` under
+`Executive Compensation`) and "section matched but carries no Summary
+Compensation Table" take the same `markResolved` path, which also clears an
+entry a previous version left, so a correctly-behaving filing never lingers on
+the retry worklist. Recording the no-section case would put an
+`Executive Compensation` entry on the worklist for the majority of all S-1s,
+permanently (only a version bump clears one), burying every genuinely
+triageable entry; the heading-coverage question it would answer is a counting
+question and belongs on a counting surface. Real failures are still recorded
+under the `S-1` extractor id with section name `Executive Compensation`
 (`sec extractor dead-letters S-1`).
+
+The stub-column **position line** is folded onto the officer named above it
+(that row commonly carries a different fiscal year's figures), but only when it
+carries something: a position row with no fiscal year and no money column is
+just the label, and folding it unconditionally emitted a second row per officer
+— same `observation_id`, null year, all-null money — in a table whose contract
+is one row per officer per fiscal year.
 
 The `executive-compensation` entry in `EVAL_EXTRACTORS` ranks the prompt through
 `sec eval extract`, against two golden fixtures: a two-year, three-officer table
@@ -687,9 +724,21 @@ checks the **headline as well as** the `source_span` against the section text: a
 paraphrased or invented caption is worthless even when the span it cites
 verifies, so it is dropped (and, when every row is, dead-lettered
 `UNVERIFIED_SOURCE_SPAN`). A category heading returned as if it were a risk is
-dropped by the same "enforce it, don't trust the prompt" guard the ownership
+caught by the same "enforce it, don't trust the prompt" guard the ownership
 subtotal gets — a heading is verbatim section text, so nothing downstream would
 otherwise stop it becoming a row that reads like a disclosed risk.
+
+That guard is applied to the section's **shape as a whole**, not row by row,
+because the shape heuristic (no sentence-ending punctuation) cannot tell a
+category heading from an Item 105(b) summary bullet. A **homogeneous** section
+is kept intact either way — all bare phrases is a summary list whose "headings"
+ARE the captions; no bare phrases is an ordinary sentence-caption list with
+nothing to drop. A **mixed** section is unanswerable and dead-letters
+`MIXED_CAPTION_SHAPE` (via `MixedRiskCaptionShapeError`) rather than persisting
+a subset: filers are inconsistent about terminal punctuation, so one summary
+bullet ending in a period was enough to make an all-or-nothing filter keep that
+single row and silently drop the other 29 — a partial disclosure recorded as
+complete, exactly what the chunked-section contract exists to prevent.
 
 Risk factors is by far the largest section in an S-1 — 3k to 246k chars across
 the committed fixtures, against 40–57k for the sections that already dominate
@@ -1124,6 +1173,28 @@ sec exposes the general downstream seams embarc-data (and future features) build
   own — and a registered table the database has not created reports `n/a`
   (`rows: null`, with a "run `db setup`?" hint) rather than failing the whole
   report; only a missing relation degrades, every other error still throws.
+
+  **Row counts on Postgres are estimates by default.** `db status` / `db stats`
+  read `pg_stat_user_tables.n_live_tup` rather than scanning, and that statistic
+  is refreshed by ANALYZE/autovacuum, so it lags recent writes. The report says
+  so: `db stats` heads the column `Rows (est.)` and marks each estimated row
+  `(est.)`, `db status` appends `  (estimated)`, both print a footer pointing at
+  `--exact`, and `--format json` carries `estimated` per row (`db stats`) and per
+  result (`db status`). Two things the query gets right that the naive form does
+  not:
+
+  - The relation name is **schema-qualified to `current_schema()`**
+    (`to_regclass(quote_ident(current_schema()) || '.' || quote_ident($1))`,
+    still fully parameterized). Unqualified, `to_regclass('filings')` resolves
+    through `search_path` and on a deployment whose path lists a staging schema
+    first would report the OTHER schema's count under sec's table name — the
+    hazard `resetAllDatabases` already qualifies its drops against.
+  - **A zero estimate falls back to the exact count.** `n_live_tup` is 0 until
+    the first ANALYZE, so right after `sec bootstrap` bulk-loads ~1M `cik_names`
+    the estimate reads 0 — `db status` printed `Entities: 0 / Filings: 0` under a
+    column labelled "Rows", inviting an operator to read a stale statistic as a
+    real count. Zero now means "no statistics yet"; a genuinely empty table pays
+    one cheap `COUNT(*)` for that.
 
   `db setup` finishes with a **column-alignment pass**
   (`alignPostgresColumnTypes`, run after the extension loop so a superset's

--- a/scripts/bunsrc.ts
+++ b/scripts/bunsrc.ts
@@ -44,11 +44,15 @@ async function useSource(): Promise<void> {
 
 async function useDist(build: boolean): Promise<void> {
   const removed = await removeSourceStubs(packageDir);
+  // No stubs is not a reason to skip the rebuild. `dist/` is gitignored, so the
+  // common way to reach this state is having deleted it — and returning early
+  // left the developer with the message "already in dist mode" and no dist at
+  // all, with nothing saying why the build never ran.
   if (removed.length === 0) {
     console.log("No stubs found — already in dist mode.");
-    return;
+  } else {
+    console.log(`Removed ${removed.length} stub(s).`);
   }
-  console.log(`Removed ${removed.length} stub(s).`);
 
   if (!build) {
     console.log("Skipping rebuild (--no-build): dist is missing its entry files until you build.");

--- a/src/cli/groups/db.ts
+++ b/src/cli/groups/db.ts
@@ -8,6 +8,16 @@ import { renderTable } from "../output/TableRenderer";
 import { runCommand } from "../runCommand";
 import { runWorkflowCli } from "../runWorkflow";
 
+/**
+ * Shown whenever a reported count came from Postgres' `n_live_tup` statistic.
+ * The number is not wrong so much as *dated* — it is refreshed by
+ * ANALYZE/autovacuum — so the report has to name it as an estimate and point at
+ * the flag that produces the real thing.
+ */
+const ESTIMATE_FOOTER =
+  "Row counts marked (est.) are PostgreSQL n_live_tup estimates and lag recent writes; " +
+  "re-run with --exact for exact counts.";
+
 export function addDbCommands(program: Command): void {
   const db = program.command("db").description("Database management commands");
 
@@ -34,7 +44,11 @@ export function addDbCommands(program: Command): void {
           return;
         }
 
-        const fmt = (n: number): string => n.toLocaleString();
+        // An estimate lags recent writes, so every metric it produced says so —
+        // reading a stale statistic as a real count is exactly the trap right
+        // after a bulk load.
+        const suffix = status.estimated ? "  (estimated)" : "";
+        const fmt = (n: number): string => `${n.toLocaleString()}${suffix}`;
         console.log("Database Status\n");
         console.log(`  Entities:              ${fmt(status.entityCount)}`);
         console.log(`  Filings:               ${fmt(status.filingCount)}`);
@@ -42,6 +56,7 @@ export function addDbCommands(program: Command): void {
         console.log(`  Processed Submissions: ${fmt(status.processedSubmissions)}`);
         console.log(`  Processed Facts:       ${fmt(status.processedFacts)}`);
         console.log(`  Extractor Runs:        ${fmt(status.extractorRuns)}`);
+        if (status.estimated) console.log(`\n${ESTIMATE_FOOTER}`);
       });
     });
 
@@ -55,25 +70,37 @@ export function addDbCommands(program: Command): void {
           new DbStatsTask({ defaults: { exact: options.exact === true } }),
         ]);
 
+        const anyEstimated = tables.some((stat) => stat.estimated);
         const columns = [
           { key: "table", header: "Table", width: 25 },
-          { key: "rows", header: "Rows", width: 12 },
+          // The header says which kind of number the column holds, so a reader
+          // who skips the footer still cannot mistake an estimate for a count.
+          { key: "rows", header: anyEstimated ? "Rows (est.)" : "Rows", width: 12 },
         ];
 
         const format = (options.format as "table" | "json") ?? "table";
         // A null count means the relation does not exist yet. JSON keeps the
-        // null (a consumer must be able to tell "not counted" from zero); the
-        // text table would render it as an empty cell, so label it.
+        // null (a consumer must be able to tell "not counted" from zero) and the
+        // per-row `estimated` flag; the text table would render the null as an
+        // empty cell, so label it, and mark the estimated rows individually
+        // since a mixed report is the normal case.
         const rendered =
           format === "json"
             ? (tables as unknown as Record<string, unknown>[])
-            : tables.map((stat) => ({ table: stat.table, rows: stat.rows ?? "n/a" }));
+            : tables.map((stat) => ({
+                table: stat.table,
+                rows:
+                  stat.rows === null ? "n/a" : stat.estimated ? `${stat.rows} (est.)` : stat.rows,
+              }));
 
         console.log(renderTable(rendered, columns, { format }));
 
         const missing = tables.filter((stat) => stat.rows === null).length;
         if (missing > 0 && format !== "json") {
           console.log(`\n${missing} table(s) not counted (n/a) — run \`db setup\`?`);
+        }
+        if (anyEstimated && format !== "json") {
+          console.log(`\n${ESTIMATE_FOOTER}`);
         }
       });
     });

--- a/src/cli/groups/eval.ts
+++ b/src/cli/groups/eval.ts
@@ -7,6 +7,7 @@
 import type { Command } from "commander";
 import { runCommand } from "../runCommand";
 import { runWorkflowCli } from "../runWorkflow";
+import { modelApiKeyEnvVar } from "../../config/registerModels";
 import { EVAL_EXTRACTORS } from "../../eval/fixtures";
 import { extractorsWithGoldenLabels } from "../../eval/goldenS1Labels";
 import {
@@ -42,6 +43,39 @@ const DEFAULT_MODELS = [
 ];
 
 /**
+ * The default set restricted to providers this shell actually holds a key for.
+ *
+ * The defaults span three providers, so a bare `sec eval extract` on a machine
+ * with only `ANTHROPIC_API_KEY` set would spend the sweep producing failed runs
+ * for half the table and report them beside the real results as if the models
+ * had been ranked and lost. Dropping them (with a warning that names the ids and
+ * the variables that would bring them back) keeps the documented default list
+ * while making the bare command work wherever it is run.
+ *
+ * Explicit `--models` is never filtered: naming an id is a request to run it,
+ * and a failed run is the honest answer to "why doesn't this work?".
+ */
+function availableDefaultModels(): string[] {
+  const missing = new Map<string, string[]>();
+  const available = DEFAULT_MODELS.filter((id) => {
+    const envVar = modelApiKeyEnvVar(id);
+    if (envVar === undefined || (process.env[envVar] ?? "").trim() !== "") return true;
+    missing.set(envVar, [...(missing.get(envVar) ?? []), id]);
+    return false;
+  });
+  if (missing.size > 0) {
+    const detail = [...missing]
+      .map(([envVar, ids]) => `${ids.join(", ")} (needs ${envVar})`)
+      .join("; ");
+    console.warn(`Skipping default model(s) with no API key configured: ${detail}`);
+  }
+  // Every provider unconfigured is a configuration problem, not a reason to run
+  // an empty sweep and report a vacuous pass: hand back the full list so the
+  // failures name themselves.
+  return available.length > 0 ? available : [...DEFAULT_MODELS];
+}
+
+/**
  * Default candidate for `sec eval s1`: score the cheap cloud model against the
  * reference, the comparison that decides production extraction. Same reasoning
  * as {@link DEFAULT_MODELS} — a local model is opt-in.
@@ -65,7 +99,7 @@ const ORACLE_DEFAULT_CANDIDATE = "claude-haiku-4-5";
 const ORACLE_DEFAULT_REFERENCE = GOLDEN_REFERENCE;
 
 function parseModels(csv: string | undefined): string[] {
-  const ids = (csv ?? DEFAULT_MODELS.join(","))
+  const ids = (csv ?? availableDefaultModels().join(","))
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);

--- a/src/cli/queries/DbStatus.postgres.test.ts
+++ b/src/cli/queries/DbStatus.postgres.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { globalServiceRegistry } from "workglow";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { ENTITY_REPOSITORY_TOKEN } from "../../storage/entity/EntitySchema";
+
+/**
+ * The Postgres estimate path, exercised without a Postgres.
+ *
+ * `resolveSqlBackend` routes an in-memory repository to `"repository"` on
+ * purpose (a fast path would read a different store), so the estimate branch is
+ * unreachable in a normal unit test — the backend decision and the pool are both
+ * stubbed here. They live in their own file because the stubs are module-wide
+ * and would otherwise change every other `DbStatus` assertion.
+ */
+const queries: { text: string; values: unknown[] }[] = [];
+let estimateByTable: (table: string) => string | number | undefined = () => undefined;
+
+vi.mock("../../util/sqlBackend", () => ({
+  resolveSqlBackend: () => "postgres",
+}));
+
+vi.mock("../../util/pg", () => ({
+  getPgPool: () => ({
+    query: async (text: string, values: unknown[]) => {
+      queries.push({ text, values });
+      const estimated_count = estimateByTable(String(values[0]));
+      return { rows: estimated_count === undefined ? [] : [{ estimated_count }] };
+    },
+  }),
+}));
+
+const { getDbStats, getDbStatus } = await import("./DbStatus");
+
+async function seedOneEntity(): Promise<void> {
+  await globalServiceRegistry.get(ENTITY_REPOSITORY_TOKEN).put({
+    cik: 1318605,
+    name: "Tesla, Inc.",
+    type: null,
+    sic: 3711,
+    ein: null,
+    description: null,
+    website: null,
+    investor_website: null,
+    category: null,
+    fiscal_year: null,
+    state_incorporation: "TX",
+    state_incorporation_desc: null,
+  });
+}
+
+describe("the Postgres row-count estimate", () => {
+  beforeEach(() => {
+    resetDependencyInjectionsForTesting();
+    queries.length = 0;
+    estimateByTable = () => undefined;
+  });
+
+  it("qualifies the relation name to current_schema()", async () => {
+    // An unqualified `to_regclass('filings')` resolves through `search_path`, so
+    // on a deployment whose path lists a staging schema first it binds the OTHER
+    // schema's table and reports its count under sec's name.
+    estimateByTable = () => 42;
+    await getDbStatus();
+
+    expect(queries.length).toBeGreaterThan(0);
+    for (const query of queries) {
+      expect(query.text).toContain("current_schema()");
+      // Still parameterized: the table name is a bind value, never interpolated.
+      expect(query.text).toContain("$1");
+      expect(query.values).toHaveLength(1);
+    }
+  });
+
+  it("falls back to the exact count when the estimate is zero", async () => {
+    // `n_live_tup` is 0 until the first ANALYZE, so right after `sec bootstrap`
+    // bulk-loads a table the estimate says 0 for a table with rows in it.
+    await seedOneEntity();
+    estimateByTable = () => 0;
+
+    const status = await getDbStatus();
+    expect(status.entityCount).toBe(1);
+    expect(status.estimated).toBe(false);
+  });
+
+  it("reports a non-zero estimate and marks the result estimated", async () => {
+    await seedOneEntity();
+    estimateByTable = (table) => (table === "entities" ? 1_000_000 : 0);
+
+    const status = await getDbStatus();
+    expect(status.entityCount).toBe(1_000_000);
+    expect(status.estimated).toBe(true);
+    // Every other metric fell back to its exact count.
+    expect(status.filingCount).toBe(0);
+  });
+
+  it("marks only the estimated rows in the per-table report", async () => {
+    await seedOneEntity();
+    estimateByTable = (table) => (table === "entities" ? 1_000_000 : 0);
+
+    const stats = await getDbStats();
+    expect(stats.find((stat) => stat.table === "entities")).toEqual({
+      table: "entities",
+      rows: 1_000_000,
+      estimated: true,
+    });
+    expect(stats.find((stat) => stat.table === "filings")).toEqual({
+      table: "filings",
+      rows: 0,
+      estimated: false,
+    });
+  });
+
+  it("uses the exact count for every table under --exact", async () => {
+    await seedOneEntity();
+    estimateByTable = () => 1_000_000;
+
+    const status = await getDbStatus({ exact: true });
+    expect(status.entityCount).toBe(1);
+    expect(status.estimated).toBe(false);
+    expect(queries).toHaveLength(0);
+  });
+});

--- a/src/cli/queries/DbStatus.test.ts
+++ b/src/cli/queries/DbStatus.test.ts
@@ -111,7 +111,7 @@ describe("getDbStats", () => {
     const stats = await getDbStats();
     const missing = stats.find((stat) => stat.table === "ext_missing");
 
-    expect(missing).toEqual({ table: "ext_missing", rows: null });
+    expect(missing).toEqual({ table: "ext_missing", rows: null, estimated: false });
     const builtIns = stats.filter((stat) => stat.table !== "ext_missing");
     expect(builtIns.length).toBeGreaterThan(0);
     expect(builtIns.every((stat) => typeof stat.rows === "number")).toBe(true);

--- a/src/cli/queries/DbStatus.ts
+++ b/src/cli/queries/DbStatus.ts
@@ -34,13 +34,24 @@ import { CANONICAL_COMPANY_REPOSITORY_TOKEN } from "../../storage/canonical/Cano
 import { PERSON_IDENTITY_LINK_REPOSITORY_TOKEN } from "../../storage/canonical/PersonIdentityLinkSchema";
 import { COMPANY_IDENTITY_LINK_REPOSITORY_TOKEN } from "../../storage/canonical/CompanyIdentityLinkSchema";
 
-export interface DbStatusResult {
+/** The headline counts, without the reporting metadata beside them. */
+export interface DbStatusCounts {
   readonly entityCount: number;
   readonly filingCount: number;
   readonly factsCount: number;
   readonly processedSubmissions: number;
   readonly processedFacts: number;
   readonly extractorRuns: number;
+}
+
+export interface DbStatusResult extends DbStatusCounts {
+  /**
+   * True when ANY of the counts above is a Postgres `n_live_tup` estimate
+   * rather than an exact count. The estimate lags recent writes, so a report
+   * that does not say which number it is showing invites an operator to read a
+   * stale statistic as a real count.
+   */
+  readonly estimated: boolean;
 }
 
 export interface TableStat {
@@ -51,6 +62,14 @@ export interface TableStat {
    * throws.
    */
   readonly rows: number | null;
+  /** True when `rows` is a Postgres `n_live_tup` estimate, not an exact count. */
+  readonly estimated: boolean;
+}
+
+/** A count paired with whether it came from the Postgres catalog estimate. */
+interface CountedRows {
+  readonly rows: number;
+  readonly estimated: boolean;
 }
 
 /**
@@ -142,24 +161,42 @@ async function countRows(token: ServiceToken<CountableRepository>): Promise<numb
  * and non-durable test repositories use the exact storage-level count.
  * PostgreSQL updates this statistic through ANALYZE/autovacuum, so it can lag
  * recent writes and must not be used where an exact cardinality is required.
+ *
+ * Two things the naive form of this query gets wrong:
+ *
+ * - **An unqualified name resolves through `search_path`.** `to_regclass
+ *   ('filings')` binds whichever schema comes first on the session's
+ *   `search_path`, so a deployment whose path lists a staging schema ahead of
+ *   sec's would report the OTHER schema's row count under sec's table name.
+ *   The name is qualified to `current_schema()` for the same reason
+ *   `resetAllDatabases` qualifies its drops. `quote_ident` keeps it
+ *   parameterized — the table name stays a bind value, never interpolated SQL.
+ * - **A zero estimate is almost never a real zero.** `n_live_tup` is 0 until
+ *   the first ANALYZE, so right after `sec bootstrap` bulk-loads ~1M
+ *   `cik_names` and before autovacuum catches up, the estimate reports 0 for a
+ *   table with a million rows. Zero therefore means "no statistics yet" and
+ *   falls back to the exact count; a genuinely empty table pays one cheap
+ *   `COUNT(*)` for that.
  */
 async function countTableRows(
   table: string,
   token: ServiceToken<CountableRepository>,
   exact = false
-): Promise<number> {
+): Promise<CountedRows> {
   const repo = globalServiceRegistry.get(token);
   if (!exact && resolveSqlBackend("read", repo) === "postgres") {
     const result = await getPgPool().query<{ estimated_count: string | number }>(
       `SELECT n_live_tup::bigint AS estimated_count
        FROM pg_stat_user_tables
-       WHERE relid = to_regclass($1)`,
+       WHERE relid = to_regclass(quote_ident(current_schema()) || '.' || quote_ident($1))`,
       [table]
     );
     const estimated = result.rows[0]?.estimated_count;
-    if (estimated !== undefined) return Number(estimated);
+    if (estimated !== undefined && Number(estimated) > 0) {
+      return { rows: Number(estimated), estimated: true };
+    }
   }
-  return await countRows(token);
+  return { rows: await countRows(token), estimated: false };
 }
 
 /**
@@ -177,7 +214,7 @@ async function countTableRowsOrNull(
   table: string,
   token: ServiceToken<CountableRepository>,
   exact: boolean
-): Promise<number | null> {
+): Promise<CountedRows | null> {
   try {
     return await countTableRows(table, token, exact);
   } catch (err) {
@@ -187,7 +224,7 @@ async function countTableRowsOrNull(
 }
 
 const STATUS_TABLES: readonly {
-  readonly key: keyof DbStatusResult;
+  readonly key: keyof DbStatusCounts;
   readonly token: ServiceToken<CountableRepository>;
 }[] = [
   { key: "entityCount", token: ENTITY_REPOSITORY_TOKEN },
@@ -199,11 +236,14 @@ const STATUS_TABLES: readonly {
 ];
 
 export async function getDbStatus(options: DbCountOptions = {}): Promise<DbStatusResult> {
-  const result = {} as Record<keyof DbStatusResult, number>;
+  const counts = {} as Record<keyof DbStatusCounts, number>;
+  let estimated = false;
   for (const { key, token } of STATUS_TABLES) {
-    result[key] = await countTableRows(secTableName(token), token, options.exact === true);
+    const counted = await countTableRows(secTableName(token), token, options.exact === true);
+    counts[key] = counted.rows;
+    estimated ||= counted.estimated;
   }
-  return result;
+  return { ...counts, estimated };
 }
 
 /**
@@ -286,7 +326,12 @@ export async function getDbStats(
       Math.round((index / tables.length) * 100),
       `counting ${table} (${current}/${tables.length})`
     );
-    results.push({ table, rows: await countTableRowsOrNull(table, token, options.exact === true) });
+    const counted = await countTableRowsOrNull(table, token, options.exact === true);
+    results.push({
+      table,
+      rows: counted?.rows ?? null,
+      estimated: counted?.estimated ?? false,
+    });
     await onProgress?.(
       Math.round((current / tables.length) * 100),
       `counted ${table} (${current}/${tables.length})`

--- a/src/config/registerModels.ts
+++ b/src/config/registerModels.ts
@@ -474,6 +474,25 @@ export function trySecModelRecord(modelId: string): ModelRecord | undefined {
 }
 
 /**
+ * The API-key environment variable a model id's provider needs, or `undefined`
+ * for a local provider (GGUF / HFT ONNX) and for an id whose shape matches no
+ * known provider.
+ *
+ * Dispatches on the same id shapes as {@link trySecModelRecord} — a caller that
+ * wants to know "can this id actually run here?" before spending a sweep on it
+ * would otherwise have to duplicate that table and let the two drift.
+ */
+export function modelApiKeyEnvVar(modelId: string): string | undefined {
+  if (isLlamaCppModelId(modelId) || isHftModelId(modelId)) return undefined;
+  if (isAnthropicModelId(modelId)) return "ANTHROPIC_API_KEY";
+  if (isOpenAiModelId(modelId)) return "OPENAI_API_KEY";
+  if (isGeminiModelId(modelId)) return "GEMINI_API_KEY";
+  if (isXaiModelId(modelId)) return "XAI_API_KEY";
+  if (isDeepSeekModelId(modelId)) return "DEEPSEEK_API_KEY";
+  return undefined;
+}
+
+/**
  * Builds a provider-appropriate {@link ModelRecord} for a model id, dispatching
  * on id shape: a `gguf:` id → node-llama-cpp (local GGUF), a HuggingFace
  * `org/name` id → HFT ONNX (local), a `claude-*` id → Anthropic, a `gpt-*`/`o*`

--- a/src/eval/fingerprintRows.test.ts
+++ b/src/eval/fingerprintRows.test.ts
@@ -43,6 +43,27 @@ describe("fingerprintRows", () => {
     expect(fingerprintRows(a, false)).not.toBe(fingerprintRows(b, false));
   });
 
+  it("produces the same digest under a different collation", () => {
+    // `localeCompare` sorts by the runtime's ICU collation, so the same rows
+    // would digest differently on two differently-configured machines and a
+    // stability report compared across them would show disagreement that is not
+    // there. Standing in a different collation must not move the digest.
+    const rows = [row("Jane Roe", "Jane"), { Alpha: 1, alpha: 2, beta: 3, Beta: 4 }];
+    const expected = fingerprintRows(rows);
+
+    const original = String.prototype.localeCompare;
+    // eslint-disable-next-line no-extend-native
+    String.prototype.localeCompare = function reversed(this: string, that: string): number {
+      return original.call(that, this);
+    };
+    try {
+      expect(fingerprintRows(rows)).toBe(expected);
+    } finally {
+      // eslint-disable-next-line no-extend-native
+      String.prototype.localeCompare = original;
+    }
+  });
+
   it("does not collapse a confidence drift into the content digest", () => {
     const a = [row("Jane Roe", "Jane", 0.9)];
     const b = [row("Jane Roe", "Jane", 0.7)];

--- a/src/eval/fingerprintRows.ts
+++ b/src/eval/fingerprintRows.ts
@@ -25,7 +25,11 @@ function canonicalize(value: unknown, includeCitations: boolean): unknown {
   if (value === null || typeof value !== "object") return value;
   const entries = Object.entries(value as Record<string, unknown>)
     .filter(([k]) => includeCitations || !CITATION_FIELDS.has(k))
-    .sort(([a], [b]) => a.localeCompare(b))
+    // Code-unit order, not `localeCompare`: the latter sorts by the runtime's
+    // ICU collation, so the same rows would digest differently on two
+    // differently-configured machines and a stability report compared across
+    // them would show disagreement that is not there.
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([k, v]) => [k, canonicalize(v, includeCitations)] as const);
   return Object.fromEntries(entries);
 }

--- a/src/sec/forms/registration-statements/Form_424.storage.ts
+++ b/src/sec/forms/registration-statements/Form_424.storage.ts
@@ -8,6 +8,7 @@ import { globalServiceRegistry, type IExecuteContext, type ModelConfig } from "w
 import { prefetchModel } from "../../../task/model/EnsureModelDownloadedTask";
 import { buildEntityObserver } from "../../../resolver/buildEntityObserver";
 import { ExtractionDeadLetterRepo } from "../../../storage/dead-letter/ExtractionDeadLetterRepo";
+import type { DeadLetterReasonCode } from "../../../storage/dead-letter/ExtractionDeadLetterSchema";
 import { ObservationProvenanceRepo } from "../../../storage/provenance/ObservationProvenanceRepo";
 import { IssuerTickerRepo } from "../../../storage/offering/IssuerTickerRepo";
 import { SpacUnitTermsRepo } from "../../../storage/offering/SpacUnitTermsRepo";
@@ -113,7 +114,7 @@ export async function processForm424(args: ProcessForm424Args): Promise<void> {
   const isSpac = form424.header?.sic === 6770;
 
   const deadLetters = new ExtractionDeadLetterRepo();
-  const recordFail = (section: string, reason: string, detail: string | null) =>
+  const recordFail = (section: string, reason: DeadLetterReasonCode, detail: string | null) =>
     deadLetters.record({
       extractor_id: EXTRACTOR_ID,
       accession_number,

--- a/src/sec/forms/registration-statements/Form_S_1.storage.compensation.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.compensation.test.ts
@@ -208,4 +208,40 @@ describe("processFormS1 executive compensation", () => {
     const pending = await new ExtractionDeadLetterRepo().listPending("S-1");
     expect(pending.map((d) => d.section_name)).not.toContain("Executive Compensation");
   });
+
+  it("leaves no dead letter — and resolves a prior one — when there is no compensation section at all", async () => {
+    // Most registration statements have no compensation section. Dead-lettering
+    // that would put an `Executive Compensation` entry on the retry worklist for
+    // the majority of all S-1s, permanently, burying every triageable entry.
+    const deadLetters = new ExtractionDeadLetterRepo();
+    await deadLetters.record({
+      extractor_id: "S-1",
+      accession_number: "acc-comp-6",
+      section_name: "Executive Compensation",
+      reason_code: "SECTION_NOT_FOUND",
+      detail: "recorded by a previous extractor version",
+      failed_extractor_version: "0.9.0",
+      source_run_id: null,
+    });
+
+    const { calls, unregister } = registerFakeStructuredProvider([MANAGEMENT_PAYLOAD]);
+    cleanup = unregister;
+
+    await run(
+      [
+        "<h1>MANAGEMENT</h1>",
+        "<p>Alina Kowalczyk — Chief Executive Officer</p>",
+        "<h1>LEGAL MATTERS</h1><p>x</p>",
+      ].join(""),
+      "acc-comp-6"
+    );
+
+    expect(await new ExecutiveCompensationRepo().queryByAccession("acc-comp-6")).toEqual([]);
+    expect(calls.some((p) => /SUMMARY COMPENSATION TABLE/.test(p))).toBe(false);
+    const pending = await deadLetters.listPending("S-1");
+    expect(pending.map((d) => d.section_name)).not.toContain("Executive Compensation");
+    expect((await deadLetters.get("S-1", "acc-comp-6", "Executive Compensation"))?.status).toBe(
+      "resolved"
+    );
+  });
 });

--- a/src/sec/forms/registration-statements/Form_S_1.storage.riskfactors.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.riskfactors.test.ts
@@ -134,6 +134,29 @@ describe("processFormS1 risk factors", () => {
     expect(entry?.status).toBe("pending");
   });
 
+  it("records MIXED_CAPTION_SHAPE and persists no rows for a mixed section", async () => {
+    // One caption ends in a period and one does not. Neither shape can be
+    // trusted as the discriminator, so the old all-or-nothing filter would have
+    // kept the punctuated row alone and written it as the filing's complete
+    // risk disclosure. Nothing is persisted and the section dead-letters.
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        risks: [
+          { headline: CATEGORY, category: null, confidence: 0.9, source_span: CATEGORY },
+          { headline: FIRST, category: CATEGORY, confidence: 0.9, source_span: FIRST },
+        ],
+      },
+    ]);
+    cleanup = unregister;
+
+    await runS1();
+
+    expect(await new RiskFactorRepo().queryByAccession(ACCESSION)).toHaveLength(0);
+    const entry = await new ExtractionDeadLetterRepo().get("S-1", ACCESSION, "risk-factors");
+    expect(entry?.reason_code).toBe("MIXED_CAPTION_SHAPE");
+    expect(entry?.status).toBe("pending");
+  });
+
   it("dead-letters SECTION_NOT_FOUND when the filing has no risk factors section", async () => {
     const { unregister } = registerFakeStructuredProvider([{ risks: [] }]);
     cleanup = unregister;

--- a/src/sec/forms/registration-statements/Form_S_1.storage.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.test.ts
@@ -127,11 +127,12 @@ describe("processFormS1", () => {
     expect(tx[0].amount).toBe(120000);
 
     const dl = await new ExtractionDeadLetterRepo().listPending("S-1");
-    // The Offering / Underwriting / Use of Proceeds / Risk Factors / Executive
-    // Compensation headings are absent from this fixture, so those sections
-    // dead-letter SECTION_NOT_FOUND.
+    // The Offering / Underwriting / Use of Proceeds / Risk Factors headings are
+    // absent from this fixture, so those sections dead-letter SECTION_NOT_FOUND.
+    // Executive Compensation is deliberately NOT among them: most registration
+    // statements have no compensation section, so recording one would put an
+    // entry on the retry worklist for the majority of all S-1s, permanently.
     expect(dl.map((d) => d.section_name).sort()).toEqual([
-      "Executive Compensation",
       "offering-terms",
       "risk-factors",
       "underwriters",

--- a/src/sec/forms/registration-statements/Form_S_1.storage.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.ts
@@ -18,6 +18,7 @@ import { RelatedPartyTransactionRepo } from "../../../storage/related-party/Rela
 import { RelatedPartyTransactionSchema } from "../../../storage/related-party/RelatedPartyTransactionSchema";
 import { assertWithinDeclaredBounds } from "../../../util/declaredBounds";
 import { ExtractionDeadLetterRepo } from "../../../storage/dead-letter/ExtractionDeadLetterRepo";
+import type { DeadLetterReasonCode } from "../../../storage/dead-letter/ExtractionDeadLetterSchema";
 import { RiskFactorRepo } from "../../../storage/risk-factor/RiskFactorRepo";
 import { S1ClassificationRepo } from "../../../storage/classification/S1ClassificationRepo";
 import { CanonicalSponsorFamilyRepo } from "../../../storage/canonical/CanonicalSponsorFamilyRepo";
@@ -223,7 +224,7 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
     spac_sic: headerSic,
   };
 
-  const recordFail = (section: string, reason: string, detail: string | null) =>
+  const recordFail = (section: string, reason: DeadLetterReasonCode, detail: string | null) =>
     deadLetters.record({
       extractor_id: EXTRACTOR_ID,
       accession_number,
@@ -683,25 +684,24 @@ export async function processFormS1(args: ProcessFormS1Args): Promise<void> {
   // --- Executive compensation (the Item 402 Summary Compensation Table) ---
   // Gated on a deterministic check for the table's mandated captions, which
   // keeps the section cheap: a blank-check company's compensation section is a
-  // single sentence stating that no officer or director has been paid. That is
-  // not a failure, so it costs no AI call and leaves no permanent dead letter —
-  // and resolving on the skip keeps a filing that a previous version
-  // dead-lettered from lingering on the version-gated retry worklist
-  // (markResolved no-ops when none exists).
+  // single sentence stating that no officer or director has been paid, and most
+  // registration statements carry no compensation section at all. NEITHER is a
+  // failure, so neither costs an AI call and neither leaves a dead letter —
+  // both resolve, which also clears an entry a previous version left behind so
+  // a correctly-behaving filing never lingers on the version-gated retry
+  // worklist (markResolved no-ops when none exists).
   //
-  // No matched section at all is a different outcome, and is recorded as
-  // SECTION_NOT_FOUND like every other section: the heading patterns are the
-  // only thing standing between a real Item 402 disclosure and this extractor,
-  // so a filing whose compensation section is headed in a spelling they miss
-  // (e.g. "Compensation Discussion and Analysis") must show up as a coverage
-  // hole to be triaged, not as a clean run that found nothing.
+  // "No section matched" therefore does not dead-letter, unlike the other
+  // sections. It would put an `Executive Compensation` entry on
+  // `sec extractor dead-letters S-1` for the MAJORITY of all S-1s, permanently
+  // (only a version bump clears one), burying every genuinely triageable entry.
+  // The heading-coverage question that motivates recording it — is a real Item
+  // 402 disclosure being missed by a spelling the patterns do not know? — is a
+  // counting question, and belongs on a counting surface rather than on the
+  // retry worklist.
   const compensationText = byName.get(S1_SECTIONS.EXECUTIVE_COMPENSATION);
   if (compensationText === undefined || compensationText.trim() === "") {
-    await recordFail(
-      S1_SECTIONS.EXECUTIVE_COMPENSATION,
-      "SECTION_NOT_FOUND",
-      "no executive compensation section text"
-    );
+    await recordOk(S1_SECTIONS.EXECUTIVE_COMPENSATION);
   } else if (!hasSummaryCompensationTable(compensationText)) {
     await recordOk(S1_SECTIONS.EXECUTIVE_COMPENSATION);
   } else {

--- a/src/sec/forms/registration-statements/s1/extractExecutiveCompensation.test.ts
+++ b/src/sec/forms/registration-statements/s1/extractExecutiveCompensation.test.ts
@@ -81,6 +81,60 @@ describe("extractExecutiveCompensation", () => {
     expect(rows[1].principal_position).toBe("Chief Executive Officer");
   });
 
+  it("drops a position line carrying no year and no money instead of folding it", async () => {
+    // The COMMON layout: every figure sits on the name row and the position row
+    // below it holds nothing but the label. Folding it unconditionally emitted a
+    // second row per officer — same observation, null fiscal year, all-null
+    // money columns — a phantom in a table whose contract is one row per officer
+    // per fiscal year.
+    const empty = {
+      fiscal_year: null,
+      salary: null,
+      bonus: null,
+      stock_awards: null,
+      option_awards: null,
+      non_equity_incentive: null,
+      pension_and_nqdc: null,
+      all_other_compensation: null,
+      total: null,
+    };
+    const { unregister } = registerFakeStructuredProvider([
+      { rows: [row({}), row({ person_name: "Chief Executive Officer", ...empty })] },
+    ]);
+    cleanup = unregister;
+    const rows = await extractExecutiveCompensation("Summary Compensation Table", fakeS1Model());
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ person_name: "Alina Kowalczyk", fiscal_year: 2025 });
+  });
+
+  it("still folds a position line whose only datum is a money column", async () => {
+    // The guard keys on "carries nothing", not on "has a year" — a position row
+    // with a figure but no year is real disclosure and must survive.
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        rows: [
+          row({}),
+          row({
+            person_name: "Chief Executive Officer",
+            fiscal_year: null,
+            salary: 570000,
+            bonus: null,
+            stock_awards: null,
+            option_awards: null,
+            non_equity_incentive: null,
+            pension_and_nqdc: null,
+            all_other_compensation: null,
+            total: null,
+          }),
+        ],
+      },
+    ]);
+    cleanup = unregister;
+    const rows = await extractExecutiveCompensation("Summary Compensation Table", fakeS1Model());
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toMatchObject({ person_name: "Alina Kowalczyk", salary: 570000 });
+  });
+
   it("drops a position line with no officer above it to attach to", async () => {
     // Nothing to fold onto, and it must not become a person in its own right.
     const { unregister } = registerFakeStructuredProvider([

--- a/src/sec/forms/registration-statements/s1/extractRiskFactors.test.ts
+++ b/src/sec/forms/registration-statements/s1/extractRiskFactors.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
-import { extractRiskFactors } from "./sectionExtractors";
+import { extractRiskFactors, MixedRiskCaptionShapeError } from "./sectionExtractors";
 import { RISK_FACTOR_CHUNK_CHARS } from "./riskFactorChunks";
 import { fakeS1Model, registerFakeStructuredProvider } from "./testing/fakeStructuredProvider";
 
@@ -79,13 +79,60 @@ describe("extractRiskFactors", () => {
     expect(rows).toHaveLength(1);
   });
 
-  it("drops a category heading the model returned as if it were a risk", async () => {
+  it("fails the section when the model mixes a category heading in with real captions", async () => {
+    // The heading is not a risk, but nothing in its SHAPE separates it from a
+    // summary bullet — so dropping it is only safe when the whole section is
+    // sentence captions. A mixed response is unanswerable and dead-letters.
     const { unregister } = registerFakeStructuredProvider([
       { risks: [risk(CATEGORY, null), risk("Our securities may be delisted.")] },
     ]);
     cleanup = unregister;
-    const rows = await extractRiskFactors(`${CATEGORY}\n\nBody.`, fakeS1Model());
-    expect(rows.map((r) => r.headline)).toEqual(["Our securities may be delisted."]);
+    await expect(extractRiskFactors(`${CATEGORY}\n\nBody.`, fakeS1Model())).rejects.toThrow(
+      MixedRiskCaptionShapeError
+    );
+  });
+
+  it("dead-letters a mixed section rather than persisting the one punctuated caption", async () => {
+    // The regression the shape rule exists for. A real Item 105(b) summary list
+    // whose filer punctuated exactly ONE of 30 bullets: the old all-or-nothing
+    // filter kept that single row and dropped the other 29, persisting one
+    // caption as if it were the filing's complete risk disclosure.
+    const bare = Array.from(
+      { length: 29 },
+      (_, i) => `Risks related to our business and operations number ${i + 1}`
+    );
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        risks: [
+          ...bare.map((bullet) => risk(bullet, null)),
+          risk("Risks related to our securities and the trust account.", null),
+        ],
+      },
+    ]);
+    cleanup = unregister;
+
+    await expect(
+      extractRiskFactors(`Summary of Risk Factors\n\n${bare.join("\n\n")}`, fakeS1Model())
+    ).rejects.toThrow(MixedRiskCaptionShapeError);
+  });
+
+  it("keeps every bullet of an all-bare-phrase summary list", async () => {
+    // The preserved case, pinned beside the mixed one: 30 in, 30 out. Nothing
+    // about the new rule may narrow a homogeneous summary list.
+    const bullets = Array.from(
+      { length: 30 },
+      (_, i) => `Risks related to our business and operations number ${i + 1}`
+    );
+    const { unregister } = registerFakeStructuredProvider([
+      { risks: bullets.map((bullet) => risk(bullet, null)) },
+    ]);
+    cleanup = unregister;
+
+    const rows = await extractRiskFactors(
+      `Summary of Risk Factors\n\n${bullets.join("\n\n")}`,
+      fakeS1Model()
+    );
+    expect(rows.map((r) => r.headline)).toEqual(bullets);
   });
 
   it("keeps bare-phrase captions when the whole section is a summary bullet list", async () => {

--- a/src/sec/forms/registration-statements/s1/extractionTemperature.test.ts
+++ b/src/sec/forms/registration-statements/s1/extractionTemperature.test.ts
@@ -32,8 +32,27 @@ describe("getExtractionTemperature", () => {
     expect(getExtractionTemperature()).toBeUndefined();
   });
 
-  it("falls back to greedy on a non-numeric value rather than sending NaN", () => {
+  it("throws on a malformed value rather than silently reading it as greedy", () => {
+    // Coercing to 0 would report exactly the setting the operator did NOT ask
+    // for — "greedy sampling is on" — with nothing saying the value was
+    // discarded. A decimal comma is the realistic typo.
+    process.env[KEY] = "0,5";
+    expect(() => getExtractionTemperature()).toThrow(/SEC_EXTRACTION_TEMPERATURE/);
     process.env[KEY] = "warm";
+    expect(() => getExtractionTemperature()).toThrow(/SEC_EXTRACTION_TEMPERATURE/);
+  });
+
+  it("rejects a temperature outside the [0, 2] sampling range", () => {
+    process.env[KEY] = "5";
+    expect(() => getExtractionTemperature()).toThrow(/out of range/);
+    process.env[KEY] = "-1";
+    expect(() => getExtractionTemperature()).toThrow(/out of range/);
+  });
+
+  it("accepts the range bounds", () => {
+    process.env[KEY] = "2";
+    expect(getExtractionTemperature()).toBe(2);
+    process.env[KEY] = "0";
     expect(getExtractionTemperature()).toBe(0);
   });
 });

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.ts
@@ -7,6 +7,7 @@
 import type { IExecuteContext, ModelConfig } from "workglow";
 import { StructuredGenerationTask } from "workglow";
 import { createHash } from "node:crypto";
+import { SecCliConfigurationError } from "../../../../config/EnvToDI";
 import { ensureModelDownloaded } from "../../../../task/model/EnsureModelDownloadedTask";
 import { resolveModelId } from "./s1Model";
 import { MIN_SPAN_CAP_CHARS } from "./verifySourceSpan";
@@ -79,6 +80,36 @@ export class NonceMismatchError extends Error {
 }
 
 /**
+ * Thrown when a risk-factors response mixes rows shaped like captions with rows
+ * shaped like category headings, so the shape heuristic cannot tell which kind
+ * the section is made of.
+ *
+ * The two populations are individually recognizable but not separable: a real
+ * Item 105 caption is a sentence, and an Item 105(b) summary bullet is a bare
+ * phrase indistinguishable in shape from a category heading. Dropping the
+ * heading-shaped rows would silently reduce a 30-bullet summary list to the one
+ * bullet that happened to end in a period — a partial disclosure persisted as
+ * if it were complete, which is precisely what the chunked-section contract
+ * exists to prevent. Failing the section instead puts it on the retry worklist
+ * where a human can look at it.
+ *
+ * {@link makeRunSection} records it under the `MIXED_CAPTION_SHAPE` reason code.
+ */
+export class MixedRiskCaptionShapeError extends Error {
+  constructor(
+    readonly headingLike: number,
+    readonly total: number
+  ) {
+    super(
+      `Risk-factor rows mix caption and category-heading shapes: ${headingLike} of ${total} rows ` +
+        `have no sentence-ending punctuation. The section cannot be separated on shape alone ` +
+        `without silently dropping either real captions or real risks.`
+    );
+    this.name = "MixedRiskCaptionShapeError";
+  }
+}
+
+/**
  * Sampling temperature for every extraction call. Defaults to 0 (greedy).
  *
  * Extraction is a transcription task, not a generative one — the answer is
@@ -91,13 +122,31 @@ export class NonceMismatchError extends Error {
  *
  * `SEC_EXTRACTION_TEMPERATURE` overrides it; an empty value omits the parameter
  * altogether.
+ *
+ * A malformed or out-of-range value throws rather than degrading. Coercing
+ * `"0,5"` to `0` reads back as "greedy sampling is on" — the operator sees
+ * exactly the behavior they asked for the opposite of, with nothing anywhere
+ * saying the setting was ignored. The whole point of the variable is to control
+ * determinism, so silently discarding it is the one failure mode it must not
+ * have.
  */
 export function getExtractionTemperature(): number | undefined {
   const raw = process.env.SEC_EXTRACTION_TEMPERATURE;
   if (raw === undefined) return 0;
   if (raw.trim() === "") return undefined;
   const n = Number(raw);
-  return Number.isFinite(n) ? n : 0;
+  if (!Number.isFinite(n)) {
+    throw new SecCliConfigurationError(
+      `SEC_EXTRACTION_TEMPERATURE is not a number: ${JSON.stringify(raw)}. ` +
+        `Set a value in [0, 2], or set it empty to omit the parameter entirely.`
+    );
+  }
+  if (n < 0 || n > 2) {
+    throw new SecCliConfigurationError(
+      `SEC_EXTRACTION_TEMPERATURE is out of range: ${n}. Sampling temperature must be in [0, 2].`
+    );
+  }
+  return n;
 }
 
 /**
@@ -811,6 +860,22 @@ export function normalizeFiscalYear(year: number | null | undefined): number | n
   return y >= 1900 && y <= 2100 ? y : null;
 }
 
+/**
+ * The Summary Compensation Table's money columns. A stub-column position row
+ * that carries none of them (and no fiscal year) is a label, not a second
+ * disclosed year — see the fold in {@link extractExecutiveCompensation}.
+ */
+const COMP_MONEY_FIELDS = [
+  "salary",
+  "bonus",
+  "stock_awards",
+  "option_awards",
+  "non_equity_incentive",
+  "pension_and_nqdc",
+  "all_other_compensation",
+  "total",
+] as const satisfies readonly (keyof ExecutiveCompensationRow)[];
+
 /** Matches `executive_compensation.principal_position`'s declared width. */
 const MAX_POSITION_CHARS = 256;
 
@@ -882,6 +947,12 @@ export async function extractExecutiveCompensation(
   // folded onto the officer named above instead — its own year and money columns
   // kept, its label becoming the position for that year. A position row with no
   // officer above it has nothing to attach to and is dropped.
+  //
+  // Folded only when it actually carries data. The common layout puts every
+  // figure on the NAME row and leaves the position row holding nothing but the
+  // label, so folding unconditionally would emit a second row per officer with
+  // the same observation, a null fiscal year and all-null money columns — a
+  // phantom in a table whose contract is one row per officer per fiscal year.
   const out: ExecutiveCompensationRow[] = [];
   let precedingOfficer: string | undefined;
   for (const row of rows) {
@@ -889,10 +960,12 @@ export async function extractExecutiveCompensation(
     const name = row.person_name.trim();
     if (isCompensationPositionLabel(name)) {
       if (precedingOfficer === undefined) continue;
+      const fiscal_year = normalizeFiscalYear(row.fiscal_year);
+      if (fiscal_year === null && !COMP_MONEY_FIELDS.some((field) => row[field] != null)) continue;
       out.push({
         ...row,
         person_name: precedingOfficer,
-        fiscal_year: normalizeFiscalYear(row.fiscal_year),
+        fiscal_year,
         principal_position: boundPrincipalPosition(row.principal_position ?? name),
       });
       continue;
@@ -1382,16 +1455,26 @@ export async function extractRiskFactors(
   // would stop it becoming a row that reads like a disclosed risk. The heuristic
   // keys on a heading having no sentence-ending punctuation.
   //
-  // Applied only when the section also yielded at least one row that does not
-  // look like a heading. An Item 105(b) "Summary of Risk Factors" bullet list —
-  // which the segmenter accepts as this section, and which is all a filing
-  // carrying only the summary has — is written as bare unpunctuated phrases
-  // ("Risks related to our inability to complete an initial business
-  // combination"), indistinguishable in shape from a category heading. Dropping
-  // on shape alone would empty exactly those filings. When every row looks like
-  // a heading, the "headings" are the captions, so they are kept.
-  const captions = out.filter((risk) => !isRiskCategoryHeading(risk.headline));
-  return captions.length > 0 ? captions : out;
+  // The rule is about the section's SHAPE, and it only has an answer when the
+  // section is homogeneous:
+  //
+  // - every row heading-shaped — an Item 105(b) "Summary of Risk Factors"
+  //   bullet list, which the segmenter accepts as this section and which is all
+  //   a filing carrying only the summary has. Its bullets are bare unpunctuated
+  //   phrases ("Risks related to our inability to complete an initial business
+  //   combination"), so the "headings" ARE the captions. Kept.
+  // - no row heading-shaped — an ordinary Item 105 list of sentence captions,
+  //   with nothing to drop. Kept.
+  // - mixed — unanswerable. Filers are inconsistent about terminal punctuation,
+  //   so one summary bullet ending in a period is enough to make 29 bare-phrase
+  //   bullets look droppable; an all-or-nothing filter would keep the single
+  //   punctuated row and persist it as the filing's complete disclosure. Fail
+  //   the section instead of guessing.
+  const headingLike = out.filter((risk) => isRiskCategoryHeading(risk.headline)).length;
+  if (headingLike > 0 && headingLike < out.length) {
+    throw new MixedRiskCaptionShapeError(headingLike, out.length);
+  }
+  return out;
 }
 
 export async function extractUseOfProceeds(

--- a/src/sec/forms/registration-statements/s1/sectionRunner.ts
+++ b/src/sec/forms/registration-statements/s1/sectionRunner.ts
@@ -5,7 +5,8 @@
  */
 
 import type { ExtractionDeadLetterRepo } from "../../../../storage/dead-letter/ExtractionDeadLetterRepo";
-import { NonceMismatchError } from "./sectionExtractors";
+import type { DeadLetterReasonCode } from "../../../../storage/dead-letter/ExtractionDeadLetterSchema";
+import { MixedRiskCaptionShapeError, NonceMismatchError } from "./sectionExtractors";
 import type { SpanVerdict } from "./verifySourceSpan";
 
 /**
@@ -27,6 +28,15 @@ export const CONFIDENCE_FLOOR = parseConfidenceFloor(process.env.SEC_S1_CONFIDEN
  * Times a section is re-asked when every confident row fails span verification.
  * Distinct from the extractor's own transport/schema retry: this one answers a
  * well-formed response whose citations do not hold up.
+ *
+ * These retries COMPOSE with the ones inside the extractor, and the product is
+ * not obvious from either site alone. This loop wraps `sargs.extract`, which for
+ * risk factors is `extractRiskFactors` — itself one call per chunk, each
+ * internally retried up to `EXTRACTION_ATTEMPTS` (3) times. The worst case is
+ * therefore `VERIFICATION_ATTEMPTS x EXTRACTION_ATTEMPTS x chunks`: a 246k-char
+ * risk-factors section (7 chunks) whose citations verify badly can cost ~63
+ * model calls before the section dead-letters. Raising either constant
+ * multiplies, it does not add.
  */
 export const VERIFICATION_ATTEMPTS = 3;
 
@@ -103,7 +113,7 @@ export function makeRunSection(opts: {
   ): Promise<void> {
     if (sargs.skip) return;
 
-    const record = (reason: string, detail: string | null) =>
+    const record = (reason: DeadLetterReasonCode, detail: string | null) =>
       deadLetters.record({
         extractor_id,
         accession_number,
@@ -225,7 +235,14 @@ export function makeRunSection(opts: {
       // structured response did not echo back the per-call verification token;
       // record it under a dedicated reason code so an operator can triage
       // nonce-check failures separately from generic invalid-output cases.
-      const reason = e instanceof NonceMismatchError ? "NONCE_MISMATCH" : "MODEL_INVALID_OUTPUT";
+      // A MixedRiskCaptionShapeError is likewise its own triage class: the
+      // response was well-formed, and what failed is the section's shape.
+      const reason: DeadLetterReasonCode =
+        e instanceof NonceMismatchError
+          ? "NONCE_MISMATCH"
+          : e instanceof MixedRiskCaptionShapeError
+            ? "MIXED_CAPTION_SHAPE"
+            : "MODEL_INVALID_OUTPUT";
       await record(reason, (e instanceof Error ? e.message : String(e)).slice(0, 1024));
     }
   };

--- a/src/storage/dead-letter/ExtractionDeadLetterRepo.ts
+++ b/src/storage/dead-letter/ExtractionDeadLetterRepo.ts
@@ -8,6 +8,7 @@ import { globalServiceRegistry } from "workglow";
 import {
   EXTRACTION_DEAD_LETTER_REPOSITORY_TOKEN,
   MODEL_ERROR_REASON_CODES,
+  type DeadLetterReasonCode,
   type ExtractionDeadLetter,
   type ExtractionDeadLetterRepositoryStorage,
 } from "./ExtractionDeadLetterSchema";
@@ -18,7 +19,15 @@ export interface DeadLetterInput {
   readonly extractor_id: string;
   readonly accession_number: string;
   readonly section_name: string;
-  readonly reason_code: string;
+  /**
+   * Constrained to the declared vocabulary rather than left as `string`. The
+   * stored column is a plain string, so a code written here but missing from
+   * {@link DEAD_LETTER_REASON_CODES} used to persist silently — which is how
+   * `UNVERIFIED_SOURCE_SPAN` and `SOURCE_SPAN_TOO_LONG` were both written for
+   * some time without ever appearing in the list an operator reads. Typing the
+   * input makes that drift a compile error.
+   */
+  readonly reason_code: DeadLetterReasonCode;
   readonly detail: string | null;
   readonly failed_extractor_version: string;
   readonly source_run_id: string | null;

--- a/src/storage/dead-letter/ExtractionDeadLetterSchema.ts
+++ b/src/storage/dead-letter/ExtractionDeadLetterSchema.ts
@@ -30,6 +30,20 @@ export const DEAD_LETTER_REASON_CODES = [
   // the entry.
   "STORE_ERROR",
   "OVERSIZED_INPUT",
+  // Every confident row cited a source_span that is not present verbatim in the
+  // section text, so none of them can be trusted. Version-gated: the fix is in
+  // the extractor's prompt or its span handling.
+  "UNVERIFIED_SOURCE_SPAN",
+  // The narrower form of the above: every confident row's source_span verified
+  // verbatim but ran past the section's length cap. The rows are probably right
+  // and only quoted too much, so it is distinguished from a genuine
+  // verification failure — the two need opposite fixes.
+  "SOURCE_SPAN_TOO_LONG",
+  // A risk-factors response mixed rows shaped like captions with rows shaped
+  // like category headings (see MixedRiskCaptionShapeError). The shape
+  // heuristic cannot separate them, and persisting the punctuated subset would
+  // record a partial risk list as the filing's complete disclosure.
+  "MIXED_CAPTION_SHAPE",
   // A structured-generation response that failed to echo back the
   // verification nonce planted in the trusted preamble (see NonceMismatchError)
   // — a real extraction failure (the response cannot be trusted), not a

--- a/src/task/db/DbStatsTask.test.ts
+++ b/src/task/db/DbStatsTask.test.ts
@@ -16,11 +16,18 @@ describe("DbStatsTask", () => {
   // The declared port schema is what downstream graph wiring reads, so the
   // degraded (`rows: null`) count has to be part of the contract, not just a
   // value the execute() happens to return.
-  it("declares the null row count in its output schema", () => {
-    const degraded = { tables: [{ table: "ext_missing", rows: null }] };
+  it("declares the null row count and the estimate flag in its output schema", () => {
+    const degraded = { tables: [{ table: "ext_missing", rows: null, estimated: false }] };
     expect(Value.Check(DbStatsTask.outputSchema(), degraded)).toBe(true);
+    expect(
+      Value.Check(DbStatsTask.outputSchema(), {
+        tables: [{ table: "t", rows: 3, estimated: true }],
+      })
+    ).toBe(true);
+    // `estimated` is part of the contract, not an optional extra: a consumer
+    // that cannot tell an estimate from a count is the bug this closes.
     expect(Value.Check(DbStatsTask.outputSchema(), { tables: [{ table: "t", rows: 3 }] })).toBe(
-      true
+      false
     );
   });
 

--- a/src/task/db/DbStatsTask.ts
+++ b/src/task/db/DbStatsTask.ts
@@ -28,11 +28,17 @@ export class DbStatsTask extends Task<DbStatsTaskInput, DbStatsTaskOutput> {
 
   public static outputSchema() {
     return Type.Object({
-      // `rows` is null for a registered table the database has not created.
-      // The port schema is the declared contract downstream wiring reads, so
-      // the union belongs here rather than only in `TableStat`.
+      // `rows` is null for a registered table the database has not created, and
+      // `estimated` says whether the count is a Postgres `n_live_tup` estimate
+      // rather than an exact count. The port schema is the declared contract
+      // downstream wiring reads, so both belong here rather than only in
+      // `TableStat`.
       tables: Type.Array(
-        Type.Object({ table: Type.String(), rows: Type.Union([Type.Number(), Type.Null()]) })
+        Type.Object({
+          table: Type.String(),
+          rows: Type.Union([Type.Number(), Type.Null()]),
+          estimated: Type.Boolean(),
+        })
       ),
     });
   }

--- a/src/task/db/DbStatusTask.ts
+++ b/src/task/db/DbStatusTask.ts
@@ -31,6 +31,8 @@ export class DbStatusTask extends Task<DbStatusTaskInput, TaskPorts<DbStatusResu
       processedSubmissions: Type.Number(),
       processedFacts: Type.Number(),
       extractorRuns: Type.Number(),
+      // True when any count above is a Postgres `n_live_tup` estimate.
+      estimated: Type.Boolean(),
     });
   }
 

--- a/src/task/forms/ProcessAccessionDocFormTask.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.ts
@@ -34,6 +34,7 @@ import { hasLoiTriggerItem } from "../../sec/forms/miscellaneous-filings/spac8kL
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { SpacRepo } from "../../storage/spac/SpacRepo";
 import { ExtractionDeadLetterRepo } from "../../storage/dead-letter/ExtractionDeadLetterRepo";
+import type { DeadLetterReasonCode } from "../../storage/dead-letter/ExtractionDeadLetterSchema";
 import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
 import { COMPONENT_VERSION_REPOSITORY_TOKEN } from "../../storage/versioning/ComponentVersionSchema";
 import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
@@ -399,7 +400,10 @@ export class ProcessAccessionDocFormTask extends Task<
       }
     };
 
-    const recordDeadLetterSafe = async (reason_code: string, detail: string): Promise<void> => {
+    const recordDeadLetterSafe = async (
+      reason_code: DeadLetterReasonCode,
+      detail: string
+    ): Promise<void> => {
       try {
         await deadLetters.record({
           extractor_id: extractorId,

--- a/src/task/spac/IdentifySpacsTask.sqlite.test.ts
+++ b/src/task/spac/IdentifySpacsTask.sqlite.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { globalServiceRegistry, type IExecuteContext } from "workglow";
+import { withSqliteDb } from "../../config/testing/withSqliteDb";
+import { ENTITY_HISTORY_REPOSITORY_TOKEN } from "../../storage/entity/EntityHistorySchema";
+import { ENTITY_REPOSITORY_TOKEN } from "../../storage/entity/EntitySchema";
+import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
+import { PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN } from "../../storage/processing/ProcessedSubmissionsSchema";
+import { SPAC_CANDIDATE_REPOSITORY_TOKEN } from "../../storage/spac/SpacCandidateSchema";
+import { IdentifySpacsTask } from "./IdentifySpacsTask";
+
+const ctx = {
+  signal: new AbortController().signal,
+  updateProgress: () => {},
+} as unknown as IExecuteContext;
+
+/**
+ * `prune` now selects the reprocessed CIKs with a `>=` range query over
+ * `processed_submissions.last_processed` instead of an `in`-list over the
+ * candidate table. `last_processed` is a plain `YYYY-MM-DD` TEXT column, so the
+ * comparison must mean the same thing on a real SQLite backend as it does on the
+ * in-memory repository the rest of the suite uses — a looser or stricter
+ * comparison here would over- or under-delete candidate rows.
+ */
+describe("IdentifySpacsTask pruning (sqlite)", () => {
+  withSqliteDb("identify_spacs_prune_sqlite_test", [
+    ENTITY_REPOSITORY_TOKEN,
+    ENTITY_HISTORY_REPOSITORY_TOKEN,
+    FILING_REPOSITORY_TOKEN,
+    PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN,
+    SPAC_CANDIDATE_REPOSITORY_TOKEN,
+  ]);
+
+  it("deletes only the rows whose CIK was reprocessed at or after the watermark", async () => {
+    const candidates = globalServiceRegistry.get(SPAC_CANDIDATE_REPOSITORY_TOKEN);
+    const processed = globalServiceRegistry.get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN);
+    const identified_at = "2026-08-01T00:00:00.000Z";
+    // The watermark is the newest identified_at minus one day: 2026-07-31.
+    const watermark = "2026-07-31";
+
+    for (const cik of [1, 2, 3]) {
+      await candidates.put({
+        cik,
+        name: `Gone Acquisition Corp ${cik}`,
+        current_sic: 6770,
+        signal_sic_6770: true,
+        signal_name_match: true,
+        signal_renamed_from: null,
+        first_reg_form: null,
+        first_reg_date: null,
+        reg_while_spac_named: null,
+        confidence: "low",
+        identified_at,
+      });
+    }
+    // 1: before the watermark — untouched, must survive.
+    await processed.put({ cik: 1, last_processed: "2026-07-30", success: true });
+    // 2: exactly on the watermark — `>=`, so it was reprocessed and is stale.
+    await processed.put({ cik: 2, last_processed: watermark, success: true });
+    // 3: after the watermark — stale.
+    await processed.put({ cik: 3, last_processed: "2026-08-05", success: true });
+
+    // None of these CIKs has an entity row, so the scan matches nothing and
+    // every candidate is a pruning candidate; only the reprocessed ones go.
+    const out = await new IdentifySpacsTask().execute({}, ctx);
+
+    expect(out.since).toBe(watermark);
+    expect(out.pruned).toBe(2);
+    expect(((await candidates.getAll()) ?? []).map((r) => r.cik)).toEqual([1]);
+  });
+});

--- a/src/task/spac/IdentifySpacsTask.test.ts
+++ b/src/task/spac/IdentifySpacsTask.test.ts
@@ -170,6 +170,118 @@ describe("IdentifySpacsTask", () => {
     expect((await candidates()).map((r) => r.cik).sort()).toEqual([1, 2]);
   });
 
+  it("an untouched candidate row survives an incremental run", async () => {
+    // The pruning intersection is the load-bearing part: a row whose CIK was
+    // never reprocessed is unexamined, not stale, and deleting it would empty
+    // the table one daily run at a time.
+    const processed = globalServiceRegistry.get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN);
+    await addEntity(1, "Old Acquisition Corp", 6770);
+    await addRegistration(1, "S-1", "2020-01-01");
+    await processed.put({ cik: 1, last_processed: "2020-01-02", success: true });
+    await new IdentifySpacsTask().execute({ full: true }, ctx);
+    expect(await candidates()).toHaveLength(1);
+
+    // CIK 1 stops matching, but its submissions were last processed long before
+    // the watermark — so this run never looked at it and must not prune it.
+    await addEntity(1, "Some Operating Co", 3711);
+    const out = await new IdentifySpacsTask().execute({}, ctx);
+
+    expect(out.pruned).toBe(0);
+    expect((await candidates()).map((r) => r.cik)).toEqual([1]);
+  });
+
+  it("prunes a rescanned CIK that stopped matching", async () => {
+    const processed = globalServiceRegistry.get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN);
+    await addEntity(1, "Old Acquisition Corp", 6770);
+    await addRegistration(1, "S-1", "2020-01-01");
+    await processed.put({ cik: 1, last_processed: "2020-01-02", success: true });
+    await new IdentifySpacsTask().execute({ full: true }, ctx);
+
+    // Same rename, but this time the CIK's submissions were reprocessed today,
+    // so the incremental scan DID consider it and its absence is evidence.
+    await addEntity(1, "Some Operating Co", 3711);
+    await processed.put({
+      cik: 1,
+      last_processed: new Date().toISOString().slice(0, 10),
+      success: true,
+    });
+    const out = await new IdentifySpacsTask().execute({}, ctx);
+
+    expect(out.pruned).toBe(1);
+    expect(await candidates()).toHaveLength(0);
+  });
+
+  it("treats the watermark date itself as reprocessed", async () => {
+    // The `>=` range query must be inclusive at the boundary and must mean the
+    // same thing on the in-memory repository as on SQLite (pinned in
+    // IdentifySpacsTask.sqlite.test.ts) — a stricter comparison here would leave
+    // stale rows behind, a looser one would delete unexamined ones.
+    const repo = globalServiceRegistry.get(SPAC_CANDIDATE_REPOSITORY_TOKEN);
+    await repo.put({
+      cik: 42,
+      name: "Gone Acquisition Corp",
+      current_sic: 6770,
+      signal_sic_6770: true,
+      signal_name_match: true,
+      signal_renamed_from: null,
+      first_reg_form: null,
+      first_reg_date: null,
+      reg_while_spac_named: null,
+      confidence: "low",
+      identified_at: "2026-08-01T00:00:00.000Z",
+    });
+    // The watermark is the newest identified_at minus one day.
+    await globalServiceRegistry
+      .get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN)
+      .put({ cik: 42, last_processed: "2026-07-31", success: true });
+
+    const out = await new IdentifySpacsTask().execute({}, ctx);
+
+    expect(out.since).toBe("2026-07-31");
+    expect(out.pruned).toBe(1);
+    expect(await candidates()).toHaveLength(0);
+  });
+
+  it("prunes with 40k candidate rows without throwing", async () => {
+    // `prune` streams the WHOLE candidate table, so the set it intersects grows
+    // monotonically with EDGAR history. The old implementation fed that set to
+    // an `in`-list query and threw above 30k bound parameters — after `putBulk`
+    // had already advanced `identified_at`, so the watermark moved forward, the
+    // unmatched set never shrank, and every later daily run threw again
+    // permanently.
+    const repo = globalServiceRegistry.get(SPAC_CANDIDATE_REPOSITORY_TOKEN);
+    const identified_at = "2026-08-01T00:00:00.000Z";
+    const stale = Array.from({ length: 40_000 }, (_, i) => ({
+      cik: 100_000 + i,
+      name: `Filler Acquisition Corp ${i}`,
+      current_sic: 6770,
+      signal_sic_6770: true,
+      signal_name_match: true,
+      signal_renamed_from: null,
+      first_reg_form: null,
+      first_reg_date: null,
+      reg_while_spac_named: null,
+      confidence: "low",
+      identified_at,
+    }));
+    for (let i = 0; i < stale.length; i += 5_000) {
+      await repo.putBulk(stale.slice(i, i + 5_000));
+    }
+    expect(await repo.size()).toBe(40_000);
+
+    // One CIK actually reprocessed today: the only row the run may delete.
+    const today = new Date().toISOString().slice(0, 10);
+    await globalServiceRegistry
+      .get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN)
+      .put({ cik: 100_000, last_processed: today, success: true });
+
+    const out = await new IdentifySpacsTask().execute({}, ctx);
+
+    expect(out.since).not.toBeNull();
+    expect(out.pruned).toBe(1);
+    expect(await repo.size()).toBe(39_999);
+  });
+
   it("falls back to a full scan when the table is empty", async () => {
     await addEntity(1, "Yuanxiang Acquisition Corp.", 6770);
     const out = await new IdentifySpacsTask().execute({}, ctx);

--- a/src/task/spac/IdentifySpacsTask.ts
+++ b/src/task/spac/IdentifySpacsTask.ts
@@ -19,15 +19,6 @@ import { scanSpacCandidates } from "./spacCandidateScan";
 /** Rows per bulk write. A full scan writes a few thousand rows in total. */
 const WRITE_BATCH = 1_000;
 
-/**
- * Values one `in`-list query may bind, with headroom under SQLite's
- * `SQLITE_MAX_VARIABLE_NUMBER` — 32766 since SQLite 3.32 (2020). The 999 of
- * older builds is not a constraint here: bun ships 3.51 and `better-sqlite3`
- * ^13 is comparably recent. Postgres binds the whole list as one array
- * parameter and has no equivalent cap.
- */
-const SQLITE_MAX_BOUND_PARAMS = 30_000;
-
 export type IdentifySpacsTaskInput = {
   /** Rescan every entity instead of only those whose submissions changed. */
   readonly full?: boolean;
@@ -183,40 +174,41 @@ export class IdentifySpacsTask extends Task<IdentifySpacsTaskInput, IdentifySpac
     }
 
     // A full scan considered every entity, so every unmatched row is stale.
-    const stale = since === null ? unmatched : await this.processedSince(unmatched, since);
+    if (since === null) {
+      for (const cik of unmatched) await repo.delete({ cik });
+      return unmatched.length;
+    }
+
+    const reprocessed = await this.processedSince(since);
+    const stale = unmatched.filter((cik) => reprocessed.has(cik));
     for (const cik of stale) await repo.delete({ cik });
     return stale.length;
   }
 
   /**
-   * Of `ciks`, those whose submissions were (re)processed on or after `since`.
+   * The CIKs whose submissions were (re)processed on or after `since`.
    *
-   * One `in`-list query rather than one `get` per CIK: the candidate table holds
-   * thousands of rows and an incremental run matches a handful, so the per-CIK
-   * form is an N+1 over almost the whole table on every daily run.
+   * Asked in that direction on purpose. The obvious form — take the unmatched
+   * candidate CIKs and ask which of them were reprocessed — makes the query's
+   * `in`-list as large as {@link prune}'s input, and that input is the WHOLE
+   * `spac_candidate` table (`prune` streams every row and keeps the ones this
+   * scan did not match), which grows monotonically with EDGAR history. Once it
+   * passed SQLite's bindable-parameter ceiling the run would throw *after* the
+   * `putBulk` above had already advanced `identified_at`: the watermark moves
+   * forward, the unmatched set never shrinks, and every later daily run throws
+   * again — permanently. Raising a bound only postpones that.
    *
-   * Deliberately unchunked. SQLite binds one parameter per value and caps them
-   * at {@link SQLITE_MAX_BOUND_PARAMS}, but the input here is the *unmatched
-   * candidate rows of one incremental scan*, which is a few thousand at most —
-   * so a chunking loop would be a branch never taken, untestable in
-   * practice and unverified in production. It is a guard instead: if that
-   * assumption ever stops holding, this fails loudly and names the fix rather
-   * than silently truncating the delete set, which would leave stale candidate
-   * rows behind with no signal.
+   * `last_processed` is a plain `YYYY-MM-DD` string column and `since` is the
+   * same shape, so a `>=` range query returns exactly the CIKs the daily run
+   * reprocessed — the same order of magnitude as the scan's own result set,
+   * which the caller already holds in memory — and the intersection happens
+   * here rather than in the database. No in-list, no chunk loop, no cap.
    */
-  private async processedSince(ciks: ReadonlyArray<number>, since: string): Promise<number[]> {
-    if (ciks.length === 0) return [];
-    if (ciks.length > SQLITE_MAX_BOUND_PARAMS) {
-      throw new Error(
-        `IdentifySpacsTask: ${ciks.length} unmatched candidate CIKs exceeds the ` +
-          `${SQLITE_MAX_BOUND_PARAMS} values one 'in'-list query can bind on SQLite. ` +
-          `This path assumed an incremental scan leaves at most a few thousand ` +
-          `unmatched rows. Chunk the query in processedSince() to lift the bound.`
-      );
-    }
+  private async processedSince(since: string): Promise<Set<number>> {
     const processed = globalServiceRegistry.get(PROCESSED_SUBMISSIONS_REPOSITORY_TOKEN);
-    const rows = (await processed.query({ cik: { value: [...ciks], operator: "in" } })) ?? [];
-    return rows.filter((row) => row.last_processed >= since).map((row) => row.cik);
+    const rows =
+      (await processed.query({ last_processed: { value: since, operator: ">=" } })) ?? [];
+    return new Set(rows.map((row) => row.cik));
   }
 
   /**


### PR DESCRIPTION
> **Stacks on #249** (`claude/zen-lamport-rjtcnx-dbstats`), whose missing-relation guard in `DbStatus.ts` this builds on rather than replaces — `countTableRowsOrNull` and the `rows: number | null` degradation are preserved, now carrying an `estimated` flag alongside. Review/merge #249 first.

Nine findings from review of the recent extraction / db ranges. Each is stated below with the concrete failure it produces.

---

## M1 + M2 — `db status` reports a stale zero as a real count, from the wrong schema

`src/cli/queries/DbStatus.ts`

**(a) Zero estimates.** Estimates are the default on Postgres, and the query returned `n_live_tup` even when `0`. `n_live_tup` is 0 until the first ANALYZE — so immediately after `sec bootstrap` bulk-loads ~1M `cik_names`, and before autovacuum catches up, `db status` printed:

```
  Entities:              0
  Filings:               0
```

under a column labelled "Rows", with no "(estimated)" marker anywhere. An operator reads a stale statistic as a real count and concludes the bootstrap did nothing.

A zero estimate now means **"no statistics yet"** and falls back automatically to the exact count. A genuinely empty table costs one cheap `COUNT(*)` for that; the post-bootstrap `0` never lies again.

**(b) Schema resolution.** `WHERE relid = to_regclass($1)` resolves an unqualified name through `search_path`. On a deployment whose `search_path` lists a staging schema first, `to_regclass('filings')` binds the **other** schema's table and reports its count under sec's name — the exact hazard `resetAllDatabases` already defends against by qualifying to `current_schema()`. Now:

```sql
WHERE relid = to_regclass(quote_ident(current_schema()) || '.' || quote_ident($1))
```

`quote_ident` keeps the table name a bind value; nothing is interpolated.

**Reporting.** Rather than widening the number, the shape widened: `TableStat` and `DbStatusResult` each gain `estimated`, wired through `DbStatsTask` / `DbStatusTask` output schemas. `db stats` heads the column `Rows (est.)` and marks each estimated row, `db status` appends `  (estimated)`, both print a footer naming `--exact`, and `--format json` carries the flag per row / per result.

## M3 — `IdentifySpacsTask` prune throws permanently once the candidate table grows

`src/task/spac/IdentifySpacsTask.ts`

The range being reviewed replaced a chunk loop with a hard 30k bound guard, arguing the loop was unreachable code. **It is right that chunking was an untested branch and wrong about the input size.** `prune()` streams the *entire* `spac_candidate` table via `repo.records(1000)` and pushes everything not in `matched` — so the `in`-list is O(table), which grows monotonically with EDGAR history, not "the unmatched rows of one incremental scan".

Why that is worse than a slow query: once the table passes 30k rows, `sec update spacs` throws **after** `putBulk` has already written and advanced `identified_at`. The watermark moves forward, the unmatched set never shrinks, and every subsequent daily run throws again — permanently, with no self-recovery. Raising the bound only postpones the date.

**Inverting the query answers the unreachable-code argument properly.** `since` is already a date and `ProcessedSubmissions.last_processed` is a plain `YYYY-MM-DD` string column, so `processedSince` is now `processed.query({ last_processed: { value: since, operator: ">=" } })` — returning exactly the CIKs the daily run reprocessed, the same order of magnitude as the `facts` array `scanSpacCandidates({ since })` already holds — intersected against the unmatched set in memory. There is no in-list, so there is no chunking branch to be unreachable and no cap to breach. `SQLITE_MAX_BOUND_PARAMS` and the throw are deleted; the guard also fired wrongly on Postgres, where `= ANY($1)` binds one array parameter (its own doc comment conceded this).

## M4 — a mixed risk-factors section silently persisted a partial disclosure

`src/sec/forms/registration-statements/s1/sectionExtractors.ts`

`return captions.length > 0 ? captions : out` was all-or-nothing per section. Real filers are inconsistent about terminal punctuation, so an Item 105(b) summary bullet list where **one** bullet happens to end in a period yields `captions.length === 1`: the other 29 bare-phrase bullets are dropped and one row is persisted **with no dead letter** — recording a partial disclosure as complete, which is exactly what the chunked-section contract exists to prevent.

The rule is now shape-**homogeneity**, per section:

| section shape | outcome |
| --- | --- |
| every row heading-shaped | kept — a summary bullet list, whose "headings" *are* the captions |
| no row heading-shaped | kept — an ordinary sentence-caption list, nothing to drop |
| **mixed** | `MixedRiskCaptionShapeError` → `MIXED_CAPTION_SHAPE` dead letter, nothing persisted |

> ⚠️ **Risk-factor dead-letter volume will RISE on the first run after this lands.** That is intended: those filings were already being extracted wrongly, they were just being recorded as complete. A visible entry on `sec extractor dead-letters S-1` is the correct state for a section nobody can currently separate.

## M5 — phantom `executive_compensation` rows

`sectionExtractors.ts`. The stub-column position-line fold pushed a row unconditionally. In the common layout — the position line has a label but no fiscal year and no money, because the figures sit only on the name row — every officer produced a **second** row: same `observation_id`, `fiscal_year: null`, every money column null. In a table documented as "one row per named executive officer per fiscal year", that is a phantom.

Now folded only when the row carries a fiscal year or at least one money column, which keeps the recovered-year case the fold was added for. A regression test pins both halves.

## M6 — move the gate, not the doc

`Form_S_1.storage.ts`. The range added a version-gated `SECTION_NOT_FOUND` dead letter for a filing with no compensation section. CLAUDE.md stated the opposite for exactly this case, and the operational argument is on the doc's side: `sec extractor dead-letters S-1` would list an `Executive Compensation` entry for the **majority of all S-1s**, permanently (only a version bump clears one), burying every genuinely triageable entry. The **code** changed — no-section now takes the same `recordOk` / `markResolved` path as no-table — and the doc-comment paragraph justifying the gate is removed. The heading-coverage concern it raised is real but belongs on a counting surface, not the retry worklist. CLAUDE.md now says explicitly that **both** "no section matched" and "section matched but no Summary Compensation Table" resolve.

## L7 — dead-letter reason codes that were written but never declared

`SOURCE_SPAN_TOO_LONG` is written at `sectionRunner.ts:172,209` and `UNVERIFIED_SOURCE_SPAN` predates it; neither was in `DEAD_LETTER_REASON_CODES`, and `reason_code` was typed `string`, so nothing caught it — while the same range *did* add `STORE_ERROR`. All three (plus `MIXED_CAPTION_SHAPE`) are declared, and `DeadLetterInput.reason_code` is now typed `DeadLetterReasonCode`, with the three `recordFail`-style wrappers (`Form_S_1`, `Form_424`, `ProcessAccessionDocFormTask`) typed against it. The next drift is a compile error.

## L8 – L12 (documentation and small correctness)

- **L8** — documented (no behavior change) that `VERIFICATION_ATTEMPTS = 3` wraps `sargs.extract`, which for risk factors is itself chunked and internally retried (`EXTRACTION_ATTEMPTS = 3`): worst case is `VERIFICATION_ATTEMPTS × EXTRACTION_ATTEMPTS × chunks`, ~63 model calls on a 246k-char section that verifies badly. Raising either constant multiplies.
- **L9** — `fingerprintRows` sorted keys with `a.localeCompare(b)`, making the digest depend on the runtime's ICU collation, so a stability report compared across two differently-configured machines showed disagreement that was not there. Now code-unit order.
- **L10** — `DEFAULT_MODELS` grew from 2 Anthropic ids to 4 across 3 providers, so a bare `sec eval extract` needed `DEEPSEEK_API_KEY` and `GEMINI_API_KEY` or half the table came back as failed runs presented as if the models had been ranked and lost. Defaults whose key is absent are skipped with a warning naming the ids and the variables; the 4-model list stays the documented default, and an explicit `--models` is never filtered.
- **L11** — `useDist` returned early on "No stubs found", skipping the rebuild. `dist/` is gitignored, so the common way to reach that state is having deleted it: the developer got the message and no build, with nothing saying why. It now continues to the rebuild unless `--no-build`.
- **L12** — `getExtractionTemperature` silently coerced a malformed `SEC_EXTRACTION_TEMPERATURE` (e.g. `"0,5"`) to `0`, which reads back as "greedy sampling is on" — the opposite of what the typo asked for. Now throws naming the variable, and range-checks `0 ≤ n ≤ 2`.

---

## Tests

New, each confirmed **failing before** and passing after:

- `extractRiskFactors` — a mixed section (29 bare-phrase bullets + 1 period-terminated) rejects with `MixedRiskCaptionShapeError`; an all-bare-phrase list keeps 30/30.
- `Form_S_1.storage` risk factors — a mixed section persists 0 `risk_factor` rows and leaves one pending `MIXED_CAPTION_SHAPE` entry.
- Executive compensation — a label-only position row is dropped (1 row, was 2); a position row carrying a figure is still folded.
- `Form_S_1.storage` compensation — a filing with no compensation section makes no model call, leaves 0 pending, and **resolves** a seeded prior entry.
- `DbStatus.postgres.test.ts` (new file, stubs the backend decision and the pool) — zero estimate falls back to the exact count; the SQL is schema-qualified (`current_schema()`) and still parameterized; only estimated rows are marked; `--exact` issues no catalog query at all.
- `IdentifySpacsTask` — prunes with 40k candidate rows without throwing (**verified failing** on the old code with the 30k guard); an untouched candidate row survives an incremental run; a rescanned non-matching row is pruned; the watermark date itself counts as reprocessed.
- `IdentifySpacsTask.sqlite.test.ts` (new file) — the same boundary against a **real SQLite** database.
- `fingerprintRows` — the digest is unchanged with `localeCompare` replaced by a reversed collation.

Superseded by design, updated deliberately (called out because they encode the old behavior):

- `extractRiskFactors` › "drops a category heading …" → now asserts the mixed section fails (M4).
- `extractionTemperature` › "falls back to greedy on a non-numeric value" → now asserts it throws (L12).
- `Form_S_1.storage` › dead-letter list no longer contains `Executive Compensation` (M6).
- `DbStatsTask` / `DbStatus` schema + shape assertions gain `estimated` (M1/M2).

### M3 backend-equivalence check (the flagged risk)

The `>=` operator over `last_processed` was exercised on **both** backends and behaves identically, including at the boundary: `IdentifySpacsTask.test.ts` pins it on the in-memory repository and `IdentifySpacsTask.sqlite.test.ts` pins the same three-CIK before/on/after case against a real SQLite database via `withSqliteDb`. Both treat `>=` as inclusive on the `YYYY-MM-DD` TEXT column, so the intersection neither over- nor under-deletes. The same operator is already used this way on `filings.filing_date` (`FilingQuery`). **Postgres was not exercised** — no instance available here (see below).

## Verification

Run and observed passing:

- `npx tsc --noEmit` — clean.
- `bunx vitest run` (full suite) — **2360 passed, 32 skipped**.
- Targeted per area: `src/task/spac/`, `src/sec/forms/registration-statements/` (incl. `s1/`), `src/cli/queries/`, `src/task/db/`, `src/eval/`.
- Every new test was additionally run against the pre-fix source to confirm it fails.
- `npx prettier --check` on the changed files; the three files formatted were the ones this branch newly unformatted (`CLAUDE.md`, `sectionRunner.ts`, `DbStatsTask.ts`, `sectionExtractors.ts` were already unformatted on the base and were left alone to avoid unrelated churn).

Not verified:

- **Postgres.** The estimate path is unit-tested with the backend decision and pool stubbed, so the SQL *text* and the fallback logic are pinned, but the query has not been executed against a live PostgreSQL — no instance in this environment. The `search_path` scenario in particular is argued, not observed.
- `src/cli/groups/version.test.ts` intermittently times out (2 of 12 tests, 15s budget) **under full-suite parallel load only**. It passes 12/12 when run alone, both with and without this branch's changes, and passed in a full-suite run as well; these tests spawn the CLI as subprocesses. Pre-existing environmental flake, unrelated to this diff.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XhfGNbddCCJR71UvDw2c7f)_