### PR TITLE
fix: restore extraction default model, ratio-gate risk-caption shape, deterministic outcome counts, fail-fast config errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,12 @@ _rank_ it, not to adopt it: score it against golden truth
 (`sec eval s1 --reference golden`) before trusting it for production extraction.
 Its cost line uses DeepSeek's **cache-miss** input price, since each section is a
 distinct prompt that never hits the context cache; DeepSeek has also announced
-(not yet enabled) 2x peak-hour pricing, which the table does not model.
+(not yet enabled) 2x peak-hour pricing, which the table does not model. Adopting
+it is a per-deployment env-var opt-in, never a change to the built-in default
+(`DEFAULT_SEC_MODEL`, which stays on a schema-enforced Anthropic id): set
+`SEC_MODEL_DEFAULT=deepseek-v4-flash` to switch every extractor at once, or
+`SEC_S1_RISK_FACTORS_MODEL=deepseek-v4-flash` to switch only the chunked
+risk-factors section that dominates per-filing cost.
 
 > ⚠️ **DeepSeek's `json-mode` is not schema-enforced.** The API supports only
 > `response_format: {type: "json_object"}` — it rejects the OpenAI `json_schema`

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -25,6 +25,7 @@ import { registerSpacCommands } from "./spac";
 import { registerEditorialCommands } from "./editorial";
 import { DefaultDI } from "../config/DefaultDI";
 import { EnvToDI } from "../config/EnvToDI";
+import { getExtractionTemperature } from "../config/extractionTemperature";
 import { registerSecModels } from "../config/registerModels";
 import { registerSecProviders } from "../config/registerProviders";
 import { registerSecResolvers } from "../config/registerResolvers";
@@ -71,6 +72,13 @@ export const AddCommands = (program: Command): void => {
     }
 
     EnvToDI();
+    // Validate the extraction sampling knob at startup. Its only other caller
+    // is inside the per-section handler that turns any throw into a
+    // version-gated dead letter, so a malformed SEC_EXTRACTION_TEMPERATURE
+    // would otherwise be recorded once per section per filing as an extraction
+    // failure no version bump can fix, instead of aborting here naming the
+    // variable.
+    getExtractionTemperature();
     DefaultDI();
     registerSecResolvers();
     await registerSecModels();

