### PR TITLE
fix(s1): stop silently deleting disclosed risk factors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -760,17 +760,36 @@ caught by the same "enforce it, don't trust the prompt" guard the ownership
 subtotal gets — a heading is verbatim section text, so nothing downstream would
 otherwise stop it becoming a row that reads like a disclosed risk.
 
-That guard is applied to the section's **shape as a whole**, not row by row,
+Two different rules do that work, and the order matters. First the chunk prefix
+is reconciled against itself: `chunkRiskFactorText` reports the heading line it
+prepended to each chunk (`RiskFactorChunk.carriedHeading`), and a row whose
+caption is exactly that line is dropped. That drop is not a judgement about the
+section — the line is one this code inserted, not a caption the filer printed
+under it — which is why it is the one drop that leaves no trace, and it removes
+the artifact chunking creates: a ~7-chunk section hands the model ~6 headings
+and invites it to echo them back as rows. An echo that is _reworded_ rather than
+copied is not this rule's problem: it fails `verifyRow` like any other
+paraphrase and lands on the existing `<section>-partial` /
+`UNVERIFIED_SOURCE_SPAN` triage entry.
+
+What survives is judged on the response's **shape as a whole**, not row by row,
 because the shape heuristic (no sentence-ending punctuation) cannot tell a
-category heading from an Item 105(b) summary bullet. A **homogeneous** section
+category heading from an Item 105(b) summary bullet. A **homogeneous** response
 is kept intact either way — all bare phrases is a summary list whose "headings"
 ARE the captions; no bare phrases is an ordinary sentence-caption list with
-nothing to drop. A **mixed** section is unanswerable and dead-letters
-`MIXED_CAPTION_SHAPE` (via `MixedRiskCaptionShapeError`) rather than persisting
-a subset: filers are inconsistent about terminal punctuation, so one summary
+nothing to drop. A **mixed** one is unanswerable and dead-letters
+`MIXED_CAPTION_SHAPE` (via `MixedRiskCaptionShapeError`) rather than persisting a
+subset: filers are inconsistent about terminal punctuation, so one summary
 bullet ending in a period was enough to make an all-or-nothing filter keep that
 single row and silently drop the other 29 — a partial disclosure recorded as
-complete, exactly what the chunked-section contract exists to prevent.
+complete, exactly what the chunked-section contract exists to prevent. A
+ratio-gated variant of this rule (drop the heading-shaped rows while they are a
+small enough minority of the response) was tried and removed: it reproduced that
+failure in the other direction — four bare bullets out of twenty deleted from a
+section that then resolved clean, with a `console.warn` as the only record. The
+price of the strict rule is that one stray heading fails the whole section; it
+fails visibly, onto the version-gated retry worklist, with every caption
+recoverable by re-running the filing.
 
 Risk factors is by far the largest section in an S-1 — 3k to 246k chars across
 the committed fixtures, against 40–57k for the sections that already dominate
@@ -779,10 +798,11 @@ chunking: one response cannot hold ~90 captions without overrunning the
 extractors' output-token ceiling and truncating the JSON. `chunkRiskFactorText`
 (`s1/riskFactorChunks.ts`) splits the section on paragraph boundaries into
 40k-char chunks (~15–25 captions each, at the ~1.5–2.8k chars per risk the
-fixtures measure) and prefixes every chunk after the first with the last
-category heading seen before it — a verbatim line from the section, so spans
-still verify — and `extractRiskFactors` runs one call per chunk, concatenating
-in document order and de-duplicating on the caption. A
+fixtures measure) and prefixes every chunk after the first with the last category heading seen
+before it — a verbatim line from the section, so spans still verify — reporting
+that line back on the chunk so the extractor can drop its echoes by exact match.
+`extractRiskFactors` runs one call per chunk, concatenating in document order and
+de-duplicating on the caption. A
 chunk that fails propagates and fails the whole section: persisting the captions
 that happened to arrive first would record a silently partial list as if it were
 the filing's complete disclosure. A section over 400k chars is a segmentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,8 +411,17 @@ a model oracle caps every candidate at its own accuracy, costs a call per
 section, and disagrees with ITSELF between runs, so the bar moves under you.
 Golden labels are free, instant and stable.
 
