### PR TITLE
fix(resolver): revert person normalization changes that re-key identity without a version bump

### DIFF
--- a/src/resolver/EntityObserver.ts
+++ b/src/resolver/EntityObserver.ts
@@ -173,12 +173,6 @@ export class EntityObserver {
       ? normalizePerson({ name: fullName, cik: claim.cik ?? undefined })
       : undefined;
 
-    // Empty string, not null, is what `join` yields for a name carrying neither
-    // kind of suffix — so it is normalized back to null rather than stored as a
-    // blank that reads like "the filing wrote an empty suffix".
-    const parsedSuffixParts = [normalized?.suffix, normalized?.credentials].filter(Boolean);
-    const parsedSuffixDisplay = parsedSuffixParts.length > 0 ? parsedSuffixParts.join(", ") : null;
-
     const now = new Date().toISOString();
 
     // Upsert observation row
@@ -192,18 +186,13 @@ export class EntityObserver {
       first_name: clamp(claim.first_name ?? null, 128),
       middle_name: clamp(claim.middle_name ?? null, 128),
       last_name: clamp(claim.last_name ?? null, 128),
-      // The RAW suffix keeps the filing's annotation whole — generational and
-      // credential alike — because this column is display, not identity (only
-      // `normalized_suffix` reaches the resolver's match tuple). Extractors that
-      // hand over one `full_name` string supply no `claim.suffix`, so without
-      // the fallback a parsed-out "CPA" would be dropped entirely now that it no
-      // longer rides along in `normalized_suffix`.
-      suffix: clamp(claim.suffix ?? parsedSuffixDisplay, 32),
+      suffix: clamp(claim.suffix ?? null, 32),
       normalized_first: clamp(normalized?.first ?? null, 128),
       normalized_middle: clamp(normalized?.middle ?? null, 128),
       normalized_last: clamp(normalized?.last ?? null, 128),
-      // Generational only — a credential annotates a person, it does not
-      // identify one. See `splitSuffixParts`.
+      // Generational AND credential suffixes alike — this column is a member of
+      // the resolver's match tuple, so narrowing it to the generational half
+      // re-keys every canonical person and needs a resolver version bump.
       normalized_suffix: clamp(normalized?.suffix ?? null, 32),
       relationship: clamp(claim.relationship ?? null, 64),
       birth_year: claim.birth_year ?? null,

--- a/src/resolver/PersonResolver.test.ts
+++ b/src/resolver/PersonResolver.test.ts
@@ -19,6 +19,7 @@ import {
   type CanonicalPerson,
 } from "../storage/canonical/CanonicalPersonSchema";
 import type { PersonObservation } from "../storage/observation/PersonObservationSchema";
+import { normalizePerson } from "../storage/person/PersonNormalization";
 import { PersonResolver } from "./PersonResolver";
 
 function makeRepos() {
@@ -206,5 +207,82 @@ describe("PersonResolver.resolve", () => {
     expect(aliasCallCount).toBe(2);
     // Exactly one canonical row was minted — find-or-create remains serialised.
     expect(createCount).toBe(1);
+  });
+});
+
+/**
+ * `personKey` matches on the observation's STORED `normalized_*` columns, so a
+ * change to what `normalizePerson` writes into them re-partitions identity at
+ * whatever `resolver_version` happens to be active. These observations are
+ * therefore built the way `EntityObserver` builds them — from a display name
+ * through `normalizePerson` — rather than with hand-written normalized values,
+ * which would pin the resolver while leaving the hazard invisible.
+ */
+describe("PersonResolver identity is keyed off normalizePerson's output", () => {
+  let setup: ReturnType<typeof makeRepos>;
+  let resolver: PersonResolver;
+
+  beforeEach(() => {
+    setup = makeRepos();
+    resolver = new PersonResolver({
+      canonicalPersonRepo: setup.canonRepo,
+      canonicalPersonAliasRepo: setup.aliasRepo,
+      activeResolverVersion: "1.0.0",
+    });
+  });
+
+  function observed(name: string, observation_id: number): PersonObservation {
+    const n = normalizePerson({ name });
+    return obs({
+      observation_id,
+      cik: null,
+      source_filing_issuer_cik: 100,
+      first_name: n?.first ?? null,
+      middle_name: n?.middle ?? null,
+      last_name: n?.last ?? null,
+      suffix: n?.suffix ?? null,
+      normalized_first: n?.first ?? null,
+      normalized_middle: n?.middle ?? null,
+      normalized_last: n?.last ?? null,
+      normalized_suffix: n?.suffix ?? null,
+    });
+  }
+
+  it("resolves a parenthesized nickname and the bare name to ONE canonical person", async () => {
+    const withNickname = await resolver.resolve(observed("Yong (David) Yan", 1));
+    const bare = await resolver.resolve(observed("Yong Yan", 2));
+
+    const rows = await setup.canonStorage.getAll();
+    expect(
+      withNickname,
+      "A parenthesized nickname reached `normalized_middle`, so the same person " +
+        "no longer matches the canonical row written from the bare spelling. " +
+        "`normalized_middle` is a member of `PersonResolver.personKey`: moving a " +
+        "name part into it re-keys every `canonical_person` row already written " +
+        "at the active resolver_version, and the next filing naming that person " +
+        "mints a SECOND row at the SAME version. Bump the `person` resolver " +
+        "(sec version start-dev resolver person <next> --bump major), re-extract " +
+        "and re-resolve at the new version, then land the change."
+    ).toBe(bare);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("still splits people who differ in a real middle name", async () => {
+    const noMiddle = await resolver.resolve(observed("Yong Yan", 1));
+    const withMiddle = await resolver.resolve(observed("Yong David Yan", 2));
+    expect(withMiddle).not.toBe(noMiddle);
+    expect(await setup.canonStorage.getAll()).toHaveLength(2);
+  });
+
+  it("keeps a credential in the key — 'Jane Doe, CPA' is its own canonical row", async () => {
+    const credentialed = await resolver.resolve(observed("Jane Doe, CPA", 1));
+    const bare = await resolver.resolve(observed("Jane Doe", 2));
+
+    // The over-split the credential rule causes, pinned as-is. Narrowing
+    // `normalized_suffix` to the generational half alone fixes it and is worth
+    // doing — behind a `person` resolver version bump, because the canonical
+    // rows already carrying "Cpa" would otherwise stop matching silently.
+    expect(credentialed).not.toBe(bare);
+    expect(await setup.canonStorage.getAll()).toHaveLength(2);
   });
 });

--- a/src/sec/forms/registration-statements/s1/splitName.ts
+++ b/src/sec/forms/registration-statements/s1/splitName.ts
@@ -12,9 +12,9 @@ export interface SplitName {
   readonly last: string | null;
   /**
    * Both trailing parts as the filing wrote them — "Jr.", "CPA", or
-   * "Jr., CPA". This lands in the observation's raw `suffix` column, which is
-   * display rather than identity, so the credential belongs here; only
-   * `normalized_suffix` (generational alone) reaches the resolver's match tuple.
+   * "Jr., CPA". `parseFullName` reports them as separate `generation` and
+   * `credential` fields; they are rejoined here so this matches what
+   * `normalizePerson` derives `normalized_suffix` from.
    */
   readonly suffix: string | null;
 }

--- a/src/storage/person/PersonNormalization.test.ts
+++ b/src/storage/person/PersonNormalization.test.ts
@@ -206,82 +206,89 @@ describe("PersonNormalization", () => {
     });
   });
 
-  describe("credentials vs generational suffixes", () => {
-    // A credential says how ONE filing annotated a person; a generational
-    // suffix says WHICH person. Only the latter may reach the identity key.
-    it("keeps a credential out of the hash so the same person does not split", () => {
-      const bare = normalizePerson({ name: "Troy A. Hering" })!;
-      const credentialed = normalizePerson({ name: "Troy A. Hering CPA" })!;
-      expect(credentialed.person_hash_id).toBe(bare.person_hash_id);
-      expect(credentialed.suffix).toBeNull();
-      expect(credentialed.credentials).toBe("Cpa"); // fixCase:1 title-cases the display form
-      expect(credentialed.last).toBe("Hering");
-    });
+  // `normalized_first`, `normalized_middle`, `normalized_last` and
+  // `normalized_suffix` are derived from the four fields below and are four of
+  // the six columns `PersonResolver.personKey` matches on. Changing what lands
+  // in any of them re-keys every `canonical_person` row already written at the
+  // active `resolver_version`, so these cases are pinned explicitly: the next
+  // change to the rules has to show up as a diff here.
+  describe("resolver-key fields (frozen without a person resolver version bump)", () => {
+    describe("suffix carries credentials as well as generational suffixes", () => {
+      it("puts a bare credential in `suffix`, so it reaches the resolver key", () => {
+        const credentialed = normalizePerson({ name: "Jane Doe, CPA" })!;
+        // Title-cased by `fixCase: 1`; the column stores it verbatim.
+        expect(credentialed.suffix).toBe("Cpa");
+        expect(credentialed.first).toBe("Jane");
+        expect(credentialed.last).toBe("Doe");
+      });
 
-    it("collapses comma-written credentials onto the bare name", () => {
-      for (const [bare, annotated] of [
-        ["Isaac Manke", "Isaac Manke, Ph.D."],
-        ["Gbola Amusa", "Gbola Amusa, M.D., CFA"],
-        ["Andrew Lam", "Andrew Lam, PharmD"],
-      ]) {
-        expect(normalizePerson({ name: annotated })!.person_hash_id).toBe(
-          normalizePerson({ name: bare })!.person_hash_id
+      it("splits a credentialed person from the bare name", () => {
+        // This over-splitting is the known cost of the current rule, not an
+        // accident: "Jane Doe" and "Jane Doe, CPA" are two canonical people.
+        // Fixing it means moving the match tuple, which needs a version bump.
+        expect(normalizePerson({ name: "Jane Doe, CPA" })!.person_hash_id).not.toBe(
+          normalizePerson({ name: "Jane Doe" })!.person_hash_id
         );
-      }
+      });
+
+      it("keeps every comma-written credential in `suffix`", () => {
+        for (const [name, suffix] of [
+          ["Troy A. Hering CPA", "Cpa"],
+          ["Isaac Manke, Ph.D.", "PhD"],
+          ["Gbola Amusa, M.D., CFA", "MD Cfa"],
+          ["Andrew Lam, PharmD", "PharmD"],
+        ]) {
+          expect(normalizePerson({ name })!.suffix).toBe(suffix);
+        }
+      });
+
+      it("separates a generational suffix — father and son are two people", () => {
+        const father = normalizePerson({ name: "John Smith" })!;
+        const son = normalizePerson({ name: "John Smith Jr." })!;
+        expect(son.suffix).toBe("Jr");
+        expect(son.person_hash_id).not.toBe(father.person_hash_id);
+      });
+
+      it("joins both kinds into one suffix, generational first", () => {
+        const both = normalizePerson({ name: "John Smith Jr., CPA" })!;
+        expect(both.suffix).toBe("Jr Cpa");
+        expect(both.person_hash_id).not.toBe(
+          normalizePerson({ name: "John Smith Jr." })!.person_hash_id
+        );
+      });
     });
 
-    it("STILL separates a generational suffix — father and son are two people", () => {
-      const father = normalizePerson({ name: "John Smith" })!;
-      const son = normalizePerson({ name: "John Smith Jr." })!;
-      expect(son.person_hash_id).not.toBe(father.person_hash_id);
-      expect(son.suffix).toBe("Jr");
-    });
+    describe("a parenthesized nickname stays out of `middle`", () => {
+      it("leaves `middle` null and reports the nickname only in `nick`", () => {
+        const p = normalizePerson({ name: "Yong (David) Yan" })!;
+        expect(p.middle).toBeNull();
+        expect(p.nick).toBe("David");
+      });
 
-    it("splits a name carrying both kinds at once", () => {
-      const both = normalizePerson({ name: "John Smith Jr., CPA" })!;
-      expect(both.suffix).toBe("Jr");
-      expect(both.credentials).toBe("Cpa");
-      // The credential is invisible to identity, so it matches the plain junior
-      // and not the plain senior.
-      expect(both.person_hash_id).toBe(normalizePerson({ name: "John Smith Jr." })!.person_hash_id);
-      expect(both.person_hash_id).not.toBe(normalizePerson({ name: "John Smith" })!.person_hash_id);
-    });
-  });
+      it("matches the bare name — `nick` has no column in the resolver key", () => {
+        // `nick` never reaches a `normalized_*` column, so a filing that prints
+        // the nickname and an amendment that omits it are one canonical person.
+        expect(normalizePerson({ name: "Yong (David) Yan" })!.person_hash_id).toBe(
+          normalizePerson({ name: "Yong Yan" })!.person_hash_id
+        );
+      });
 
-  describe("a parenthesized nickname is identity-bearing", () => {
-    // Unlike a credential, a nickname is treated as part of who someone is: for
-    // the very common given-name + surname pairs an SEC roster holds, it is
-    // routinely the only token separating two people.
-    it("folds the nickname into `middle`, which is what the resolver keys on", () => {
-      const p = normalizePerson({ name: "Yong (David) Yan" })!;
-      expect(p.middle).toBe("David");
-      // Still exposed separately for display.
-      expect(p.nick).toBe("David");
-    });
+      it("does NOT match the same name written without parentheses", () => {
+        // The unparenthesized spelling is a real middle name, so it does reach
+        // the key. Folding "(David)" into `middle` would collapse these two —
+        // desirable, and gated on a resolver version bump.
+        expect(normalizePerson({ name: "Yong (David) Yan" })!.middle).toBeNull();
+        expect(normalizePerson({ name: "Yong David Yan" })!.middle).toBe("David");
+        expect(normalizePerson({ name: "Yong (David) Yan" })!.person_hash_id).not.toBe(
+          normalizePerson({ name: "Yong David Yan" })!.person_hash_id
+        );
+      });
 
-    it("agrees with the same name written without parentheses", () => {
-      // These disagreed before: the nickname went to `nick`, which has no column
-      // in the resolver's match tuple, so the parenthesized spelling resolved
-      // with middle=null and the plain one with middle="David".
-      expect(normalizePerson({ name: "Yong (David) Yan" })!.person_hash_id).toBe(
-        normalizePerson({ name: "Yong David Yan" })!.person_hash_id
-      );
-    });
-
-    it("separates a nicknamed person from the bare name", () => {
-      expect(normalizePerson({ name: "Yong (David) Yan" })!.person_hash_id).not.toBe(
-        normalizePerson({ name: "Yong Yan" })!.person_hash_id
-      );
-    });
-
-    it("does not overwrite a real middle name", () => {
-      const p = normalizePerson({ name: "Robert James (Bob) Smith" })!;
-      expect(p.middle).toBe("James");
-      expect(p.nick).toBe("Bob");
-    });
-
-    it("counts the nickname once — the hash is not 'david-david'", () => {
-      expect(normalizePerson({ name: "Yong (David) Yan" })!.person_hash_id).toBe("yong-david-yan");
+      it("leaves a real middle name alone alongside a nickname", () => {
+        const p = normalizePerson({ name: "Robert James (Bob) Smith" })!;
+        expect(p.middle).toBe("James");
+        expect(p.nick).toBe("Bob");
+      });
     });
   });
 });

--- a/src/storage/person/PersonNormalization.ts
+++ b/src/storage/person/PersonNormalization.ts
@@ -19,19 +19,12 @@ export type Person = {
   middle: string | null;
   last: string;
   /**
-   * Generational suffix ONLY — "Jr.", "Sr.", "III". This is identity-bearing:
-   * a junior and a senior sharing a name are different people, so the suffix
-   * belongs in {@link generatePersonHash} and in the resolver's match tuple.
+   * Every trailing name part as one comma-joined string — generational ("Jr.",
+   * "III") and professional ("CPA", "Ph.D.") alike. This reaches
+   * `normalized_suffix`, a member of the resolver's match tuple, so its spelling
+   * decides which canonical person an observation resolves to.
    */
   suffix: string | null;
-  /**
-   * Professional credentials as written ("CPA", "Ph.D.", "M.D., CFA"), kept off
-   * the identity key. A credential describes how ONE filing annotated a person,
-   * not who they are — the same director is "Isaac Manke" in one filing and
-   * "Isaac Manke, Ph.D." in the next — so folding it into the key split every
-   * such person into two canonical rows.
-   */
-  credentials: string | null;
   title: string | null;
   nick: string | null;
   dob?: string | null;
@@ -46,15 +39,37 @@ function emptyToNull(value: string | undefined): string | null {
 }
 
 /**
+ * Re-joins the two trailing-part fields `parseFullName` v3 reports separately —
+ * `generation` ("Jr.", "III") and `credential` ("CPA", "M.D., CFA") — into the
+ * single comma-joined suffix v2 returned, which is the spelling every
+ * `canonical_person.normalized_suffix` written so far was derived from.
+ *
+ * Keeping only the generational half is the better rule: a credential says how
+ * ONE filing annotated a person, not who they are. But `normalized_suffix` sits
+ * in the resolver's match tuple, so narrowing it changes which canonical row an
+ * observation matches. Rows already written under the combined spelling stop
+ * matching and the next filing naming the same person mints a SECOND canonical
+ * row at the same `resolver_version` — an identity split with nothing to
+ * distinguish it from a legitimate row. Splitting the two fields is therefore a
+ * resolver-version-gated change: bump the `person` resolver, re-resolve, then
+ * land it.
+ *
+ * Order is generational-first, which is how filings write it ("Jr., CPA"); v2
+ * preserved the filing's own order, so a name that wrote a credential ahead of a
+ * generational suffix joins back in the opposite order.
+ */
+function combineSuffixParts(generation: string, credential: string): string | null {
+  return emptyToNull([generation, credential].filter((part) => part.trim() !== "").join(", "));
+}
+
+/**
  * Generates a hash ID for a person based on normalized name components
  */
 function generatePersonHash(person: Omit<Person, "person_hash_id">): string {
-  // `nick` is deliberately absent: `normalizePerson` folds a nickname into
-  // `middle` when there is no middle name, so including it here would spell
-  // "Yong (David) Yan" as `yong-david-david-yan`. Listing exactly the parts the
-  // resolver's match tuple uses also keeps this hash and `personKey` from
-  // disagreeing about who is the same person — they did before, in both
-  // directions.
+  // `nick` is deliberately absent: it has no `normalized_*` column, so it never
+  // reaches `PersonResolver.personKey`. Listing exactly the parts that tuple
+  // uses keeps this hash and the resolver from disagreeing about who is the
+  // same person — they did before, in both directions.
   const hashString = [person.first, person.middle, person.last, person.suffix, person.notes]
     .filter((v) => v !== null && v !== undefined)
     .join("-")
@@ -75,10 +90,7 @@ function generatePersonHash(person: Omit<Person, "person_hash_id">): string {
  */
 function stripNamePartPunctuation(part: string | null): string | null {
   if (part === null || part === undefined) return part ?? null;
-  const cleaned = part
-    .replace(/[.,]/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  const cleaned = part.replace(/[.,]/g, "").replace(/\s+/g, " ").trim();
   return cleaned === "" ? null : cleaned;
 }
 
@@ -111,39 +123,22 @@ export function normalizePerson(importPerson: PersonImport | null): Person | und
 
   // Strip identity-neutral punctuation (initial/suffix periods) so the resolver
   // key ("first|middle|last|suffix") is stable across spelling variants.
-  // `parseFullName` classifies the trailing parts itself — it owns the suffix
-  // vocabulary, so it is the only place that can do this without the two lists
-  // drifting apart. A credential is an annotation, not an identity, and must
-  // reach neither the hash nor the resolver's match tuple, or the same director
-  // splits in two the moment one filing writes "Isaac Manke, Ph.D." and the
-  // next "Isaac Manke".
-  // A parenthesized nickname is folded into `middle` when there is no middle
-  // name, which is what puts it in the resolver's match tuple
-  // (first|middle|last|suffix) — `nick` has no column there and so was being
-  // dropped from identity entirely.
   //
-  // It is treated as identity-bearing, not as an annotation like a credential,
-  // because it frequently IS the only distinguishing signal. Across the very
-  // common Chinese/Korean/Vietnamese given-name + surname pairs a filing roster
-  // holds, "Yong Yan" is genuinely ambiguous while the adopted Western name is
-  // not; discarding "(David)" merges people that the filing itself distinguishes.
-  //
-  // The cost is the mirror image, and it is real: a filing that prints the
-  // nickname and an amendment that omits it now resolve to two canonical people
-  // — the same over-splitting that keeping credentials off the key was meant to
-  // avoid. That is bounded by `personKey` scoping the tuple to one issuer CIK,
-  // so the merge this prevents and the split it risks both live inside a single
-  // filer, where a roster's spelling is usually consistent.
-  const parsedNick = emptyToNull(results.nick);
-  const parsedMiddle = stripNamePartPunctuation(results.middle);
+  // A parenthesized nickname stays in `nick` and out of `middle`. `nick` has no
+  // column in the observation row, so it reaches neither `normalized_middle` nor
+  // the resolver's match tuple: "Yong (David) Yan" and "Yong Yan" resolve to one
+  // canonical person. Folding it into `middle` is arguably the better rule — the
+  // adopted Western name is often the only token separating two people on a
+  // roster — but it moves the match tuple, so it belongs behind a `person`
+  // resolver version bump, not in a build that keeps writing at the version
+  // whose canonical rows were minted under this rule.
   const person: Omit<Person, "person_hash_id"> = {
     first: stripNamePartPunctuation(results.first) ?? results.first,
-    middle: parsedMiddle ?? stripNamePartPunctuation(parsedNick),
+    middle: stripNamePartPunctuation(results.middle),
     last: stripNamePartPunctuation(results.last) ?? results.last,
-    suffix: stripNamePartPunctuation(emptyToNull(results.generation)),
-    credentials: emptyToNull(results.credential),
+    suffix: stripNamePartPunctuation(combineSuffixParts(results.generation, results.credential)),
     title: results.title,
-    nick: parsedNick,
+    nick: emptyToNull(results.nick),
     dob: null,
     notes: null,
     cik,


### PR DESCRIPTION
## This reverts a deliberate improvement

Both changes reverted here are **correct on the merits** and should ship. A professional credential (`CPA`, `Ph.D.`) says how one filing annotated a person, not who they are — keeping it out of the identity key is right. A parenthesized nickname frequently *is* the only token separating two people on a roster — folding it into the key is defensible.

What makes them unsafe **as shipped** is not the logic. It is that both moved the `person` resolver's match tuple while the resolver kept writing at the same `resolver_version`. That is a data-corrupting combination regardless of how good the new rule is. The re-land sequence below is how to get the improvement back.

## What broke

`PersonResolver.personKey` (`src/resolver/PersonResolver.ts:21-38`) and `CanonicalPersonRepo.findByResolverAndName` key on:

```
(resolver_version, normalized_first, normalized_middle, normalized_last, normalized_suffix, source_filing_issuer_cik)
```

Two commits changed what `normalizePerson` writes into two of those six columns, with no bump to the `person` resolver:

| commit | change | effect on the key |
| --- | --- | --- |
| [`a41e7b3`](https://github.com/workglow-dev/sec/commit/a41e7b3e12a2279bb75f0847bb8fc44810f84f10) | upgraded `@sroussey/parse-full-name` `2.0.0` → `3.0.0`, which replaces the single `suffix` field with `generation` + `credential`; narrowed `suffix` to `results.generation` and moved credentials to a new non-identity `credentials` field | `normalized_suffix`: `"Cpa"` → `null` |
| [`c3d7af1`](https://github.com/workglow-dev/sec/commit/c3d7af1cb694f698a2f218caaf50225f8d8ae5f9) | folded a parenthesized nickname into `middle` when there is no middle name | `normalized_middle`: `null` → `"David"` |

An existing database holds `canonical_person` rows written under the OLD rules. The next filing mentioning the same person now produces the new spelling, **misses** `findByResolverAndName`, and mints a **second** canonical row **at the same `resolver_version`**. `person_role` tenures split with it (a tenure is scoped to a `canonical_person_id`). Nothing on either row distinguishes it from a legitimate one.

Concretely, at the same `source_filing_issuer_cik`:

| filing writes | old rules | new rules |
| --- | --- | --- |
| `Jane Doe, CPA` | `normalized_suffix = "Cpa"` | `normalized_suffix = null` |
| `Yong (David) Yan` | `normalized_middle = null` | `normalized_middle = "David"` |

---

## 1. How to detect the splits

For each `resolver_version`, group `canonical_person` on `(source_filing_issuer_cik, normalized_first, normalized_last)` and report groups holding more than one row that differ only in `normalized_middle` / `normalized_suffix`, where at least one row was created after the offending build was deployed.

**Substitute the actual deploy timestamp** for `'2026-08-07T00:00:00Z'` below — it is the time the build carrying `a41e7b3` / `c3d7af1` went live, not the commit date.

### PostgreSQL

```sql
WITH split_groups AS (
  SELECT
    resolver_version,
    source_filing_issuer_cik,
    normalized_first,
    normalized_last,
    COUNT(*)                                     AS row_count,
    COUNT(DISTINCT COALESCE(normalized_middle, '')) AS distinct_middles,
    COUNT(DISTINCT COALESCE(normalized_suffix, '')) AS distinct_suffixes,
    MAX(created_at)                              AS newest_created_at
  FROM canonical_person
  WHERE cik IS NULL                       -- the CIK fast-path never used the name tuple
    AND source_filing_issuer_cik IS NOT NULL
    AND normalized_last IS NOT NULL
  GROUP BY 1, 2, 3, 4
  HAVING COUNT(*) > 1
     AND (COUNT(DISTINCT COALESCE(normalized_middle, '')) > 1
       OR COUNT(DISTINCT COALESCE(normalized_suffix, '')) > 1)
)
SELECT
  p.resolver_version,
  p.source_filing_issuer_cik,
  p.normalized_first,
  p.normalized_middle,
  p.normalized_last,
  p.normalized_suffix,
  p.canonical_person_id,
  p.display_first, p.display_middle, p.display_last, p.display_suffix,
  p.created_at
FROM canonical_person p
JOIN split_groups g
  ON  g.resolver_version         = p.resolver_version
  AND g.source_filing_issuer_cik = p.source_filing_issuer_cik
  AND g.normalized_first  IS NOT DISTINCT FROM p.normalized_first
  AND g.normalized_last   IS NOT DISTINCT FROM p.normalized_last
WHERE g.newest_created_at > '2026-08-07T00:00:00Z'   -- deploy time of the offending build
ORDER BY p.resolver_version, p.source_filing_issuer_cik,
         p.normalized_last, p.normalized_first, p.created_at;
```

Count them first:

```sql
SELECT resolver_version, COUNT(*) AS split_groups
FROM (
  SELECT resolver_version, source_filing_issuer_cik, normalized_first, normalized_last
  FROM canonical_person
  WHERE cik IS NULL AND source_filing_issuer_cik IS NOT NULL AND normalized_last IS NOT NULL
  GROUP BY 1, 2, 3, 4
  HAVING COUNT(*) > 1
     AND (COUNT(DISTINCT COALESCE(normalized_middle, '')) > 1
       OR COUNT(DISTINCT COALESCE(normalized_suffix, '')) > 1)
     AND MAX(created_at) > '2026-08-07T00:00:00Z'
) s
GROUP BY resolver_version
ORDER BY resolver_version;
```

### SQLite

`IS NOT DISTINCT FROM` is not available; SQLite's `IS` operator is the null-safe equality equivalent.

```sql
WITH split_groups AS (
  SELECT
    resolver_version,
    source_filing_issuer_cik,
    normalized_first,
    normalized_last,
    COUNT(*)                                        AS row_count,
    COUNT(DISTINCT COALESCE(normalized_middle, '')) AS distinct_middles,
    COUNT(DISTINCT COALESCE(normalized_suffix, '')) AS distinct_suffixes,
    MAX(created_at)                                 AS newest_created_at
  FROM canonical_person
  WHERE cik IS NULL
    AND source_filing_issuer_cik IS NOT NULL
    AND normalized_last IS NOT NULL
  GROUP BY 1, 2, 3, 4
  HAVING COUNT(*) > 1
     AND (COUNT(DISTINCT COALESCE(normalized_middle, '')) > 1
       OR COUNT(DISTINCT COALESCE(normalized_suffix, '')) > 1)
)
SELECT
  p.resolver_version,
  p.source_filing_issuer_cik,
  p.normalized_first,
  p.normalized_middle,
  p.normalized_last,
  p.normalized_suffix,
  p.canonical_person_id,
  p.display_first, p.display_middle, p.display_last, p.display_suffix,
  p.created_at
FROM canonical_person p
JOIN split_groups g
  ON  g.resolver_version         =  p.resolver_version
  AND g.source_filing_issuer_cik =  p.source_filing_issuer_cik
  AND g.normalized_first         IS p.normalized_first
  AND g.normalized_last          IS p.normalized_last
WHERE g.newest_created_at > '2026-08-07T00:00:00Z'   -- deploy time of the offending build
ORDER BY p.resolver_version, p.source_filing_issuer_cik,
         p.normalized_last, p.normalized_first, p.created_at;
```

**Narrow to the two known shapes.** Not every group the query above returns is caused by these commits — two genuinely different people can share a first and last name at one issuer. Two signatures identify these:

```sql
-- The credential half: one row carries a suffix, its twin carries none.
SELECT * FROM canonical_person a
JOIN canonical_person b
  ON  a.resolver_version         = b.resolver_version
  AND a.source_filing_issuer_cik = b.source_filing_issuer_cik
  AND a.normalized_first  = b.normalized_first
  AND a.normalized_last   = b.normalized_last
  AND COALESCE(a.normalized_middle, '') = COALESCE(b.normalized_middle, '')
WHERE a.normalized_suffix IS NOT NULL
  AND b.normalized_suffix IS NULL
  AND a.canonical_person_id <> b.canonical_person_id;

-- The nickname half: one row has a middle name, its twin has none, and the
-- twin's display name shows the parenthesized nickname.
SELECT * FROM canonical_person a
JOIN canonical_person b
  ON  a.resolver_version         = b.resolver_version
  AND a.source_filing_issuer_cik = b.source_filing_issuer_cik
  AND a.normalized_first  = b.normalized_first
  AND a.normalized_last   = b.normalized_last
  AND COALESCE(a.normalized_suffix, '') = COALESCE(b.normalized_suffix, '')
WHERE a.normalized_middle IS NOT NULL
  AND b.normalized_middle IS NULL
  AND a.canonical_person_id <> b.canonical_person_id;
```

Cross-check each candidate against the observations behind it (`person_identity_link` → `person_observation`) before merging: the raw `first_name` / `middle_name` / `last_name` / `suffix` display columns show what the filing actually wrote.

## 2. How to repair

Merge each confirmed duplicate into the keeper — the row the older observations already point at — **before** any re-land:

```bash
sec canonical person alias "<dup-name>" "<keeper-name>" --reason "split by unversioned normalization change (a41e7b3 / c3d7af1)"
sec canonical person alias-list            # review
sec canonical person alias-list --orphans  # names whose target no longer exists
```

Aliases are the right instrument here: `PersonResolver.resolve` runs the alias lookup inside its per-key mutex as the final pass, so both spellings converge on the keeper from then on. Repair first — merging after a re-land means chasing the same duplicates across two resolver versions.

## 3. The correct re-land sequence

`getActiveSlot` (`src/storage/versioning/getActiveSlot.ts:30-33`) prefers `next` over `current`:

```ts
const next = await reg.getNext(kind, id);
if (next) return { slot: "next", semver: next.semver };
const current = await reg.getCurrent(kind, id);
```

That is the whole reason this is safe. Opening the dev cycle **before** deploying the new build means the moment the new normalization goes live, every write already targets `next` = 2.0.0. The 1.0.0 canonical rows are never touched, never re-keyed, and never mixed with rows written under the new rules.

1. **Quiesce the form sweeps.** Nothing writing person observations — no `sec fetch form`, no `sec extractor backfill`, no scheduled ingestion. The window between opening the dev cycle and deploying the build must produce no writes, or a handful of observations land at 2.0.0 under the *old* rules.

2. **Record the baseline.**
   ```bash
   sec version coverage resolver person
   ```
   Save the 1.0.0 number. It is what you compare against in step 7 — without it you cannot tell a coverage gate failure from a coverage gate that was never going to pass.

3. **Open the dev cycle.**
   ```bash
   sec version start-dev resolver person 2.0.0 --bump major \
     --notes "person nickname/credential normalization"
   ```
   `--bump major` matters: `promote` enforces a coverage gate on major bumps only. A minor or patch bump would let you promote a half-resolved corpus. This must come **before** the deploy — see the `getActiveSlot` note above.

4. **Deploy the build carrying the normalization change.** Re-apply `a41e7b3`'s suffix narrowing and `c3d7af1`'s nickname fold (both are in this PR's diff, inverted).

5. **Resume ingestion.** New writes go to `next` = 2.0.0 under the new rules. 1.0.0 rows are untouched and still queryable; nothing is destroyed at any point before step 8.

6. **Re-normalize, THEN re-resolve.**

   > **`sec resolve --kind person --resolver-version 2.0.0 --all` alone is NOT sufficient.**

   `personKey` reads the observation's **stored** `normalized_*` columns — it does not re-run `normalizePerson`. A batch re-resolve over untouched observations therefore re-links the **old** keys at the new version: you get a 2.0.0 corpus partitioned by 1.0.0's rules, coverage reads ~1.0, the gate passes, and nothing has actually changed. The two halves recover differently:

   - **The credential half is recoverable by backfill.** `person_observation.suffix` is a display column and still holds what the filing wrote (`"CPA"`, `"Jr., CPA"`). A one-off pass can recompute `normalized_suffix` from it under the new rule — no re-extraction, no AI cost.
   - **The nickname half is NOT.** `person_observation` has no raw-name column. Old-rule writes already dropped `(David)` from `middle_name` — the parser routed it to `nick`, which has no column at all. The information is gone from the observation tier. Only re-extraction restores it:
     ```bash
     sec extractor backfill S-1
     sec extractor backfill D
     # ...and every other extractor that observes persons
     ```

   Expect the corpus to be **mixed-fidelity at 2.0.0** until each extractor is backfilled: filings re-extracted since the deploy carry nicknames in `normalized_middle`, older ones do not. Plan the backfill order by how much you care about each extractor's person data, and treat coverage as complete only after the last one.

   Then run the batch re-resolve over the re-normalized observations:
   ```bash
   sec resolve --kind person --resolver-version 2.0.0 --all
   ```

7. **Verify, then promote.**
   ```bash
   sec version coverage resolver person   # expect ~1.0
   sec version promote resolver person
   ```
   `promote` rotates `next → current → previous`, so 1.0.0 moves to `previous` and stays intact and rollback-able (`sec version rollback resolver person`).

8. **Only after verification, purge.**
   ```bash
   sec version drop-previous resolver person
   ```
   This is the irreversible step and the last one for a reason. It purges `person_identity_link`, the canonical rows, the address/phone junctions — **and `person_role`**, whose `dropPrevious` closure calls `PersonRoleRepo.deleteForResolverVersion` (`src/config/registerResolvers.ts:37-41`).

   > **`person_role` tenures are rebuilt by RE-EXTRACTION, not by batch `resolve`.** A tenure needs `filing_date`, `source_filing_issuer_cik`, and a `role_scope` population tag, and roster closure (`closeUnassertedPersonRoles`) only runs inside a form's person loop. `sec resolve` rebuilds identity links and junctions and nothing else. If step 6's backfill did not cover an extractor, `drop-previous` deletes tenures that only a backfill of that extractor can restore.

## Changes in this PR

| file | change |
| --- | --- |
| `src/storage/person/PersonNormalization.ts` | `middle` back to `stripNamePartPunctuation(results.middle)`; `suffix` back to the combined generational + credential string via a new `combineSuffixParts` helper (v3 no longer exposes `results.suffix`, so the v2 spelling is reconstructed from `generation` + `credential`); `credentials` field removed |
| `src/resolver/EntityObserver.ts` | dropped `parsedSuffixDisplay`, restored `suffix: clamp(claim.suffix ?? null, 32)`; comments now describe what the column actually holds |
| `src/sec/forms/registration-statements/s1/splitName.ts` | comment only — it already rejoined `generation` + `credential`, but claimed `normalized_suffix` was generational-only |
| `src/storage/person/PersonNormalization.test.ts` | both rules pinned explicitly |
| `src/resolver/PersonResolver.test.ts` | new end-to-end guard |

`generatePersonHash` keeps `c3d7af1`'s exclusion of `nick`. `person_hash_id` is not persisted anywhere (`normalizePerson` has exactly one caller, `EntityObserver`) and `nick` has no `normalized_*` column, so excluding it is what makes the hash agree with `personKey` under the reverted rules. Its comment was updated — the old justification ("nick is folded into middle") no longer applies.

### Tests

`PersonNormalization.test.ts` pins the reverted rules as observed values, not descriptions:

- `"Jane Doe, CPA"` → `suffix = "Cpa"` (title-cased by `fixCase: 1`; the column stores it verbatim), and a distinct identity from `"Jane Doe"` — the known over-split, pinned as-is
- `"Troy A. Hering CPA"` → `"Cpa"`, `"Isaac Manke, Ph.D."` → `"PhD"`, `"Gbola Amusa, M.D., CFA"` → `"MD Cfa"`, `"Andrew Lam, PharmD"` → `"PharmD"`
- `"John Smith Jr., CPA"` → `"Jr Cpa"` (generational first), distinct from `"John Smith Jr."`
- `"Yong (David) Yan"` → `middle = null`, `nick = "David"`; same identity as `"Yong Yan"`, different from `"Yong David Yan"`
- `"Robert James (Bob) Smith"` → `middle = "James"`, `nick = "Bob"`

`PersonResolver.test.ts` adds a guard that goes through the real path — observations built from a display name via `normalizePerson`, exactly as `EntityObserver` builds them, rather than hand-written `normalized_*` values that would pin the resolver while leaving the hazard invisible. Two observations differing only in a parenthesized nickname must resolve to **one** canonical row, and the failure message names the reason and the fix.

### Verification

```
$ bunx vitest run src/storage/ src/resolver/
 Test Files  110 passed (110)
      Tests  740 passed (740)

$ bunx vitest run src/sec/forms/registration-statements/
 Test Files  45 passed (45)
      Tests  381 passed (381)

$ npx tsc --noEmit
TSC OK
```

**The guard was confirmed to fail when the change is re-applied.** Temporarily restoring the nickname fold (`middle: stripNamePartPunctuation(results.middle) ?? stripNamePartPunctuation(emptyToNull(results.nick))`):

```
 FAIL  src/resolver/PersonResolver.test.ts > PersonResolver identity is keyed off
       normalizePerson's output > resolves a parenthesized nickname and the bare
       name to ONE canonical person
AssertionError: A parenthesized nickname reached `normalized_middle`, so the same
person no longer matches the canonical row written from the bare spelling.
`normalized_middle` is a member of `PersonResolver.personKey`: moving a name part
into it re-keys every `canonical_person` row already written at the active
resolver_version, and the next filing naming that person mints a SECOND row at
the SAME version. Bump the `person` resolver (sec version start-dev resolver
person <next> --bump major), re-extract and re-resolve at the new version, then
land the change.: expected 'e5c853a4-…' to be 'c45e2c5b-…'

 Test Files  1 failed (1)
      Tests  1 failed | 9 passed (10)
```

And restoring the suffix narrowing (`suffix: stripNamePartPunctuation(emptyToNull(results.generation))`):

```
 × puts a bare credential in `suffix`, so it reaches the resolver key
 × splits a credentialed person from the bare name
 × keeps every comma-written credential in `suffix`
 × joins both kinds into one suffix, generational first
 × keeps a credential in the key — 'Jane Doe, CPA' is its own canonical row

 Test Files  2 failed (2)
      Tests  5 failed | 35 passed (40)
```

Both temporary re-applications were reverted before committing; the branch contains only the reverted rules.

### Out of scope, deliberately

No re-land, no version ceremony, no data repair in this PR. Steps 1–8 above are operator actions against a live database with irreversible consequences (`drop-previous` in particular), and a code change cannot sequence them correctly against ingestion.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz


---
_Generated by [Claude Code](https://claude.ai/code/session_01K6huUY7hSkRbjun1P9HKsz)_