### PR TITLE
Add --fixture flag to re-run specific evaluation fixtures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ coercing to `0`, which would read back as "greedy sampling is on" — the opposi
 of what a typo like `0,5` was asking for).
 Extraction is transcription — the answer is already in the filing — and unpinned
 sampling made re-processing ONE filing yield 138/138/109 risk factors whose
-contents differed in all three cases; the two 138-row runs disagreed on *which*
+contents differed in all three cases; the two 138-row runs disagreed on _which_
 captions they found. On OpenAI's reasoning families the two knobs are coupled:
 `gpt-5.6-luna` answers `temperature` alone with `400 Unsupported parameter`, but
 accepts `{reasoning: {effort: "none"}, temperature: 0}`. The provider therefore
@@ -302,6 +302,9 @@ sec eval extract                              # default: haiku, sonnet, deepseek
 sec eval extract --models "claude-haiku-4-5,onnx-community/Qwen3-4B-Instruct-2507-ONNX"
 sec eval extract --extractor management --format json
 
+# Re-run just the fixture a model failed on (name as printed in the failures list)
+sec eval extract --fixture s1-management-operating-company --models "claude-haiku-4-5"
+
 # Cross-provider head-to-head: Anthropic vs OpenAI vs Gemini vs xAI vs DeepSeek.
 # Each id routes to its provider by shape (gpt-*→OpenAI, gemini-*→Gemini,
 # grok-*→xAI, deepseek-*→DeepSeek); needs the matching *_API_KEY per provider
@@ -371,6 +374,16 @@ models work for `json-mode` — a thinking model wraps the JSON in reasoning.
   (`src/eval/modelPricing.ts`: ~4 chars/token × public per-M pricing; local models $0).
   Absolute dollars are approximate; the ranking is what matters.
 - **Speed** — measured wall-clock latency per extraction.
+
+The `ok` column is `successful runs / total runs`, where total is
+models × fixtures × `--runs` — **not** a retry count. `--extractor management`
+has two fixtures, so a clean sweep of one model reads `2/2` and `1/2` means one
+of the two fixtures failed (named underneath). Retries are a separate,
+inner loop: `runStructured` passes `maxRetries: 1`, so
+`StructuredGenerationTask` reports "after 2 attempt(s)" — the initial call plus
+one schema-feedback retry. Every score in the row is averaged over ALL runs
+including failures (a failure scores 0), so one perfect and one failed fixture
+reads 50% across the board; `latency` is likewise a mean, not one call.
 
 Models are registered on demand via `registerModelIds`, so any candidate id works;
 a model that fails to resolve or errors on a fixture is recorded as a failed run
@@ -1197,7 +1210,6 @@ sec exposes the general downstream seams embarc-data (and future features) build
   `--exact`, and `--format json` carries `estimated` per row (`db stats`) and per
   result (`db status`). Two things the query gets right that the naive form does
   not:
-
   - The relation name is **schema-qualified to `current_schema()`**
     (`to_regclass(quote_ident(current_schema()) || '.' || quote_ident($1))`,
     still fully parameterized). Unqualified, `to_regclass('filings')` resolves
@@ -1242,8 +1254,8 @@ sec exposes the general downstream seams embarc-data (and future features) build
   orphaning them (the derivation is pinned against the installed storage's own
   migration DDL by `resetAllDatabases.test.ts`). Every Postgres drop is
   schema-qualified to
-  `current_schema()` — an unqualified name resolves through the search_path and
-  would reach a same-named table in the _next_ schema on it. Tables it does not
+  `current_schema()` — an unqualified name resolves through the search*path and
+  would reach a same-named table in the \_next* schema on it. Tables it does not
   own are left in place and named in a warning. `--cascade` drops dependent
   objects; `--drop-schema` restores the old whole-schema drop (Postgres only,
   destroys unowned objects too). A drop blocked by a dependent object raises an

--- a/src/cli/groups/eval.ts
+++ b/src/cli/groups/eval.ts
@@ -365,6 +365,11 @@ export function addEvalCommands(program: Command): void {
       // EVAL_EXTRACTORS with no committed fixture has nothing to run.
       `limit to one extractor (${extractorsWithFixtures().join(", ")})`
     )