-They cover `management` and `beneficial-ownership` only. A golden run scores
-those and reports every other section as skipped rather than quietly passing it.
+Coverage is derived from `GOLDEN_S1_LABELS`, not fixed: every extractor with at
+least one committed label is scored, and `extractorsWithGoldenLabels()` is what
+both the default `--extractors` set and the `sec eval s1 --help` line read — so
+the current list is always one `--help` away and this paragraph cannot silently
+go stale. As committed today that is 12 extractors —
+`beneficial-ownership`, `executive-compensation`, `management`,
+`offering-terms`, `related-party`, `risk-factors`, `spac-classification`,
+`spac-profile`, `spac-sponsors`, `sponsor-promote`, `underwriters`,
+`use-of-proceeds` — over 42 labelled filings. A golden run scores the sections
+that carry a label and reports every other one as skipped rather than quietly
+passing it.
 Pass `--reference <model-id>` (use the strongest available, currently
 `claude-opus-5` — never the model you are evaluating) to fall back to an oracle
 for the unlabelled extractors, accepting that its verdict is an opinion.
@@ -426,8 +435,10 @@ truth — even the strongest model drops or invents the odd role, capping
 achievable agreement and penalizing a correct candidate. `--reference golden`
 scores candidates against **committed labels** (`src/eval/goldenS1Labels.ts`)
 instead of a model run — no reference API call, `$0`, deterministic. Only sections
-with a golden entry are scored (the rest are reported as skipped); currently
-seven committed `management` sections and seven `beneficial-ownership` sections.
+with a golden entry are scored (the rest are reported as skipped);
+the committed set is roughly 400 labelled (filing, section) pairs across the 12
+extractors named above — densest on `risk-factors`, `spac-classification` and
+`use-of-proceeds` (42 filings each), thinnest on `spac-sponsors` (2).
 Titles are stored in canonical (`normalizeManagementTitles`) form and unit-tested
 to stay canonical. Use golden truth to tell which model is actually _correct_
 (not merely reference-like); use a model reference to sweep sections that aren't
@@ -440,6 +451,15 @@ hypothetical — embarc-data vendors its own copy of the S-1 corpus
 behind sec's the labelled filing produced no section at all, so the sweep scored
 fewer filings than the labels covered and still printed a clean table. Re-copy
 the corpus into the vendoring package when you add a fixture.
+
+**A bare `sec eval s1` is not a cheap command.** Under the default golden
+reference the default extractor set is _every_ labelled extractor, so one
+candidate model sweeps roughly 400 sections — more calls than that, since
+`risk-factors` chunks its section into several — over prose running from a few
+thousand chars to ~246k. Budget it, or narrow it: `--extractors` picks the
+sections, `--cik` picks the filer, and the two compose. Only the candidate side
+costs money under `--reference golden` (no oracle call); a model reference
+roughly doubles the calls and pays the reference model's rate on top.
 
 `--cik <csv>` narrows a sweep to one filer (leading zeros optional), which is how
 you check a newly added fixture or label without paying for the whole corpus. A

