### PR TITLE
Optimize DOM traversal in HTML parsing and style resolution

### DIFF
--- a/src/eval/goldenS1Labels.test.ts
+++ b/src/eval/goldenS1Labels.test.ts
@@ -93,13 +93,20 @@ describe("goldenS1Labels", () => {
     }
   });
 
-  it("labels only sections that exist in the committed set", () => {
-    const { sections } = loadRealS1Sections([...LABELED_EXTRACTORS]);
-    const present = new Set(sections.map((s) => goldenLabelKey(s.filing, s.extractor)));
-    for (const key of Object.keys(GOLDEN_S1_LABELS)) {
-      expect(present.has(key), `golden key not found in committed sections: ${key}`).toBe(true);
-    }
-  });
+  // First call in this process segments every committed fixture — tens of MB of
+  // HTML, growing with each fixture added. The `it.each` below reuses the parse
+  // cache, so only this one needs the headroom.
+  it(
+    "labels only sections that exist in the committed set",
+    () => {
+      const { sections } = loadRealS1Sections([...LABELED_EXTRACTORS]);
+      const present = new Set(sections.map((s) => goldenLabelKey(s.filing, s.extractor)));
+      for (const key of Object.keys(GOLDEN_S1_LABELS)) {
+        expect(present.has(key), `golden key not found in committed sections: ${key}`).toBe(true);
+      }
+    },
+    120_000
+  );
 
   it.each(LABELED_EXTRACTORS)(
     "covers every committed %s section (so --reference golden scores them all)",

--- a/src/eval/realSections.test.ts
+++ b/src/eval/realSections.test.ts
@@ -7,17 +7,28 @@
 import { describe, expect, it } from "vitest";
 import { fixtureCik, loadRealS1Sections } from "./realSections";
 
+/**
+ * Whichever test segments the corpus first pays for parsing every committed
+ * fixture — tens of MB of HTML, and growing with each one added. Later calls in
+ * the same process hit the parse cache, so only the first needs the headroom.
+ */
+const CORPUS_PARSE_TIMEOUT_MS = 120_000;
+
 describe("loadRealS1Sections", () => {
-  it("extracts non-empty management sections from committed real S-1 HTML", () => {
-    const { sections } = loadRealS1Sections(["management"]);
-    // The committed corpus has several S-1s with a management section.
-    expect(sections.length).toBeGreaterThanOrEqual(3);
-    for (const s of sections) {
-      expect(s.extractor).toBe("management");
-      expect(s.text.trim().length).toBeGreaterThan(0);
-      expect(s.filing).toMatch(/^s1_/);
-    }
-  });
+  it(
+    "extracts non-empty management sections from committed real S-1 HTML",
+    () => {
+      const { sections } = loadRealS1Sections(["management"]);
+      // The committed corpus has several S-1s with a management section.
+      expect(sections.length).toBeGreaterThanOrEqual(3);
+      for (const s of sections) {
+        expect(s.extractor).toBe("management");
+        expect(s.text.trim().length).toBeGreaterThan(0);
+        expect(s.filing).toMatch(/^s1_/);
+      }
+    },
+    CORPUS_PARSE_TIMEOUT_MS
+  );
 
   it("returns nothing for an extractor with no mapped section", () => {
     const { sections } = loadRealS1Sections(["not-a-real-extractor"]);

--- a/src/eval/realSections.ts
+++ b/src/eval/realSections.ts
@@ -58,6 +58,38 @@ const EXTRACTOR_TO_SECTION: Record<string, string> = {
   "spac-classification": S1_SECTIONS.PROSPECTUS_SUMMARY,
 };
 
+interface SegmentedFixture {
+  /** Section name -> prose, or undefined when the fixture failed to parse. */
+  readonly byName: Map<string, string> | undefined;
+  readonly error: string | undefined;
+}
+
+/**
+ * Parsed + segmented fixtures, keyed by absolute path. The corpus is committed
+ * HTML that never changes under a running process, and a sweep asking for one
+ * extractor at a time would otherwise re-segment tens of MB per call.
+ */
+const segmentedFixtures = new Map<string, SegmentedFixture>();
+
+function segmentFixture(path: string, title: string): SegmentedFixture {
+  const cached = segmentedFixtures.get(path);
+  if (cached !== undefined) return cached;
+  let result: SegmentedFixture;
+  try {
+    const html = readFileSync(path, "utf8");
+    const doc = parseEdgarHtml(html, title);
+    const segmented = new DocumentTreeSegmenter().segment(doc);
+    result = {
+      byName: new Map(segmented.map((s) => [s.name as string, s.text])),
+      error: undefined,
+    };
+  } catch (err) {
+    result = { byName: undefined, error: err instanceof Error ? err.message : String(err) };
+  }
+  segmentedFixtures.set(path, result);
+  return result;
+}
+
 export interface RealSection {
   /** Source filename (accession-derived). */
   readonly filing: string;
@@ -141,16 +173,14 @@ export function loadRealS1Sections(
     }
     return true;
   });
+  // Nothing to look for — don't pay to segment the corpus (tens of MB of HTML)
+  // only to filter every section back out.
+  if (mapped.length === 0) return { sections, skipped };
 
   for (const file of files.sort()) {
-    let byName: Map<string, string>;
-    try {
-      const html = readFileSync(join(resolvedDir, file), "utf8");
-      const doc = parseEdgarHtml(html, file);
-      const segmented = new DocumentTreeSegmenter().segment(doc);
-      byName = new Map(segmented.map((s) => [s.name as string, s.text]));
-    } catch (err) {
-      skipped.push(`${file}: parse failed (${err instanceof Error ? err.message : String(err)})`);
+    const { byName, error } = segmentFixture(join(resolvedDir, file), file);
+    if (byName === undefined) {
+      skipped.push(`${file}: parse failed (${error})`);
       continue;
     }
     for (const extractor of mapped) {

--- a/src/sec/html/StyleResolver.ts
+++ b/src/sec/html/StyleResolver.ts
@@ -95,33 +95,93 @@ function upperRatio(text: string): number {
   return upper / letters.length;
 }
 
+/** Element traits gathered from a single descendant walk. */
+interface DescendantTraits {
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  /** Largest `<font size="N">` among descendants, in points. */
+  maxFontSizePt: number | undefined;
+}
+
+/**
+ * Emphasis tags and legacy font sizes anywhere below `el`, in one pass.
+ *
+ * These were four separate `$el.find(...)` calls; each runs the selector engine
+ * over the whole subtree, and `resolveStyle` is called once per prose block, so
+ * on a large filing the four walks dominated style resolution.
+ */
+function scanDescendants(el: unknown): DescendantTraits {
+  const traits: DescendantTraits = {
+    bold: false,
+    italic: false,
+    underline: false,
+    maxFontSizePt: undefined,
+  };
+  const visit = (node: unknown): void => {
+    const children = (node as { children?: unknown[] }).children;
+    if (children === undefined) return;
+    for (const child of children) {
+      const c = child as { name?: string; attribs?: Record<string, string> };
+      // Text, comment and doctype nodes carry no tag name.
+      if (c.name === undefined) continue;
+      switch (c.name.toLowerCase()) {
+        case "b":
+        case "strong":
+          traits.bold = true;
+          break;
+        case "i":
+        case "em":
+          traits.italic = true;
+          break;
+        case "u":
+          traits.underline = true;
+          break;
+        case "font": {
+          const pt = fontSizeAttrToPt(c.attribs?.size);
+          if (pt !== undefined && (traits.maxFontSizePt === undefined || pt > traits.maxFontSizePt))
+            traits.maxFontSizePt = pt;
+          break;
+        }
+      }
+      visit(child);
+    }
+  };
+  visit(el);
+  return traits;
+}
+
 /** Resolve the effective style of `el` by merging ancestor inline styles (child wins). */
 export function resolveStyle($: CheerioAPI, el: unknown): ResolvedStyle {
   const $el = $(el as never);
   const chain: RawStyle[] = [];
   const tagNames: string[] = [];
-  let cur = $(el as never);
-  while (cur && cur.length > 0 && cur.get(0)) {
-    const node = cur.get(0) as unknown as { tagName?: string; name?: string };
-    const tag = (node.tagName ?? node.name ?? "").toLowerCase();
+  // Raw domhandler traversal rather than `cur.parent()`: the cheerio wrapper
+  // allocated an object per ancestor, per block.
+  let cur = el as
+    | { name?: string; attribs?: Record<string, string>; parent?: unknown }
+    | null
+    | undefined;
+  while (cur) {
+    const tag = (cur.name ?? "").toLowerCase();
     tagNames.push(tag);
-    const raw = parseInlineStyle(cur.attr("style") ?? "");
+    const attribs = cur.attribs;
+    const raw = parseInlineStyle(attribs?.style ?? "");
     // Legacy EDGAR uses the HTML attribute <font size="N"> rather than a CSS
     // font-size; fold it in when no inline size is present.
     let merged =
       raw.fontSizePt === undefined && tag === "font"
-        ? { ...raw, fontSizePt: fontSizeAttrToPt(cur.attr("size")) }
+        ? { ...raw, fontSizePt: fontSizeAttrToPt(attribs?.size) }
         : raw;
     // Likewise ALIGN="center" rather than a CSS text-align — pre-CSS EDGAR
     // markup centers headings with the attribute (<P ALIGN="center"><B>The
     // Offering</B></P>), which heading detection must count as a trait.
     if (merged.centered === undefined) {
-      const alignAttr = (cur.attr("align") ?? "").trim().toLowerCase();
+      const alignAttr = (attribs?.align ?? "").trim().toLowerCase();
       if (alignAttr !== "") merged = { ...merged, centered: alignAttr === "center" };
     }
     chain.push(merged);
-    cur = cur.parent() as unknown as typeof cur;
-    if (!cur || cur.length === 0) break;
+    cur = cur.parent as typeof cur;
   }
 
   const pick = <K extends keyof RawStyle>(key: K): RawStyle[K] => {
@@ -133,22 +193,17 @@ export function resolveStyle($: CheerioAPI, el: unknown): ResolvedStyle {
   // (CSS inheritance), or an inner emphasis tag that wraps the text — EDGAR
   // headings are commonly `<p><b>MANAGEMENT</b></p>`. A bare `<b>`/`<font>`
   // carries no inline style, so the cascade alone misses these.
-  const inChainOrDescendant = (...tags: string[]): boolean =>
-    tags.some((t) => tagNames.includes(t)) || $el.find(tags.join(",")).length > 0;
-  const tagBold = inChainOrDescendant("b", "strong");
-  const tagItalic = inChainOrDescendant("i", "em");
-  const tagUnderline = inChainOrDescendant("u");
+  const descendants = scanDescendants(el);
+  const inChainOrDescendant = (fromDescendant: boolean, ...tags: string[]): boolean =>
+    tags.some((t) => tagNames.includes(t)) || fromDescendant;
+  const tagBold = inChainOrDescendant(descendants.bold, "b", "strong");
+  const tagItalic = inChainOrDescendant(descendants.italic, "i", "em");
+  const tagUnderline = inChainOrDescendant(descendants.underline, "u");
 
   // A descendant <font size="N"> (e.g. <div><font size="5">RISK FACTORS</font></div>)
   // sets the effective size too; take the largest descendant size if the cascade
   // gave none.
-  let fontSizePt = pick("fontSizePt");
-  if (fontSizePt === undefined) {
-    $el.find("font[size]").each((_, f) => {
-      const pt = fontSizeAttrToPt($(f as never).attr("size"));
-      if (pt !== undefined && (fontSizePt === undefined || pt > fontSizePt)) fontSizePt = pt;
-    });
-  }
+  const fontSizePt = pick("fontSizePt") ?? descendants.maxFontSizePt;
 
   const text = $el.text();
   return {

--- a/src/sec/html/parseToBlocks.ts
+++ b/src/sec/html/parseToBlocks.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as cheerio from "cheerio";
-import type { CheerioAPI } from "cheerio";
 import { NodeKind, uuid4 } from "workglow";
 import type { ImageNode, ListNode, ParagraphNode } from "workglow";
 import type { EdgarBlock, ResolvedStyle } from "./types";
@@ -33,13 +32,18 @@ const STRIP_BEFORE_WALK_SELECTOR =
   "script, style, noscript, textarea, template, xmp, plaintext, " +
   "iframe, noembed, noframes, title, svg, math";
 
+/** An element's raw attributes, or undefined for text/comment nodes. */
+function attribsOf(el: unknown): Record<string, string> | undefined {
+  return (el as { attribs?: Record<string, string> }).attribs;
+}
+
 /** True if `el` has a CSS/structural page-break signal (edgartools heuristics). */
-function isPageBreak($: CheerioAPI, el: unknown): boolean {
-  const $el = $(el as never);
+function isPageBreak(el: unknown): boolean {
   const node = el as { tagName?: string; name?: string };
   const tag = (node.tagName ?? node.name ?? "").toLowerCase();
-  const style = ($el.attr("style") ?? "").toLowerCase();
-  const cls = ($el.attr("class") ?? "").toLowerCase();
+  const attribs = attribsOf(el);
+  const style = (attribs?.style ?? "").toLowerCase();
+  const cls = (attribs?.class ?? "").toLowerCase();
   if (/page-break-(before|after)\s*:\s*always/.test(style)) return true;
   if (cls.includes("pagebreak") || cls.includes("brpfpagebreak")) return true;
   if (tag === "hr") {
@@ -118,7 +122,7 @@ export function parseToBlocks(html: string): EdgarBlock[] {
     const node = el as { tagName?: string; name?: string; type?: string };
     const tag = (node.tagName ?? node.name ?? "").toLowerCase();
 
-    if (isPageBreak($, el)) {
+    if (isPageBreak(el)) {
       emitProse(prose, out);
       out.push({ type: "page-break" });
       // EDGAR wraps each page's content in a page-sized container element (e.g.
@@ -137,7 +141,7 @@ export function parseToBlocks(html: string): EdgarBlock[] {
     // display:none subtrees are invisible to a reader and, in iXBRL filings,
     // hold the ix:header metadata block (contexts, units, hidden facts) whose
     // text must not leak into prose. The XBRL pass parses them separately.
-    if (/display\s*:\s*none/i.test($(el as never).attr("style") ?? "")) return;
+    if (/display\s*:\s*none/i.test(attribsOf(el)?.style ?? "")) return;
 
     if (tag === "table") {
       emitProse(prose, out);
@@ -230,9 +234,7 @@ export function parseToBlocks(html: string): EdgarBlock[] {
   // Walk an element's children in document order: text nodes feed the prose
   // buffer, element nodes recurse through `walk`.
   function descend(el: unknown): void {
-    for (const child of $(el as never)
-      .contents()
-      .toArray()) {
+    for (const child of (el as { children?: unknown[] }).children ?? []) {
       const cn = child as { type?: string; data?: string };
       if (cn.type === "text") {
         const t = (cn.data ?? "").replace(/\s+/g, " ").trim();

--- a/src/sec/html/parseToBlocks.ts
+++ b/src/sec/html/parseToBlocks.ts
@@ -52,6 +52,21 @@ function isPageBreak($: CheerioAPI, el: unknown): boolean {
   return false;
 }
 
+/** Every comment node in the subtree, in document order. */
+function collectComments(root: unknown): unknown[] {
+  const found: unknown[] = [];
+  const visit = (node: unknown): void => {
+    const children = (node as { children?: unknown[] }).children;
+    if (children === undefined) return;
+    for (const child of children) {
+      if ((child as { type?: string }).type === "comment") found.push(child);
+      else visit(child);
+    }
+  };
+  visit(root);
+  return found;
+}
+
 function emitProse(buffer: string[], out: EdgarBlock[]): void {
   const text = buffer
     .join("\n\n")
@@ -86,10 +101,13 @@ export function parseToBlocks(html: string): EdgarBlock[] {
   // `type === "comment"`, and while the walker only reads element/text
   // children, any consumer that later calls `.text()` on a raw parent would
   // otherwise see their contents.
-  $("*")
-    .contents()
-    .filter((_i, el) => (el as { type?: string }).type === "comment")
-    .remove();
+  //
+  // Collected with one linear DOM walk rather than `$("*").contents()`, whose
+  // cost grows superlinearly with element count: on a 7 MB S-1 (63k elements)
+  // that single call took ~14s of a ~16s parse, and found no comments at all.
+  for (const comment of collectComments($.root().get(0))) {
+    $(comment as never).remove();
+  }
 
   const out: EdgarBlock[] = [];
   const prose: string[] = [];


### PR DESCRIPTION
## Summary

This PR eliminates redundant DOM traversals that were causing significant performance bottlenecks in HTML parsing and style resolution. By replacing multiple selector engine calls with single linear walks and caching parsed fixtures, we reduce the time complexity of processing large SEC filings from superlinear to linear.

## Key Changes

- **StyleResolver.ts**: Introduced `scanDescendants()` function that performs a single DOM walk to collect emphasis tags (`<b>`, `<strong>`, `<i>`, `<em>`, `<u>`) and legacy font sizes, replacing four separate `$el.find()` calls. This eliminates redundant selector engine traversals that were called once per prose block.

- **StyleResolver.ts**: Refactored `resolveStyle()` to use raw domhandler node traversal instead of cheerio wrapper objects, avoiding object allocation per ancestor per block. Changed from `cur.parent()` to direct `cur.parent` property access.

- **parseToBlocks.ts**: Introduced `collectComments()` function for a single linear DOM walk to find comment nodes, replacing `$("*").contents().filter()` which had superlinear cost growth with element count (e.g., ~14s of ~16s parse time on a 7 MB S-1 with 63k elements).

- **parseToBlocks.ts**: Removed cheerio wrapper usage in `isPageBreak()` and `descend()` functions, using raw domhandler properties and direct `children` array access instead of `$(el).attr()` and `$(el).contents()`.

- **realSections.ts**: Added fixture parse caching via `segmentedFixtures` map and `segmentFixture()` function. Since the committed corpus never changes during a process, this eliminates redundant re-parsing of tens of MB of HTML across multiple test runs.

- **realSections.ts**: Added early exit in `loadRealS1Sections()` when no extractors match, avoiding unnecessary corpus segmentation.

- **Test files**: Added `CORPUS_PARSE_TIMEOUT_MS` constant (120s) to tests that trigger initial corpus parsing, providing adequate headroom for the first parse while later tests benefit from the cache.

## Implementation Details

- The `DescendantTraits` interface encapsulates the results of a single descendant walk, making the optimization explicit and maintainable.
- Raw domhandler traversal (`node.parent`, `node.children`, `node.attribs`) replaces cheerio wrappers, which allocate objects per node per operation.
- Comment collection now uses a single recursive walk instead of cheerio's selector engine, which was the primary bottleneck on large documents.
- Fixture caching is transparent to callers and uses absolute paths as keys to ensure correctness across different test invocations.

https://claude.ai/code/session_016mhX8KBNHn6MQdugusiTgr