--- a/src/config/Constants.ts
+++ b/src/config/Constants.ts
@@ -34,8 +34,15 @@ export const SecFetchMaxPerSec = ((): number => {
  * General default model id shared by every SEC AI extractor (S-1, merger-proxy,
  * redemption) when its own env override (e.g. SEC_S1_MODEL) is unset. Override
  * for all extractors at once via the SEC_MODEL_DEFAULT environment variable.
+ *
+ * The default stays on a provider whose `json-mode` is schema-enforced
+ * server-side: a default that a deployment holding only ANTHROPIC_API_KEY
+ * cannot resolve turns every AI section into a MODEL_RESOLUTION_ERROR dead
+ * letter. A cheaper tier is adopted per deployment through SEC_MODEL_DEFAULT
+ * (all extractors) or a per-extractor variable such as
+ * SEC_S1_RISK_FACTORS_MODEL, after ranking it with `sec eval s1`.
  */
-const DEFAULT_SEC_MODEL = "deepseek-v4-flash";
+export const DEFAULT_SEC_MODEL = "claude-sonnet-5";
 export const SecModelDefault = process.env.SEC_MODEL_DEFAULT?.trim() || DEFAULT_SEC_MODEL;
 
 /**

--- a/src/config/extractionTemperature.ts
+++ b/src/config/extractionTemperature.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SecCliConfigurationError } from "./EnvToDI";
+
+/**
+ * Sampling temperature for every extraction call. Defaults to 0 (greedy).
+ *
+ * Extraction is a transcription task, not a generative one — the answer is
+ * already in the filing — but nothing pinned the temperature, so calls ran at
+ * the provider default of 1.0. Measured on one filing across three clean runs,
+ * that produced 138/138/109 risk factors whose contents differed in ALL THREE
+ * cases: the two 138-row runs disagreed on which captions they found, not just
+ * how many. Re-processing a filing therefore rewrote its disclosures with a
+ * different list each time.
+ *
+ * `SEC_EXTRACTION_TEMPERATURE` overrides it; an empty value omits the parameter
+ * altogether.
+ *
+ * A malformed or out-of-range value throws rather than degrading. Coercing
+ * `"0,5"` to `0` reads back as "greedy sampling is on" — the operator sees
+ * exactly the behavior they asked for the opposite of, with nothing anywhere
+ * saying the setting was ignored. The whole point of the variable is to control
+ * determinism, so silently discarding it is the one failure mode it must not
+ * have.
+ *
+ * It lives in `config/` rather than beside its call site because the thrown
+ * error must reach the operator, not the dead-letter worklist: the CLI calls it
+ * once at startup so a malformed value aborts naming the variable, instead of
+ * every section of every filing recording a version-gated extraction failure
+ * that no version bump can fix.
+ */
+export function getExtractionTemperature(): number | undefined {
+  const raw = process.env.SEC_EXTRACTION_TEMPERATURE;
+  if (raw === undefined) return 0;
+  if (raw.trim() === "") return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    throw new SecCliConfigurationError(
+      `SEC_EXTRACTION_TEMPERATURE is not a number: ${JSON.stringify(raw)}. ` +
+        `Set a value in [0, 2], or set it empty to omit the parameter entirely.`
+    );
+  }
+  if (n < 0 || n > 2) {
+    throw new SecCliConfigurationError(
+      `SEC_EXTRACTION_TEMPERATURE is out of range: ${n}. Sampling temperature must be in [0, 2].`
+    );
+  }
+  return n;
+}

--- a/src/config/registerModels.test.ts
+++ b/src/config/registerModels.test.ts
@@ -11,7 +11,7 @@ import {
   setGlobalModelRepository,
 } from "workglow";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { SecHftModelDefault, SecModelDefault } from "./Constants";
+import { DEFAULT_SEC_MODEL, SecHftModelDefault, SecModelDefault } from "./Constants";
 import { SecCliConfigurationError } from "./EnvToDI";
 import {
   anthropicModelRecord,
@@ -141,6 +141,21 @@ describe("registerSecModels", () => {
       secModelRecord(SecModelDefault).provider
     );
     expect((await repo.findByName(SecHftModelDefault))?.provider).toBe("HF_TRANSFORMERS_ONNX");
+  });
+
+  it("pins the built-in default to a schema-enforced cloud model", () => {
+    // Deliberately NOT derived from SecModelDefault: the derived test above
+    // asserts the wiring, so nothing failed when the built-in value itself was
+    // changed. A default whose provider a deployment has no key for
+    // dead-letters every AI section with MODEL_RESOLUTION_ERROR, and a default
+    // whose json-mode is not schema-enforced raises the schema-failure rate on
+    // every extractor at once. Adopting another tier is an env-var opt-in
+    // (SEC_MODEL_DEFAULT / a per-extractor variable), not a change here.
+    expect(DEFAULT_SEC_MODEL).toBe("claude-sonnet-5");
+    expect(secModelRecord(DEFAULT_SEC_MODEL).provider).toBe("ANTHROPIC");
+    // `.env.test` sets no SEC_MODEL_DEFAULT, and beforeEach deletes it, so the
+    // exported default is what the extractors actually resolve to here.
+    expect(SecModelDefault).toBe(DEFAULT_SEC_MODEL);
   });
 
   it("is idempotent — a second run does not duplicate or throw", async () => {

--- a/src/sec/forms/registration-statements/s1/extractRiskFactors.test.ts
+++ b/src/sec/forms/registration-statements/s1/extractRiskFactors.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
-import { extractRiskFactors, MixedRiskCaptionShapeError } from "./sectionExtractors";
+import {
+  extractRiskFactors,
+  MIXED_SHAPE_FAIL_RATIO,
+  MixedRiskCaptionShapeError,
+} from "./sectionExtractors";
 import { RISK_FACTOR_CHUNK_CHARS } from "./riskFactorChunks";
 import { fakeS1Model, registerFakeStructuredProvider } from "./testing/fakeStructuredProvider";
 
@@ -114,6 +118,66 @@ describe("extractRiskFactors", () => {
     await expect(
       extractRiskFactors(`Summary of Risk Factors\n\n${bare.join("\n\n")}`, fakeS1Model())
     ).rejects.toThrow(MixedRiskCaptionShapeError);
+  });
+
+  it("drops the chunk-prefix heading echoes instead of losing every real caption", async () => {
+    // The regression the ratio gate exists for. chunkRiskFactorText prefixes
+    // every chunk after the first with the last category heading, so a section
+    // large enough to chunk hands the model roughly one heading per chunk and
+    // invites it to echo them back. An all-or-nothing rule turned six such
+    // strays into a version-gated dead letter that discarded all 90 captions.
+    const captions = Array.from(
+      { length: 90 },
+      (_, i) => `We may be unable to complete our initial business combination number ${i + 1}.`
+    );
+    const echoes = Array.from({ length: 6 }, (_, i) => `Risks Relating to our Securities ${i + 1}`);
+    const { unregister } = registerFakeStructuredProvider([
+      { risks: [...captions.map((c) => risk(c)), ...echoes.map((e) => risk(e, null))] },
+    ]);
+    cleanup = unregister;
+
+    const rows = await extractRiskFactors("Some risk prose.", fakeS1Model());
+    expect(rows.map((r) => r.headline)).toEqual(captions);
+    expect(6 / 96).toBeLessThan(MIXED_SHAPE_FAIL_RATIO);
+  });
+
+  it("fails at exactly MIXED_SHAPE_FAIL_RATIO, so the boundary is inclusive", async () => {
+    // 3 of 12 is exactly the ratio: a section this mixed is unanswerable, and
+    // the gate must not let the boundary case through on a `>` comparison.
+    const headingCount = 3;
+    const total = Math.round(headingCount / MIXED_SHAPE_FAIL_RATIO);
+    const captions = Array.from(
+      { length: total - headingCount },
+      (_, i) => `Our securities may be delisted for reason ${i + 1}.`
+    );
+    const headings = Array.from(
+      { length: headingCount },
+      (_, i) => `Risks Relating to our Business ${i + 1}`
+    );
+    const { unregister } = registerFakeStructuredProvider([
+      { risks: [...captions.map((c) => risk(c)), ...headings.map((h) => risk(h, null))] },
+    ]);
+    cleanup = unregister;
+
+    await expect(extractRiskFactors("Some risk prose.", fakeS1Model())).rejects.toThrow(
+      MixedRiskCaptionShapeError
+    );
+  });
+
+  it("keeps every caption of an all-sentence list, with nothing heading-shaped to drop", async () => {
+    // The other homogeneous case, pinned beside the drop: no row is
+    // heading-shaped, so the gate is never entered and the list passes through.
+    const captions = Array.from(
+      { length: 12 },
+      (_, i) => `We may be unable to complete our initial business combination number ${i + 1}.`
+    );
+    const { unregister } = registerFakeStructuredProvider([
+      { risks: captions.map((c) => risk(c)) },
+    ]);
+    cleanup = unregister;
+
+    const rows = await extractRiskFactors("Some risk prose.", fakeS1Model());
+    expect(rows.map((r) => r.headline)).toEqual(captions);
   });
 
   it("keeps every bullet of an all-bare-phrase summary list", async () => {

--- a/src/sec/forms/registration-statements/s1/extractionTemperature.test.ts
+++ b/src/sec/forms/registration-statements/s1/extractionTemperature.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
+import { SecCliConfigurationError } from "../../../../config/EnvToDI";
+import { getExtractionTemperature as getExtractionTemperatureFromConfig } from "../../../../config/extractionTemperature";
 import { getExtractionTemperature, isTemperatureUnsupportedError } from "./sectionExtractors";
 
 const KEY = "SEC_EXTRACTION_TEMPERATURE";
@@ -45,8 +47,26 @@ describe("getExtractionTemperature", () => {
   it("rejects a temperature outside the [0, 2] sampling range", () => {
     process.env[KEY] = "5";
     expect(() => getExtractionTemperature()).toThrow(/out of range/);
+    process.env[KEY] = "3";
+    expect(() => getExtractionTemperature()).toThrow(/out of range/);
     process.env[KEY] = "-1";
     expect(() => getExtractionTemperature()).toThrow(/out of range/);
+  });
+
+  it("throws a configuration error, the class the pipeline exempts from dead-lettering", () => {
+    // The type is what carries the fix: a bad env value is wrong for every
+    // section of every filing, so the section runner and the form task both
+    // re-throw this class instead of recording a version-gated dead letter.
+    process.env[KEY] = "0,5";
+    expect(() => getExtractionTemperature()).toThrow(SecCliConfigurationError);
+    process.env[KEY] = "3";
+    expect(() => getExtractionTemperature()).toThrow(SecCliConfigurationError);
+  });
+
+  it("is the same function whether reached through config or the extractors module", () => {
+    // It moved to `config/` so the CLI can validate it at startup; the
+    // extractors module re-exports it so call sites did not have to move.
+    expect(getExtractionTemperature).toBe(getExtractionTemperatureFromConfig);
   });
 
   it("accepts the range bounds", () => {

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.ts
@@ -7,7 +7,7 @@
 import type { IExecuteContext, ModelConfig } from "workglow";
 import { StructuredGenerationTask } from "workglow";
 import { createHash } from "node:crypto";
-import { SecCliConfigurationError } from "../../../../config/EnvToDI";
+import { getExtractionTemperature } from "../../../../config/extractionTemperature";
 import { ensureModelDownloaded } from "../../../../task/model/EnsureModelDownloadedTask";
 import { resolveModelId } from "./s1Model";
 import { MIN_SPAN_CAP_CHARS } from "./verifySourceSpan";
@@ -46,6 +46,11 @@ import { RedemptionOutputSchema, type RedemptionRow } from "./redemptionSchema";
 import { LoiOutputSchema, type LoiRow } from "./loiSchema";
 import { normalizeManagementTitles } from "./normalizeTitle";
 
+// Re-exported so the extraction knob still reads as part of this module's
+// surface; it lives in `config/` because a malformed value must abort the CLI
+// rather than be caught by a per-section handler and dead-lettered.
+export { getExtractionTemperature } from "../../../../config/extractionTemperature";
+
 const MAX_TOKENS = 4096;
 
 /**
@@ -60,6 +65,20 @@ const MAX_TOKENS = 4096;
  * a target.
  */
 const RISK_FACTORS_MAX_TOKENS = 16_384;
+
+/**
+ * Share of heading-shaped rows at or above which a mixed-shape risk-factor
+ * section is unanswerable and fails, rather than having its heading-shaped rows
+ * dropped.
+ *
+ * A minority below this is the chunking artifact, not an ambiguous section:
+ * {@link chunkRiskFactorText} prefixes every chunk after the first with the last
+ * category heading, so the model is handed roughly one heading per chunk and
+ * echoes some back. A 246k-char section is ~7 chunks against ~90 captions —
+ * well under the ratio — and failing it would discard all ~90 for the sake of
+ * ~6 strays.
+ */
+export const MIXED_SHAPE_FAIL_RATIO = 0.25;
 
 /**
  * Thrown when a model's structured response fails to echo back the per-call
@@ -107,46 +126,6 @@ export class MixedRiskCaptionShapeError extends Error {
     );
     this.name = "MixedRiskCaptionShapeError";
   }
-}
-
-/**
- * Sampling temperature for every extraction call. Defaults to 0 (greedy).
- *
- * Extraction is a transcription task, not a generative one — the answer is
- * already in the filing — but nothing pinned the temperature, so calls ran at
- * the provider default of 1.0. Measured on one filing across three clean runs,
- * that produced 138/138/109 risk factors whose contents differed in ALL THREE
- * cases: the two 138-row runs disagreed on which captions they found, not just
- * how many. Re-processing a filing therefore rewrote its disclosures with a
- * different list each time.
- *
- * `SEC_EXTRACTION_TEMPERATURE` overrides it; an empty value omits the parameter
- * altogether.
- *
- * A malformed or out-of-range value throws rather than degrading. Coercing
- * `"0,5"` to `0` reads back as "greedy sampling is on" — the operator sees
- * exactly the behavior they asked for the opposite of, with nothing anywhere
- * saying the setting was ignored. The whole point of the variable is to control
- * determinism, so silently discarding it is the one failure mode it must not
- * have.
- */
-export function getExtractionTemperature(): number | undefined {
-  const raw = process.env.SEC_EXTRACTION_TEMPERATURE;
-  if (raw === undefined) return 0;
-  if (raw.trim() === "") return undefined;
-  const n = Number(raw);
-  if (!Number.isFinite(n)) {
-    throw new SecCliConfigurationError(
-      `SEC_EXTRACTION_TEMPERATURE is not a number: ${JSON.stringify(raw)}. ` +
-        `Set a value in [0, 2], or set it empty to omit the parameter entirely.`
-    );
-  }
-  if (n < 0 || n > 2) {
-    throw new SecCliConfigurationError(
-      `SEC_EXTRACTION_TEMPERATURE is out of range: ${n}. Sampling temperature must be in [0, 2].`
-    );
-  }
-  return n;
 }
 
 /**
@@ -1468,14 +1447,29 @@ export async function extractRiskFactors(
   //   combination"), so the "headings" ARE the captions. Kept.
   // - no row heading-shaped — an ordinary Item 105 list of sentence captions,
   //   with nothing to drop. Kept.
-  // - mixed — unanswerable. Filers are inconsistent about terminal punctuation,
-  //   so one summary bullet ending in a period is enough to make 29 bare-phrase
-  //   bullets look droppable; an all-or-nothing filter would keep the single
-  //   punctuated row and persist it as the filing's complete disclosure. Fail
-  //   the section instead of guessing.
+  // - mixed — answered by how large the heading-shaped minority is
+  //   (MIXED_SHAPE_FAIL_RATIO). Filers are inconsistent about terminal
+  //   punctuation, so one summary bullet ending in a period is enough to make
+  //   29 bare-phrase bullets look droppable; an all-or-nothing filter would
+  //   keep the single punctuated row and persist it as the filing's complete
+  //   disclosure. At or above the ratio the section is unanswerable and fails
+  //   rather than guessing; below it, the minority is the chunk-prefix echo
+  //   described at the drop below.
   const headingLike = out.filter((risk) => isRiskCategoryHeading(risk.headline)).length;
   if (headingLike > 0 && headingLike < out.length) {
-    throw new MixedRiskCaptionShapeError(headingLike, out.length);
+    if (headingLike / out.length >= MIXED_SHAPE_FAIL_RATIO) {
+      throw new MixedRiskCaptionShapeError(headingLike, out.length);
+    }
+    // A small minority of heading-shaped rows is the expected artifact of
+    // chunking, not an ambiguous section: every chunk after the first is
+    // prefixed with the last category heading seen before it, so a ~7-chunk
+    // section hands the model ~6 headings and invites it to echo them back as
+    // rows. Failing the section on those discards every real caption it found,
+    // so drop the handful and keep the disclosure. Only when heading-shaped
+    // rows are a large enough share is the section's shape genuinely
+    // unanswerable (a summary-bullet list whose bullets ARE the captions).
+    console.warn(`risk factors: dropped ${headingLike} heading-shaped row(s) of ${out.length}`);
+    return out.filter((risk) => !isRiskCategoryHeading(risk.headline));
   }
   return out;
 }

--- a/src/sec/forms/registration-statements/s1/sectionRunner.test.ts
+++ b/src/sec/forms/registration-statements/s1/sectionRunner.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { SecCliConfigurationError } from "../../../../config/EnvToDI";
 import type { ExtractionDeadLetterRepo } from "../../../../storage/dead-letter/ExtractionDeadLetterRepo";
 import { VERIFICATION_ATTEMPTS, makeRunSection, parseConfidenceFloor } from "./sectionRunner";
 
@@ -276,5 +277,38 @@ describe("makeRunSection confidenceFloor", () => {
       persist: async () => 0,
     });
     expect(call).toBe(1);
+  });
+});
+
+describe("makeRunSection configuration errors", () => {
+  it("propagates a SecCliConfigurationError instead of dead-lettering it", async () => {
+    // A malformed SEC_EXTRACTION_TEMPERATURE is wrong for every section of
+    // every filing. Recorded as MODEL_INVALID_OUTPUT it would stamp a
+    // version-gated entry across the whole corpus that no version bump can
+    // clear, and the operator would never see the message naming the variable.
+    const { repo, letters, resolved } = stubDeadLetters();
+    const runSection = makeRunSection({
+      deadLetters: repo,
+      extractor_id: "S-1",
+      extractor_version: "1.0.0",
+      accession_number: "acc-config",
+    });
+
+    await expect(
+      runSection<{ confidence: number; span: string }>({
+        sectionName: "management",
+        text: "Some text.",
+        emptyDetail: "none returned",
+        lowConfidenceDetail: "low",
+        verifyRow: (text, r) => text.includes(r.span),
+        extract: async () => {
+          throw new SecCliConfigurationError("SEC_EXTRACTION_TEMPERATURE is not a number");
+        },
+        persist: async () => 0,
+      })
+    ).rejects.toThrow(SecCliConfigurationError);
+
+    expect(letters).toEqual([]);
+    expect(resolved).toEqual([]);
   });
 });

--- a/src/sec/forms/registration-statements/s1/sectionRunner.ts
+++ b/src/sec/forms/registration-statements/s1/sectionRunner.ts
@@ -6,6 +6,7 @@
 
 import type { ExtractionDeadLetterRepo } from "../../../../storage/dead-letter/ExtractionDeadLetterRepo";
 import type { DeadLetterReasonCode } from "../../../../storage/dead-letter/ExtractionDeadLetterSchema";
+import { SecCliConfigurationError } from "../../../../config/EnvToDI";
 import { MixedRiskCaptionShapeError, NonceMismatchError } from "./sectionExtractors";
 import type { SpanVerdict } from "./verifySourceSpan";
 
@@ -231,6 +232,13 @@ export function makeRunSection(opts: {
         }
       }
     } catch (e) {
+      // A configuration error is not an extraction failure: the value is wrong
+      // for every section of every filing, so recording it would stamp a
+      // version-gated dead letter across the whole corpus that no version bump
+      // can clear. Let it reach the operator instead. (The CLI validates the
+      // same knob at startup; this covers a library consumer that never runs
+      // that hook.)
+      if (e instanceof SecCliConfigurationError) throw e;
       // A NonceMismatchError is a defense-in-depth signal that the model's
       // structured response did not echo back the per-call verification token;
       // record it under a dedicated reason code so an operator can triage

--- a/src/task/forms/FetchAndStoreFormsTask.test.ts
+++ b/src/task/forms/FetchAndStoreFormsTask.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { globalServiceRegistry, type IExecuteContext } from "workglow";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
+import {
+  EXTRACTOR_RUN_REPOSITORY_TOKEN,
+  type ExtractorRun,
+} from "../../storage/versioning/ExtractorRunSchema";
+import { FetchAndStoreFormsTask } from "./FetchAndStoreFormsTask";
+import { ProcessAccessionDocFormTask } from "./ProcessAccessionDocFormTask";
+
+const CIK = 1234567;
+const ACC = "0001234567-26-000001";
+
+async function seedFiling(form: string): Promise<void> {
+  const repo = globalServiceRegistry.get(FILING_REPOSITORY_TOKEN);
+  await repo.put({
+    cik: CIK,
+    accession_number: ACC,
+    form,
+    primary_doc: "doc.htm",
+    file_number: "333-1",
+    filing_date: "2026-01-02",
+    acceptance_date: "2026-01-02T00:00:00.000Z",
+    report_date: null,
+    film_number: null,
+    primary_doc_description: null,
+    size: null,
+    is_xbrl: null,
+    is_inline_xbrl: null,
+    items: null,
+    act: null,
+  } as never);
+}
+
+/**
+ * Writes a run row straight through the storage rather than `recordRun`, which
+ * stamps `ran_at` with the current time — these tests are about which row the
+ * counter picks, so both the timestamp and the insertion order must be chosen.
+ */
+async function seedRun(row: {
+  extractor_id: string;
+  extractor_version: string;
+  outcome: ExtractorRun["outcome"];
+  ran_at: string;
+  form: string;
+}): Promise<void> {
+  await globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN).put({
+    cik: CIK,
+    accession_number: ACC,
+    form: row.form,
+    extractor_id: row.extractor_id,
+    extractor_version: row.extractor_version,
+    slot_at_run: "current",
+    ran_at: row.ran_at,
+    success: row.outcome === "success",
+    outcome: row.outcome,
+    error: null,
+  } as ExtractorRun);
+}
+
+/**
+ * The counting logic under test reads back rows the sub-task would otherwise
+ * write; a no-op keeps the seeded rows as the only input.
+ */
+function stubProcessing(): () => void {
+  const proto = ProcessAccessionDocFormTask.prototype;
+  const real = proto.execute;
+  proto.execute = async () => ({ success: true });
+  return () => {
+    proto.execute = real;
+  };
+}
+
+async function runTask(form: string): Promise<{
+  succeeded: number;
+  partial: number;
+  failed: number;
+  triage: number;
+}> {
+  const restore = stubProcessing();
+  try {
+    const task = new FetchAndStoreFormsTask();
+    return await task.execute({ cik: CIK, form }, {
+      own: <T>(value: T) => value,
+    } as unknown as IExecuteContext);
+  } finally {
+    restore();
+  }
+}
+
+describe("FetchAndStoreFormsTask outcome counts", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+  });
+
+  it("counts only the form's own extractor, not the sub-extractors it gates", async () => {
+    // A known-SPAC 8-K writes three run rows for one filing: the form's own
+    // `8-K` extractor plus the `loi` and `redemption` sub-extractors. Counting
+    // every row for the accession reported the filing as failed whenever a
+    // sub-extractor's row happened to come back last.
+    await seedFiling("8-K");
+    await seedRun({
+      extractor_id: "8-K",
+      extractor_version: "1.0.0",
+      outcome: "success",
+      ran_at: "2026-02-01T00:00:00.000Z",
+      form: "8-K",
+    });
+    await seedRun({
+      extractor_id: "loi",
+      extractor_version: "1.0.0",
+      outcome: "failure",
+      ran_at: "2026-02-01T00:00:01.000Z",
+      form: "8-K",
+    });
+    await seedRun({
+      extractor_id: "redemption",
+      extractor_version: "1.0.0",
+      outcome: "failure",
+      ran_at: "2026-02-01T00:00:02.000Z",
+      form: "8-K",
+    });
+
+    const out = await runTask("8-K");
+    expect(out.succeeded).toBe(1);
+    expect(out.failed).toBe(0);
+    expect(out.partial).toBe(0);
+  });
+
+  it("takes the newest run by ran_at, not the last row a query returned", async () => {
+    // The re-run case: the PK includes extractor_version, so an older attempt's
+    // row survives beside the new one. Row order is not guaranteed on any
+    // backend, and here the older row is inserted last.
+    await seedFiling("8-K");
+    await seedRun({
+      extractor_id: "8-K",
+      extractor_version: "1.1.0",
+      outcome: "success",
+      ran_at: "2026-03-01T00:00:00.000Z",
+      form: "8-K",
+    });
+    await seedRun({
+      extractor_id: "8-K",
+      extractor_version: "1.0.0",
+      outcome: "failure",
+      ran_at: "2026-01-01T00:00:00.000Z",
+      form: "8-K",
+    });
+
+    const out = await runTask("8-K");
+    expect(out.succeeded).toBe(1);
+    expect(out.failed).toBe(0);
+  });
+
+  it("counts a filing with no run row for its extractor as failed", async () => {
+    await seedFiling("8-K");
+    await seedRun({
+      extractor_id: "loi",
+      extractor_version: "1.0.0",
+      outcome: "success",
+      ran_at: "2026-02-01T00:00:00.000Z",
+      form: "8-K",
+    });
+
+    const out = await runTask("8-K");
+    expect(out.succeeded).toBe(0);
+    expect(out.failed).toBe(1);
+  });
+
+  it("throws naming the form when no extractor is wired for it", async () => {
+    await seedFiling("NOT-A-FORM");
+    await expect(runTask("NOT-A-FORM")).rejects.toThrow(/NOT-A-FORM/);
+  });
+});

--- a/src/task/forms/FetchAndStoreFormsTask.ts
+++ b/src/task/forms/FetchAndStoreFormsTask.ts
@@ -9,7 +9,9 @@ import { globalServiceRegistry, IExecuteContext, Task, TaskError, Workflow } fro
 import { TypeSecCik } from "../../sec/submissions/EnititySubmissionSchema";
 import { type Filing, FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
 import { EXTRACTION_DEAD_LETTER_REPOSITORY_TOKEN } from "../../storage/dead-letter/ExtractionDeadLetterSchema";
+import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
 import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
+import { formToExtractorId } from "../../storage/versioning/extractorIds";
 import { stripXslPrefix } from "../../util/accessionDocPath";
 import { ProcessAccessionDocFormTask } from "./ProcessAccessionDocFormTask";
 
@@ -134,22 +136,33 @@ export class FetchAndStoreFormsTask extends Task<
     // ProcessAccessionDocFormTask contains its own failures and returns rather
     // than throwing, so without reading these back a filing whose sections all
     // dead-lettered is indistinguishable from a clean run.
-    const runRepo = globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN);
+    const runRepo = new ExtractorRunRepo(globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN));
     const deadLetterRepo = globalServiceRegistry.get(EXTRACTION_DEAD_LETTER_REPOSITORY_TOKEN);
+    // The outcome being counted is this form's own extractor. A filing writes a
+    // run row per extractor that touched it — a known-SPAC 8-K writes `8-K`,
+    // `loi` and `redemption` — so an unfiltered read mixes sub-extractor
+    // outcomes into the count for the form the operator asked for.
+    const extractorId = formToExtractorId(form);
+    if (extractorId === undefined) {
+      throw new TaskError(`No extractor is wired for form '${form}'`);
+    }
     let succeeded = 0;
     let partial = 0;
     let failed = 0;
     let triage = 0;
     for (const filing of filings) {
-      const runs =
-        (await runRepo.query({ cik, accession_number: filing.accession_number })) ?? [];
-      // Newest version wins: this task deliberately re-processes, and the PK
-      // includes extractor_version, so an older attempt's row can still be here.
-      const latest = runs.at(-1);
+      // Newest run wins by `ran_at`, not by row order: this task deliberately
+      // re-processes and the PK includes extractor_version, so an older
+      // attempt's row can still be here, and no backend guarantees the order a
+      // query returns rows in.
+      const latest = await runRepo.findLatestRun(cik, filing.accession_number, extractorId);
       if (latest?.outcome === "success") succeeded++;
       else if (latest?.outcome === "partial") partial++;
       else failed++;
 
+      // Deliberately NOT filtered to `extractorId`: every pending entry on this
+      // accession is genuine triage produced by this fetch, including the ones
+      // the sub-extractors (`loi`, `redemption`) wrote while processing it.
       const pending =
         (await deadLetterRepo.query({
           accession_number: filing.accession_number,

--- a/src/task/forms/ProcessAccessionDocFormTask.configerror.test.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.configerror.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { globalServiceRegistry } from "workglow";
+import { SecCliConfigurationError } from "../../config/EnvToDI";
+import { resetDependencyInjectionsForTesting } from "../../config/TestingDI";
+import { setupAllDatabases } from "../../config/setupAllDatabases";
+import { SEC_RAW_DATA_FOLDER } from "../../config/tokens";
+import { ExtractionDeadLetterRepo } from "../../storage/dead-letter/ExtractionDeadLetterRepo";
+import { FILING_REPOSITORY_TOKEN } from "../../storage/filing/FilingSchema";
+import { ExtractorRunRepo } from "../../storage/versioning/ExtractorRunRepo";
+import { EXTRACTOR_RUN_REPOSITORY_TOKEN } from "../../storage/versioning/ExtractorRunSchema";
+import { ProcessAccessionDocFormTask } from "./ProcessAccessionDocFormTask";
+
+// The store stage is reached through the form's storage module, so that module
+// is the seam: a misconfigured environment surfaces from inside it (the section
+// runner re-throws configuration errors rather than dead-lettering them).
+vi.mock("../../sec/forms/exempt-offerings/Form_D.storage", () => ({
+  processFormD: async () => {
+    throw new SecCliConfigurationError('SEC_EXTRACTION_TEMPERATURE is not a number: "0,5"');
+  },
+}));
+
+const CIK = 1018724;
+const ACCESSION = "0000000000-26-000151";
+
+const GOOD_FORM_D = readFileSync(
+  path.join(
+    __dirname,
+    "../../sec/forms/exempt-offerings/mock_data/form-d/000192959422000001-primary_doc.xml"
+  ),
+  "utf-8"
+);
+
+class ConfigErrorStoreTask extends ProcessAccessionDocFormTask {
+  protected override async runFetch(): Promise<string> {
+    return GOOD_FORM_D;
+  }
+}
+
+let rawRoot: string | undefined;
+
+async function seedFiling(): Promise<void> {
+  await globalServiceRegistry.get(FILING_REPOSITORY_TOKEN).put({
+    cik: CIK,
+    accession_number: ACCESSION,
+    form: "D",
+    primary_doc: "primary_doc.xml",
+    file_number: "333-1",
+    filing_date: "2026-01-02",
+    acceptance_date: "2026-01-02T00:00:00.000Z",
+    report_date: null,
+    film_number: null,
+    primary_doc_description: null,
+    size: null,
+    is_xbrl: null,
+    is_inline_xbrl: null,
+    items: null,
+    act: null,
+  } as never);
+}
+
+describe("ProcessAccessionDocFormTask configuration errors", () => {
+  beforeEach(async () => {
+    resetDependencyInjectionsForTesting();
+    await setupAllDatabases();
+    rawRoot = mkdtempSync(path.join(tmpdir(), "sec-cfg-"));
+    globalServiceRegistry.registerInstance(SEC_RAW_DATA_FOLDER, rawRoot);
+  });
+
+  afterEach(() => {
+    if (rawRoot) {
+      rmSync(rawRoot, { recursive: true, force: true });
+      rawRoot = undefined;
+    }
+    resetDependencyInjectionsForTesting();
+  });
+
+  it("re-throws a SecCliConfigurationError from the store stage rather than dead-lettering it", async () => {
+    // Without this escape, the section runner's re-throw only relocates the
+    // problem: every filing would take a filing-level STORE_ERROR instead of a
+    // per-section MODEL_INVALID_OUTPUT — equally version-gated, equally
+    // unfixable by a version bump, and equally silent about the env var.
+    await seedFiling();
+
+    await expect(
+      new ConfigErrorStoreTask().run({ accessionNumber: ACCESSION })
+    ).rejects.toThrowError(SecCliConfigurationError);
+
+    expect(await new ExtractionDeadLetterRepo().get("D", ACCESSION, "")).toBeFalsy();
+
+    const runRepo = new ExtractorRunRepo(globalServiceRegistry.get(EXTRACTOR_RUN_REPOSITORY_TOKEN));
+    expect(await runRepo.findRun(CIK, ACCESSION, "D", "1.0.0")).toBeUndefined();
+  });
+});

--- a/src/task/forms/ProcessAccessionDocFormTask.ts
+++ b/src/task/forms/ProcessAccessionDocFormTask.ts
@@ -14,6 +14,7 @@ import {
   TaskError,
   Workflow,
 } from "workglow";
+import { SecCliConfigurationError } from "../../config/EnvToDI";
 import { ALL_FORMS_MAP } from "../../sec/forms/all-forms";
 import type { ParsedFormDocument } from "../../sec/forms/parsedFormDocument";
 import { processForm1A } from "../../sec/forms/exempt-offerings/Form_1_A.storage";
@@ -725,6 +726,15 @@ export class ProcessAccessionDocFormTask extends Task<
     // would dead-letter every filing of that form on every sweep, forever,
     // wearing the same reason code as a genuine storage failure.
     if (storeError instanceof MissingStorageHandlerError) {
+      throw storeError;
+    }
+
+    // A misconfigured environment is not this filing's fault either. The
+    // per-section handler already re-throws these rather than dead-lettering;
+    // without the matching escape here that re-throw would merely convert a
+    // per-section MODEL_INVALID_OUTPUT storm into a filing-level STORE_ERROR
+    // storm, equally version-gated and equally wrong.
+    if (storeError instanceof SecCliConfigurationError) {
       throw storeError;
     }
 


### PR DESCRIPTION
Four reviewed fixes. Each prevents a concrete, silent data-loss or false-reporting failure in the extraction pipeline.

## ⚠️ Read first — commit 1 reverts a default-model change that may have been deliberate

`DEFAULT_SEC_MODEL` (`src/config/Constants.ts`) was flipped from `claude-sonnet-5` to `deepseek-v4-flash` in c3d7af1 ("feat: enhance command exports and improve error handling in fetch commands"), a commit that changed nothing else about model selection. **This PR sets it back.** If that flip was intentional, this is the commit to push back on — the reasoning for reverting it:

- **Provider-key availability.** It is the fallback for `getS1ModelId`, `getLoiModelId`, `getRedemptionModelId`, `getMergerProxyModelId` and the S-1 SPAC content classifier. A deployment holding only `ANTHROPIC_API_KEY` — the documented baseline — resolves nothing and dead-letters *every* AI section with `MODEL_RESOLUTION_ERROR`.
- **Schema enforcement.** CLAUDE.md's own warning: DeepSeek's `json-mode` is not schema-enforced (only `response_format: {type: "json_object"}`; the schema goes in the prompt and the model may ignore it). Anthropic/OpenAI/Gemini enforce server-side. The doc calls this "a reason to _rank_ it, not to adopt it".
- **Doc contradiction.** CLAUDE.md still documents `claude-sonnet-5` as the default in every extractor section.

**The DeepSeek opt-in is preserved unchanged**, and is now stated explicitly in CLAUDE.md's DeepSeek paragraph:

- `SEC_MODEL_DEFAULT=deepseek-v4-flash` — switches every extractor at once.
- `SEC_S1_RISK_FACTORS_MODEL=deepseek-v4-flash` — switches only the chunked risk-factors section that dominates per-filing cost.

The constant is now `export`ed so a test can assert the value itself. The existing test derives the provider from `SecModelDefault`, which is exactly why nothing failed when the built-in default changed underneath it; the derived test is kept, and a non-derived one added beside it. `s1Model.test.ts` / `loiModel.test.ts` / `redemptionModel.test.ts` stay derived — they test fallback wiring, not the value.

## The other three fixes

**2. Ratio-gate `MIXED_CAPTION_SHAPE` (`sectionExtractors.ts`).** `extractRiskFactors` threw `MixedRiskCaptionShapeError` whenever `0 < headingLike < out.length`, so one stray heading-shaped row discarded every real caption behind a version-gated dead letter. That stray is not rare: `chunkRiskFactorText` deliberately prefixes each chunk after the first with the last category heading, so a 246k-char section is ~7 chunks carrying ~6 headings the model is invited to echo back — losing ~89 captions. Heading-shaped rows below the exported `MIXED_SHAPE_FAIL_RATIO` (0.25) are now dropped with a warning; at or above it the section is genuinely unanswerable and still fails. Both homogeneous cases pass through untouched, and the 29-bullets-plus-one-punctuated regression still dead-letters. No "is this a standalone paragraph" refinement was added — in the summary-list case the bullets are standalone too, which would invert the guard.

**3. Deterministic outcome counts (`FetchAndStoreFormsTask.ts`).** The counter read every `extractor_runs` row for an accession and took `runs.at(-1)`, assuming an ordering Postgres does not guarantee and mixing in sub-extractor rows — a known-SPAC 8-K writes three (`8-K`, `loi`, `redemption`), so a sub-extractor failure landing last reported the filing as failed. The form's own extractor id is resolved once via `formToExtractorId` (an unwired form throws a `TaskError` naming it), and the outcome comes from `ExtractorRunRepo.findLatestRun` (max `ran_at` for that extractor across versions). The dead-letter **triage** count stays deliberately unfiltered — the `loi`/`redemption` entries are genuine triage for that fetch — now with a comment saying so, since it visibly differs from the run lookup.

Verified the old behaviour really was wrong: with the three rows seeded in order, `query(...).at(-1)` returns the `redemption` `failure` row, so both new tests fail against the previous logic.

**4. Configuration errors must not dead-letter.** `getExtractionTemperature()` throws `SecCliConfigurationError` but was only reachable from `runStructured` inside `makeRunSection`'s blanket `try/catch`, so a malformed `SEC_EXTRACTION_TEMPERATURE` (e.g. `0,5`) persisted a version-gated `MODEL_INVALID_OUTPUT` for every section of every filing — unfixable by a version bump, and the operator never sees the message naming the variable. It moves to `src/config/extractionTemperature.ts` (re-exported from `sectionExtractors.ts`, so call sites and existing tests are untouched) and the CLI `preAction` hook calls it once after `EnvToDI()` and before `registerSecModels()`, aborting startup on a bad value. For library consumers that skip that hook, **both** containment layers re-throw the class: `sectionRunner.ts`'s catch, and `ProcessAccessionDocFormTask.ts`'s store stage beside the existing `TaskAbortedError` / `MissingStorageHandlerError` escapes. Both are required — without the second, the per-section re-throw would only convert a `MODEL_INVALID_OUTPUT` storm into an equally version-gated filing-level `STORE_ERROR` storm. Confirmed by temporarily disabling the store-stage escape: the new test fails without it.

## Deliberately out of scope

A fifth reviewed finding — **person-normalization identity splits** in `src/storage/person/PersonNormalization.ts` — is **not** in this PR. It is not a code-only change: altering the normalizer repartitions canonical persons, so it needs a `sec version start-dev resolver person` ceremony plus a data-repair pass over existing identity links and `person_role` tenures. Shipping the code without the ceremony would silently split identities under the current resolver version. That file is untouched here.

## Verification

Commands run and their actual output.

`npx tsc --noEmit` — clean, no output:
```
TSC_OK
```

Targeted suites (`src/config/registerModels.test.ts`, all of `src/sec/forms/registration-statements/s1/`, all of `src/task/forms/`):
```
$ npx vitest run src/config/registerModels.test.ts src/sec/forms/registration-statements/s1/ src/task/forms/
 Test Files  44 passed (44)
      Tests  417 passed (417)
   Duration  38.09s
```

Full suite on this branch:
```
$ npx vitest run
 Test Files  308 passed | 4 skipped (312)
      Tests  2487 passed | 32 skipped (2519)
   Duration  233.28s
```

Full suite on `origin/main` for comparison (separate worktree, same node_modules):
```
 Test Files  306 passed | 4 skipped (310)
      Tests  2475 passed | 32 skipped (2507)
   Duration  233.81s
```

Honest note on one earlier run: an initial full-suite run on this branch reported 2 failures in `src/cli/groups/version.test.ts` (`promote with --force …`, `rollback swaps current and previous`) — both `Test timed out in 15000ms`. Those tests spawn the CLI as a subprocess and each already sits near their 15s budget. They pass standalone both with and without these changes, and the clean full-suite run above (idle machine, same command) reproduces no failure. They look like load-sensitive timeouts, not a regression, but flagging them rather than omitting them.

Formatting: new files pass `prettier --check`. `sectionExtractors.ts`, `sectionRunner.ts` and `CLAUDE.md` still report Prettier warnings — they do so on `origin/main` too (verified), so they were left alone rather than reformatted wholesale into this diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz)_