--- a/src/sec/forms/registration-statements/Form_S_1.storage.riskfactors.test.ts
+++ b/src/sec/forms/registration-statements/Form_S_1.storage.riskfactors.test.ts
@@ -37,7 +37,7 @@ const NULL_HEADER = {
 
 const ACCESSION = "0000000000-26-000001";
 
-async function runS1(): Promise<void> {
+async function runS1With(html: string): Promise<void> {
   await processFormS1({
     cik: 1018724,
     file_number: "333-1",
@@ -45,9 +45,13 @@ async function runS1(): Promise<void> {
     filing_date: "2026-01-02",
     primary_doc: "s1.htm",
     form: "S-1",
-    formS1: { header: NULL_HEADER, html: HTML, xbrlInstanceXml: null, feeExhibitHtml: null },
+    formS1: { header: NULL_HEADER, html, xbrlInstanceXml: null, feeExhibitHtml: null },
     model: fakeS1Model(),
   });
+}
+
+async function runS1(): Promise<void> {
+  await runS1With(HTML);
 }
 
 let cleanup: (() => void) | undefined;
@@ -155,6 +159,51 @@ describe("processFormS1 risk factors", () => {
     const mixed = await new ExtractionDeadLetterRepo().get("S-1", ACCESSION, "risk-factors");
     expect(mixed?.reason_code).toBe("MIXED_CAPTION_SHAPE");
     expect(mixed?.status).toBe("pending");
+  });
+
+  it("dead-letters a mixed section rather than resolving it with the minority deleted", async () => {
+    // The end-to-end shape of the defect, at the layer an operator reads. Four
+    // sentence captions and one heading-shaped row: a heading-shaped minority
+    // small enough that a ratio-gated filter deletes it and lets the rest
+    // through, leaving the section marked resolved and nothing on the retry
+    // worklist to say four rows were persisted from a response the extractor
+    // could not read. The same reasoning applies in reverse — had those bare
+    // phrases been real Item 105(b) bullets, they would be the disclosures
+    // deleted. Neither is separable on shape, so the section fails visibly.
+    const captions = [
+      FIRST,
+      SECOND,
+      "Our stock price may be volatile after this offering.",
+      "We do not intend to pay dividends on our common stock.",
+    ];
+    const html =
+      "<h1>RISK FACTORS</h1>" +
+      `<h2>${CATEGORY}</h2>` +
+      captions
+        .map((c) => `<p><b>${c}</b></p><p>Explanatory paragraph for the caption above.</p>`)
+        .join("");
+
+    const { unregister } = registerFakeStructuredProvider([
+      {
+        risks: [
+          ...captions.map((c) => ({
+            headline: c,
+            category: CATEGORY,
+            confidence: 0.9,
+            source_span: c,
+          })),
+          { headline: CATEGORY, category: null, confidence: 0.9, source_span: CATEGORY },
+        ],
+      },
+    ]);
+    cleanup = unregister;
+
+    await runS1With(html);
+
+    expect(await new RiskFactorRepo().queryByAccession(ACCESSION)).toHaveLength(0);
+    const entry = await new ExtractionDeadLetterRepo().get("S-1", ACCESSION, "risk-factors");
+    expect(entry?.reason_code).toBe("MIXED_CAPTION_SHAPE");
+    expect(entry?.status).toBe("pending");
   });
 
   it("refuses an elided caption rather than storing its head as the whole thing", async () => {

--- a/src/sec/forms/registration-statements/s1/extractRiskFactors.test.ts
+++ b/src/sec/forms/registration-statements/s1/extractRiskFactors.test.ts
@@ -5,11 +5,7 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  extractRiskFactors,
-  MIXED_SHAPE_FAIL_RATIO,
-  MixedRiskCaptionShapeError,
-} from "./sectionExtractors";
+import { extractRiskFactors, MixedRiskCaptionShapeError } from "./sectionExtractors";
 import { RISK_FACTOR_CHUNK_CHARS } from "./riskFactorChunks";
 import { fakeS1Model, registerFakeStructuredProvider } from "./testing/fakeStructuredProvider";
 
@@ -120,42 +116,55 @@ describe("extractRiskFactors", () => {
     ).rejects.toThrow(MixedRiskCaptionShapeError);
   });
 
-  it("drops the chunk-prefix heading echoes instead of losing every real caption", async () => {
-    // The regression the ratio gate exists for. chunkRiskFactorText prefixes
-    // every chunk after the first with the last category heading, so a section
-    // large enough to chunk hands the model roughly one heading per chunk and
-    // invites it to echo them back. An all-or-nothing rule turned six such
-    // strays into a version-gated dead letter that discarded all 90 captions.
-    const captions = Array.from(
-      { length: 90 },
-      (_, i) => `We may be unable to complete our initial business combination number ${i + 1}.`
+  it("drops a chunk's echo of the heading the chunker prefixed onto it", async () => {
+    // The artifact chunking creates, removed at its source instead of by a
+    // ratio. chunkRiskFactorText prepends the last category heading to every
+    // chunk that starts mid-category, so the model is handed a heading it did
+    // not read in the filer's body and invited to echo it back as a row. That
+    // one line is the only thing this code inserted, so an EXACT match against
+    // it is provably not a caption the filer printed.
+    const CATEGORY_LINE = "Risks Relating to our Securities";
+    const bodies = Array.from(
+      { length: 40 },
+      (_, i) =>
+        `We may be unable to complete a business combination number ${i + 1}.\n\n${"prose ".repeat(500)}`
     );
-    const echoes = Array.from({ length: 6 }, (_, i) => `Risks Relating to our Securities ${i + 1}`);
-    const { unregister } = registerFakeStructuredProvider([
-      { risks: [...captions.map((c) => risk(c)), ...echoes.map((e) => risk(e, null))] },
+    const text = [CATEGORY_LINE, ...bodies].join("\n\n");
+
+    const { unregister, calls } = registerFakeStructuredProvider([
+      { risks: [risk("First risk.")] },
+      { risks: [risk(CATEGORY_LINE, null), risk("Second risk.")] },
+      { risks: [risk(CATEGORY_LINE, null), risk("Third risk.")] },
     ]);
     cleanup = unregister;
 
-    const rows = await extractRiskFactors("Some risk prose.", fakeS1Model());
-    expect(rows.map((r) => r.headline)).toEqual(captions);
-    expect(6 / 96).toBeLessThan(MIXED_SHAPE_FAIL_RATIO);
+    const rows = await extractRiskFactors(text, fakeS1Model());
+    expect(calls.length).toBeGreaterThan(1);
+    // Every real caption survives and the injected line never becomes a row —
+    // so the shape check that follows sees a homogeneous response and the
+    // section is not failed for an artifact of our own chunking.
+    expect(rows.map((r) => r.headline)).toEqual(["First risk.", "Second risk.", "Third risk."]);
   });
 
-  it("fails at exactly MIXED_SHAPE_FAIL_RATIO, so the boundary is inclusive", async () => {
-    // 3 of 12 is exactly the ratio: a section this mixed is unanswerable, and
-    // the gate must not let the boundary case through on a `>` comparison.
-    const headingCount = 3;
-    const total = Math.round(headingCount / MIXED_SHAPE_FAIL_RATIO);
+  it("dead-letters a mixed section instead of silently deleting the heading-shaped minority", async () => {
+    // The inverse of the case above, and the reason a ratio cannot stand in for
+    // exact echo removal. One chunk, so nothing was injected: these four bare
+    // phrases may well be real Item 105(b) summary bullets the filer printed,
+    // and nothing in their shape proves otherwise. Deleting them would record
+    // 16 of 20 disclosed risks as the filing's complete list, with the section
+    // marked resolved.
     const captions = Array.from(
-      { length: total - headingCount },
+      { length: 16 },
       (_, i) => `Our securities may be delisted for reason ${i + 1}.`
     );
-    const headings = Array.from(
-      { length: headingCount },
-      (_, i) => `Risks Relating to our Business ${i + 1}`
-    );
+    const bare = [
+      "Risks related to our sponsor and management team",
+      "Risks related to our securities and the trust account",
+      "Risks related to our inability to complete an initial business combination",
+      "Risks related to our business and operations",
+    ];
     const { unregister } = registerFakeStructuredProvider([
-      { risks: [...captions.map((c) => risk(c)), ...headings.map((h) => risk(h, null))] },
+      { risks: [...captions.map((c) => risk(c)), ...bare.map((b) => risk(b, null))] },
     ]);
     cleanup = unregister;
 

--- a/src/sec/forms/registration-statements/s1/riskFactorChunks.test.ts
+++ b/src/sec/forms/registration-statements/s1/riskFactorChunks.test.ts
@@ -41,7 +41,9 @@ describe("isRiskCategoryHeading", () => {
 describe("chunkRiskFactorText", () => {
   it("returns one chunk for a section that fits", () => {
     const text = [CATEGORY, CAPTION, "Body paragraph."].join("\n\n");
-    expect(chunkRiskFactorText(text)).toEqual([text]);
+    // A single chunk carries no injected heading: nothing precedes it, so every
+    // line in it is the filer's.
+    expect(chunkRiskFactorText(text)).toEqual([{ text, carriedHeading: null }]);
   });
 
   it("returns nothing for blank text", () => {
@@ -53,7 +55,10 @@ describe("chunkRiskFactorText", () => {
     const chunks = chunkRiskFactorText(paragraphs.join("\n\n"), 400);
     expect(chunks.length).toBeGreaterThan(1);
     for (const paragraph of paragraphs) {
-      expect(chunks.some((c) => c.includes(paragraph)), paragraph).toBe(true);
+      expect(
+        chunks.some((c) => c.text.includes(paragraph)),
+        paragraph
+      ).toBe(true);
     }
   });
 
@@ -63,7 +68,11 @@ describe("chunkRiskFactorText", () => {
       CAPTION.length + 40
     );
     expect(chunks.length).toBeGreaterThan(1);
-    for (const chunk of chunks) expect(chunk.startsWith(CATEGORY)).toBe(true);
+    for (const chunk of chunks) expect(chunk.text.startsWith(CATEGORY)).toBe(true);
+    // The first chunk opens on the filer's own heading; only the later ones had
+    // one injected, and each says so.
+    expect(chunks[0].carriedHeading).toBeNull();
+    for (const c of chunks.slice(1)) expect(c.carriedHeading).toBe(CATEGORY);
   });
 
   it("does not prefix a chunk that already opens on a category heading", () => {
@@ -75,14 +84,33 @@ describe("chunkRiskFactorText", () => {
       CATEGORY.length + CAPTION.length + 10
     );
     expect(chunks).toHaveLength(2);
-    expect(chunks[1].startsWith(second)).toBe(true);
-    expect(chunks[1]).not.toContain(CATEGORY);
+    expect(chunks[1].text.startsWith(second)).toBe(true);
+    expect(chunks[1].text).not.toContain(CATEGORY);
+    // Nothing was injected, so there is no echo for the extractor to remove.
+    expect(chunks[1].carriedHeading).toBeNull();
   });
 
   it("keeps a paragraph larger than the chunk size whole", () => {
     const huge = `${CAPTION} `.repeat(40).trim();
     const chunks = chunkRiskFactorText([huge, CAPTION].join("\n\n"), 200);
-    expect(chunks[0]).toBe(huge);
+    expect(chunks[0].text).toBe(huge);
     expect(chunks).toHaveLength(2);
+  });
+
+  it("reports the heading it injected so the extractor can un-echo it", () => {
+    // The contract the extractor's echo removal depends on: when a chunk
+    // reports a carried heading, that heading is literally the chunk's first
+    // line. Exact string equality is what makes dropping an echo safe — no
+    // caption the model read out of the body can ever match it.
+    const chunks = chunkRiskFactorText(
+      [CATEGORY, ...Array.from({ length: 8 }, (_, i) => `${CAPTION} (${i})`)].join("\n\n"),
+      CAPTION.length + 40
+    );
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      if (chunk.carriedHeading === null) continue;
+      expect(chunk.text.startsWith(chunk.carriedHeading)).toBe(true);
+    }
+    expect(chunks.some((c) => c.carriedHeading !== null)).toBe(true);
   });
 });

--- a/src/sec/forms/registration-statements/s1/riskFactorChunks.ts
+++ b/src/sec/forms/registration-statements/s1/riskFactorChunks.ts
@@ -32,7 +32,7 @@ export const MAX_RISK_FACTORS_CHARS = 400_000;
 /** Upper bound on a category heading's length; real ones run well under it. */
 const CATEGORY_MAX_CHARS = 200;
 
-function stripHeadingMarkers(paragraph: string): string {
+export function stripHeadingMarkers(paragraph: string): string {
   return paragraph.replace(/^#{1,6}\s*/, "").trim();
 }
 
@@ -45,10 +45,8 @@ function stripHeadingMarkers(paragraph: string): string {
  *
  * Two callers: {@link chunkRiskFactorText} carries the last heading into the
  * next chunk, where a false positive costs only a redundant context line; and
- * the extractor drops a returned row whose caption looks like a heading, where a
- * false positive drops a caption written as a bare phrase. The terminal-
- * punctuation rule is what keeps that second case rare, and erring that way is
- * deliberate — a heading persisted as a row reads like a disclosed risk.
+ * the extractor uses it to ask whether a response's rows are homogeneous in
+ * shape, where a mixed verdict fails the section rather than dropping rows.
  */
 export function isRiskCategoryHeading(paragraph: string): boolean {
   const line = stripHeadingMarkers(paragraph);
@@ -58,13 +56,26 @@ export function isRiskCategoryHeading(paragraph: string): boolean {
   return /\brisks?\b/i.test(line);
 }
 
+export interface RiskFactorChunk {
+  /** Prose handed to one structured-generation call, carried prefix included. */
+  readonly text: string;
+  /**
+   * The category-heading line prepended to this chunk, or null when the chunk
+   * opens on its own heading (or is the first). A row echoing it back is an
+   * artifact of the prefix, not a caption the filer printed.
+   */
+  readonly carriedHeading: string | null;
+}
+
 /**
  * Splits risk-factor section prose into chunks of at most `maxChars`, never
  * cutting a paragraph. Each chunk after the first is prefixed with the most
  * recent category heading seen before it, so a chunk that starts mid-category
  * can still attribute its captions. That prefix is a verbatim line from the
  * section, so a caption or span quoting it still verifies against the full
- * section text.
+ * section text — and it is reported back on the chunk (`carriedHeading`) so the
+ * extractor can drop a row echoing it by exact match, which is the one drop
+ * that provably discards nothing the filer wrote.
  *
  * A single paragraph longer than `maxChars` becomes its own oversized chunk:
  * splitting inside it would hand the model half a caption and produce a row
@@ -73,14 +84,14 @@ export function isRiskCategoryHeading(paragraph: string): boolean {
 export function chunkRiskFactorText(
   text: string,
   maxChars: number = RISK_FACTOR_CHUNK_CHARS
-): string[] {
+): RiskFactorChunk[] {
   const paragraphs = text
     .split(/\n{2,}/)
     .map((p) => p.trim())
     .filter((p) => p.length > 0);
   if (paragraphs.length === 0) return [];
 
-  const chunks: string[] = [];
+  const chunks: RiskFactorChunk[] = [];
   let current: string[] = [];
   let currentChars = 0;
   let carriedCategory: string | null = null;
@@ -89,9 +100,12 @@ export function chunkRiskFactorText(
   const flush = (): void => {
     if (current.length === 0) return;
     // A chunk that already opens on a category heading needs no carried one.
-    const prefix =
-      carriedCategory !== null && !isRiskCategoryHeading(current[0]) ? [carriedCategory] : [];
-    chunks.push([...prefix, ...current].join("\n\n"));
+    const carried =
+      carriedCategory !== null && !isRiskCategoryHeading(current[0]) ? carriedCategory : null;
+    chunks.push({
+      text: (carried !== null ? [carried, ...current] : current).join("\n\n"),
+      carriedHeading: carried,
+    });
     carriedCategory = lastCategory;
     current = [];
     currentChars = 0;

--- a/src/sec/forms/registration-statements/s1/sectionExtractors.ts
+++ b/src/sec/forms/registration-statements/s1/sectionExtractors.ts
@@ -40,7 +40,11 @@ import {
 import { UnderwriterOutputSchema, type UnderwriterRowOut } from "./underwriterSchema";
 import { UseOfProceedsOutputSchema, type UseOfProceedsLineRow } from "./useOfProceedsSchema";
 import { RiskFactorsOutputSchema, type RiskFactorRow } from "./riskFactorSchema";
-import { chunkRiskFactorText, isRiskCategoryHeading } from "./riskFactorChunks";
+import {
+  chunkRiskFactorText,
+  isRiskCategoryHeading,
+  stripHeadingMarkers,
+} from "./riskFactorChunks";
 import { MergerDealOutputSchema, type MergerDealRow } from "./mergerDealSchema";
 import { RedemptionOutputSchema, type RedemptionRow } from "./redemptionSchema";
 import { LoiOutputSchema, type LoiRow } from "./loiSchema";
@@ -65,20 +69,6 @@ const MAX_TOKENS = 4096;
  * a target.
  */
 const RISK_FACTORS_MAX_TOKENS = 16_384;
-
-/**
- * Share of heading-shaped rows at or above which a mixed-shape risk-factor
- * section is unanswerable and fails, rather than having its heading-shaped rows
- * dropped.
- *
- * A minority below this is the chunking artifact, not an ambiguous section:
- * {@link chunkRiskFactorText} prefixes every chunk after the first with the last
- * category heading, so the model is handed roughly one heading per chunk and
- * echoes some back. A 246k-char section is ~7 chunks against ~90 captions —
- * well under the ratio — and failing it would discard all ~90 for the sake of
- * ~6 strays.
- */
-export const MIXED_SHAPE_FAIL_RATIO = 0.25;
 
 /**
  * Thrown when a model's structured response fails to echo back the per-call
@@ -111,6 +101,10 @@ export class NonceMismatchError extends Error {
  * if it were complete, which is precisely what the chunked-section contract
  * exists to prevent. Failing the section instead puts it on the retry worklist
  * where a human can look at it.
+ *
+ * Echoes of the heading {@link chunkRiskFactorText} itself prefixed onto a chunk
+ * are removed by exact match before this check, so what reaches it is genuinely
+ * ambiguous rather than an artifact of our own chunking.
  *
  * {@link makeRunSection} records it under the `MIXED_CAPTION_SHAPE` reason code.
  */
@@ -1622,7 +1616,8 @@ export function riskFactorsInstructions(): string {
  * is the largest in an S-1 and enumerates far more rows than one response can
  * hold, so the text is split into paragraph-aligned chunks
  * ({@link chunkRiskFactorText}) and each is enumerated by its own call; rows are
- * concatenated in document order and de-duplicated on the caption.
+ * concatenated in document order, de-duplicated on the caption, and stripped of
+ * echoes of the category heading the chunker itself prefixed onto a chunk.
  *
  * A chunk that fails propagates, failing the section as a whole: persisting the
  * captions that happened to come back before the failure would record a
@@ -1641,58 +1636,46 @@ export async function extractRiskFactors(
       "risk factors",
       model,
       riskFactorsInstructions(),
-      chunk,
+      chunk.text,
       RiskFactorsOutputSchema,
       context,
       RISK_FACTORS_MAX_TOKENS
     );
     const risks = (obj.risks as RiskFactorRow[] | undefined) ?? [];
+    const carriedKey =
+      chunk.carriedHeading === null
+        ? null
+        : riskHeadlineKey(stripHeadingMarkers(chunk.carriedHeading));
     for (const risk of risks) {
       const key = riskHeadlineKey(risk?.headline);
       if (key === "" || seen.has(key)) continue;
       seen.add(key);
+      // The carried prefix is a line this code prepended so a chunk starting
+      // mid-category can attribute its captions; a row echoing it is that
+      // artifact, not a caption the filer printed. Matched EXACTLY, so no
+      // caption the model read out of the body is ever at stake. Keyed into
+      // `seen` above, so a later chunk echoing the same heading goes too.
+      if (
+        carriedKey !== null &&
+        riskHeadlineKey(stripHeadingMarkers(risk?.headline ?? "")) === carriedKey
+      ) {
+        continue;
+      }
       out.push(risk);
     }
   }
 
-  // Enforce the "a category heading is not a risk" rule rather than trusting the
-  // prompt: a heading verifies as verbatim section text, so nothing downstream
-  // would stop it becoming a row that reads like a disclosed risk. The heuristic
-  // keys on a heading having no sentence-ending punctuation.
-  //
-  // The rule is about the section's SHAPE, and it only has an answer when the
-  // section is homogeneous:
-  //
-  // - every row heading-shaped — an Item 105(b) "Summary of Risk Factors"
-  //   bullet list, which the segmenter accepts as this section and which is all
-  //   a filing carrying only the summary has. Its bullets are bare unpunctuated
-  //   phrases ("Risks related to our inability to complete an initial business
-  //   combination"), so the "headings" ARE the captions. Kept.
-  // - no row heading-shaped — an ordinary Item 105 list of sentence captions,
-  //   with nothing to drop. Kept.
-  // - mixed — answered by how large the heading-shaped minority is
-  //   (MIXED_SHAPE_FAIL_RATIO). Filers are inconsistent about terminal
-  //   punctuation, so one summary bullet ending in a period is enough to make
-  //   29 bare-phrase bullets look droppable; an all-or-nothing filter would
-  //   keep the single punctuated row and persist it as the filing's complete
-  //   disclosure. At or above the ratio the section is unanswerable and fails
-  //   rather than guessing; below it, the minority is the chunk-prefix echo
-  //   described at the drop below.
+  // Enforce the "a category heading is not a risk" rule rather than trusting
+  // the prompt: a heading verifies as verbatim section text, so nothing
+  // downstream would stop it becoming a row that reads like a disclosed risk.
+  // The rule is about the response's SHAPE as a whole and only has an answer
+  // when it is homogeneous — all bare phrases is an Item 105(b) summary list
+  // whose "headings" ARE the captions; none is an ordinary sentence-caption
+  // list. Mixed is unanswerable: dropping either minority records a partial
+  // disclosure as complete, so the section fails onto the retry worklist.
   const headingLike = out.filter((risk) => isRiskCategoryHeading(risk.headline)).length;
   if (headingLike > 0 && headingLike < out.length) {
-    if (headingLike / out.length >= MIXED_SHAPE_FAIL_RATIO) {
-      throw new MixedRiskCaptionShapeError(headingLike, out.length);
-    }
-    // A small minority of heading-shaped rows is the expected artifact of
-    // chunking, not an ambiguous section: every chunk after the first is
-    // prefixed with the last category heading seen before it, so a ~7-chunk
-    // section hands the model ~6 headings and invites it to echo them back as
-    // rows. Failing the section on those discards every real caption it found,
-    // so drop the handful and keep the disclosure. Only when heading-shaped
-    // rows are a large enough share is the section's shape genuinely
-    // unanswerable (a summary-bullet list whose bullets ARE the captions).
-    console.warn(`risk factors: dropped ${headingLike} heading-shaped row(s) of ${out.length}`);
-    return out.filter((risk) => !isRiskCategoryHeading(risk.headline));
+    throw new MixedRiskCaptionShapeError(headingLike, out.length);
   }
   return out;
 }


### PR DESCRIPTION
## The defect

`extractRiskFactors` guarded against the model returning a category heading as if it were a risk. That guard was **ratio-gated**: when heading-shaped rows were under 25% of the response, it deleted them, emitted a `console.warn`, and returned the rest.

Concretely: a response with 16 sentence captions and 4 bare phrases is 20% heading-shaped. The four bare phrases are deleted. The remaining 16 rows verify, persist, and the section calls `markResolved`. `rows.length === raw.length` at the runner (the drop happened *inside* `extract`), so no `-partial` triage entry is written either.

Those four bare phrases may well be real Item 105(b) summary bullets — a filer's summary list is a run of unpunctuated phrases, which is the same shape as a category heading. So the outcome is **four disclosed risks deleted from a filing whose risk-factor section is then recorded as complete and resolved**, with a line on stderr as the only record anywhere. Nothing on `sec extractor dead-letters S-1`, nothing in the row data, nothing an operator could query.

`CLAUDE.md` documented the opposite contract the whole time ("a **mixed** section is unanswerable and dead-letters `MIXED_CAPTION_SHAPE` … rather than persisting a subset"). The code and the doc drifted because the ratio landed without it.

## The fix

Remove the ratio; address the artifact it was built for at its source.

- `chunkRiskFactorText` now returns `RiskFactorChunk { text, carriedHeading }`, reporting the category line it prepended to a chunk that starts mid-category.
- `extractRiskFactors` drops a row whose caption matches that line **exactly**. That drop provably discards nothing the filer wrote — the line is one this code inserted — and it removes the dominant source of stray heading rows (a ~7-chunk section is handed ~6 headings and invited to echo them back).
- A *reworded* echo needs no new machinery: it is not verbatim section text, so `verifyRow` already drops it into the existing `-partial` / `UNVERIFIED_SOURCE_SPAN` triage entry.
- Whatever survives is judged all-or-nothing again. Homogeneous is kept intact; mixed throws `MixedRiskCaptionShapeError` → `MIXED_CAPTION_SHAPE` dead letter, version-gated and retryable. No `console.warn` remains on the path.

The residual cost is stated plainly: one stray body-heading echo now fails the whole section. That is the pre-existing contract, it fails *loudly*, and every caption is recoverable by re-running the filing.

## Operational consequences (please read before merging)

1. **Dead-letter volume will grow on the next sweep.** Sections whose model response mixes shapes now dead-letter `MIXED_CAPTION_SHAPE` instead of resolving with rows deleted. That is the intended trade — loud over silent — but the `sec extractor dead-letters S-1` worklist will be longer than it was. Nothing is lost: `retry-dead-letters` after a version bump re-runs them.
2. **`risk-factors` eval scores may drop.** `sec eval extract --extractor risk-factors` and `sec eval s1 --extractors risk-factors` now record a **failed run** (score 0) where a mixed response previously scored on its surviving rows. A fall in the `risk-factors` numbers after this lands is the guard firing, not a regression.

## Also in this PR

**`CLAUDE.md` golden-label coverage.** The doc said golden labels cover "`management` and `beneficial-ownership` only … seven committed sections" each. The committed set is **402 labels over 42 filings across 12 extractors**, and `sec eval s1` defaults `--extractors` to `extractorsWithGoldenLabels()`. So a bare `sec eval s1` is a ~400-section paid sweep that read as a 14-section one. Coverage is now described as derived (naming the function both the default and `--help` read), with a paragraph on cost and how to narrow it.

## Tests

Each regression test was written first and confirmed **failing** against unmodified `main`:

| Test | Behaviour on `main` |
|---|---|
| `Form_S_1.storage.riskfactors.test.ts` — "dead-letters a mixed section rather than resolving it with the minority deleted" | persists 4 rows, section resolved |
| `extractRiskFactors.test.ts` — "dead-letters a mixed section instead of silently deleting the heading-shaped minority" | resolves to 16 rows + `console.warn` |
| `extractRiskFactors.test.ts` — "drops a chunk's echo of the heading the chunker prefixed onto it" | throws `MixedRiskCaptionShapeError` |

The storage test is the load-bearing one: it pins the contract at the layer an operator actually reads — rows persisted plus the dead-letter entry — rather than at the extractor's return value.

`bunx tsc --noEmit` clean, `bun run build` clean, full `bun run test`: **2665 passed, 32 skipped, 0 failed** (312 files). `bun.lock` untouched.

## Withdrawn from this PR

An earlier revision also reverted `hftModelRecord` to `device: "cpu"` / `dtype: "q4"`. That was wrong — `webgpu` / `q4f16` is the intended configuration, and `src/config/registerModels.ts` is untouched here. The review reasoning behind that change (queue-strategy routing reading the raw `device` string) is left on the table rather than acted on.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDvMMv78PuEw4T5atLeJeS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDvMMv78PuEw4T5atLeJeS)_