+    .option(
+      "--fixture <csv>",
+      "limit to these fixtures by name, as printed in the failures list " +
+        "(e.g. s1-management-operating-company) — re-run just the one a model failed on"
+    )
     .option("--format <fmt>", "table | json", "table")
     .option("--no-details", "hide per-row/field disagreements after the table")
     .option(
@@ -380,6 +385,7 @@ export function addEvalCommands(program: Command): void {
       async (opts: {
         models?: string;
         extractor?: string;
+        fixture?: string;
         format: string;
         details: boolean;
         runs?: number;
@@ -395,9 +401,17 @@ export function addEvalCommands(program: Command): void {
               `unknown extractor "${opts.extractor}"; known: ${Object.keys(EVAL_EXTRACTORS).join(", ")}`
             );
           }
+          const fixtures = (opts.fixture ?? "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+          if (opts.fixture !== undefined && fixtures.length === 0) {
+            throw new Error("--fixture was given but names no fixture");
+          }
           const input = {
             models,
             ...(opts.extractor ? { extractor: opts.extractor } : {}),
+            ...(fixtures.length > 0 ? { fixtures } : {}),
             ...(opts.runs !== undefined ? { runs: Math.trunc(opts.runs) } : {}),
             ...(opts.real ? { real: true } : {}),
           };

--- a/src/eval/runExtractionEval.test.ts
+++ b/src/eval/runExtractionEval.test.ts
@@ -41,4 +41,32 @@ describe("runExtractionEval fixture selection", () => {
       runExtractionEval({ models: ["claude-haiku-4-5"], extractor: "does-not-exist" })
     ).rejects.toThrow(/has no fixtures in EVAL_FIXTURES/);
   });
+
+  // A misspelled --fixture would otherwise sweep zero runs and print an empty
+  // table with exit 0 — indistinguishable from a passing evaluation.
+  it("throws for a fixture name that matches nothing, listing what is available", async () => {
+    const real = EVAL_FIXTURES[0]!.name;
+    await expect(
+      runExtractionEval({ models: ["claude-haiku-4-5"], fixtures: ["does-not-exist"] })
+    ).rejects.toThrow(/no fixture named "does-not-exist"/);
+    // The message names the real candidates, so a typo is fixable from the error.
+    await expect(
+      runExtractionEval({ models: ["claude-haiku-4-5"], fixtures: ["does-not-exist"] })
+    ).rejects.toThrow(new RegExp(real.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  });
+
+  // The filter composes with --extractor rather than reaching past it: a real
+  // fixture belonging to a different extractor must not smuggle itself in.
+  it("throws when a named fixture is outside the selected extractor", async () => {
+    const management = EVAL_FIXTURES.find((f) => f.extractor === "management");
+    const other = EVAL_FIXTURES.find((f) => f.extractor !== "management");
+    if (management === undefined || other === undefined) return;
+    await expect(
+      runExtractionEval({
+        models: ["claude-haiku-4-5"],
+        extractor: "management",
+        fixtures: [other.name],
+      })
+    ).rejects.toThrow(/no fixture named/);
+  });
 });

--- a/src/eval/runExtractionEval.ts
+++ b/src/eval/runExtractionEval.ts
@@ -87,6 +87,12 @@ export interface RunEvalOptions {
   /** Restrict to one extractor (e.g. `management`); default runs every fixture. */
   readonly extractor?: string;
   /**
+   * Restrict to named fixtures (e.g. `s1-management-operating-company`), the way
+   * `sec eval s1 --cik` narrows to one filer: re-running the single fixture a
+   * model failed on, without paying for the ones that already passed.
+   */
+  readonly fixtures?: readonly string[];
+  /**
    * Sweep the real committed S-1 sections instead of the curated miniatures.
    * Correctness is not scored (no golden labels at that size); reproducibility,
    * latency and cost are.
@@ -169,6 +175,27 @@ function selectFixtures(extractor: string | undefined): EvalFixture[] {
       `extractor "${extractor}" has no fixtures in EVAL_FIXTURES — nothing to score. ` +
         `Add one to src/eval/fixtures.ts. Extractors with fixtures: ` +
         `${extractorsWithFixtures().join(", ")}`
+    );
+  }
+  return selected;
+}
+
+/**
+ * Narrow an already-selected fixture set to the named ones.
+ *
+ * A name matching nothing is an error listing what is available, not an empty
+ * sweep: a zero-fixture run prints a table with no rows and exits 0, which reads
+ * exactly like a passing evaluation — the same trap `--extractor` and
+ * `sec eval s1 --cik` already refuse to fall into.
+ */
+function filterByName(fixtures: EvalFixture[], names: readonly string[]): EvalFixture[] {
+  const wanted = new Set(names);
+  const selected = fixtures.filter((f) => wanted.has(f.name));
+  const missing = names.filter((n) => !fixtures.some((f) => f.name === n));
+  if (missing.length > 0) {
+    throw new Error(
+      `no fixture named ${missing.map((m) => `"${m}"`).join(", ")} in this sweep — ` +
+        `available: ${fixtures.map((f) => f.name).join(", ")}`
     );
   }
   return selected;
@@ -303,7 +330,9 @@ export function summarizeModelRuns(
  */
 export async function runExtractionEval(opts: RunEvalOptions): Promise<EvalReport> {
   // Select first: an unscorable extractor should fail before we register models.
-  const fixtures = opts.real ? realSectionFixtures(opts.extractor) : selectFixtures(opts.extractor);
+  const selected = opts.real ? realSectionFixtures(opts.extractor) : selectFixtures(opts.extractor);
+  const fixtures =
+    opts.fixtures && opts.fixtures.length > 0 ? filterByName(selected, opts.fixtures) : selected;
   await registerModelIds(opts.models);
   const repo = getGlobalModelRepository();
 

--- a/src/task/eval/EvalExtractTask.ts
+++ b/src/task/eval/EvalExtractTask.ts
@@ -18,6 +18,13 @@ const InputSchema = () =>
     extractor: Type.Optional(
       Type.String({ title: "Extractor", description: "Limit to one extractor (e.g. 'management')" })
     ),
+    fixtures: Type.Optional(
+      Type.Array(Type.String(), {
+        title: "Fixture names",
+        description: "Limit to these fixtures by name (e.g. 's1-management-operating-company')",
+        minItems: 1,
+      })
+    ),
     real: Type.Optional(
       Type.Boolean({
         title: "Real sections",
@@ -87,6 +94,7 @@ export class EvalExtractTask extends Task<EvalExtractTaskInput, EvalExtractTaskO
     const report = await runExtractionEval({
       models: input.models,
       extractor: input.extractor,
+      fixtures: input.fixtures,
       runs: input.runs,
       real: input.real,
       signal: context.signal,


### PR DESCRIPTION
## Summary

Adds a `--fixture` CLI flag to `sec eval extract` that allows re-running specific evaluation fixtures by name, without re-running the entire evaluation suite. This mirrors the `--cik` narrowing behavior in other commands and prevents accidental silent passes when a fixture name is misspelled.

## Changes

- **New `fixtures` option in `RunEvalOptions`**: Accepts an array of fixture names to narrow the evaluation scope after extractor selection
- **`filterByName()` function**: Filters selected fixtures to only those matching provided names, with validation that throws an error (listing available fixtures) if any requested name doesn't exist — preventing zero-fixture runs from silently passing
- **CLI integration**: Added `--fixture <csv>` flag to the `eval extract` command that parses comma-separated fixture names and passes them through to the evaluation engine
- **Task schema update**: Extended `EvalExtractTaskInput` to include optional `fixtures` array parameter
- **Test coverage**: Added tests verifying that misspelled fixture names throw helpful errors listing available options, and that fixture filtering respects extractor boundaries (a fixture from a different extractor cannot be smuggled in)
- **Documentation**: Updated CLAUDE.md with usage example and clarified how the `ok` column in evaluation results is calculated

## Implementation Details

The fixture filtering composes with extractor selection rather than bypassing it: `selectFixtures(extractor)` runs first, then `filterByName()` narrows the result. This ensures a fixture belonging to a different extractor cannot be accessed via `--fixture`, maintaining the extractor boundary.

Error handling follows the pattern established by `--extractor`: a non-existent fixture name throws immediately with a helpful message listing all available fixtures in the current sweep, rather than silently running zero fixtures and printing an empty passing table.

https://claude.ai/code/session_01XzKnPGnsqZBcazx3yXFTsj